### PR TITLE
Improved overlay dialog on IE11, Win 7.

### DIFF
--- a/packages/contentprocessing/assets/css/preview.css
+++ b/packages/contentprocessing/assets/css/preview.css
@@ -85,7 +85,7 @@
 
 .preview__sidebar--visible {
     opacity: 1;
-    pointer-events: initial;
+    pointer-events: auto;
     right: 0;
 }
 

--- a/resources/assets/less/partials/new/_structure.less
+++ b/resources/assets/less/partials/new/_structure.less
@@ -142,7 +142,7 @@ table {
 
 .header__profile:hover .header__profile__card {
     opacity: 1;
-    pointer-events: initial;
+    pointer-events: auto;
 }
 
 .actions {


### PR DESCRIPTION
The overlays used "pointer-events: initial" to restore mouse interaction.
This rule is not supported in IE11 on Windows 7 and is interpreted with no action, leaving the elements not subject to pointer events

Closes #34 
Closes #39 