### PR TITLE
French translation 0.20

### DIFF
--- a/packages/licenses/assets/descriptions/fr/not-explicit.md
+++ b/packages/licenses/assets/descriptions/fr/not-explicit.md
@@ -1,0 +1,1 @@
+Aucune information disponible concernant la licence. Conformément au droit internaitonal, **tous les droits** sont réservés par le détenteur des droits d'auteurs. Veuillez le contacter pour obtenir une permission individuelle d'utiliser cette œuvre d'une quelconque manière (incluant la copie, la modification, la distribution et le téléchargement).

--- a/packages/licenses/assets/licenses.json
+++ b/packages/licenses/assets/licenses.json
@@ -5,7 +5,8 @@
         "short_title": "No explicit license",
         "title": {
             "en": "License information is not available. According to the international law, all rights are reserved",
-            "ru": "Информация о лицензии недоступна. Согласно международным стандартам, все права защищены"
+            "ru": "Информация о лицензии недоступна. Согласно международным стандартам, все права защищены",
+            "fr": "Aucune information disponible concernant la licence. Conformément au droit internaitonal, tous les droits sont réservés"
         },
         "icon": "copy.svg",
         "description": "not-explicit.md",

--- a/packages/licenses/lang/fr/help.php
+++ b/packages/licenses/lang/fr/help.php
@@ -2,7 +2,7 @@
 
 return [
 
-    'description_disclaimer' => 'Cet acte met uniquement en évidence quelques unes des caractéristiques principales et des conditions de cette licence. Ce n\'est pas une licence et n\'a pas de valeur légale. Vous devriez minutieusement passer en revue les termes et conditions de la licence avant d\'utiliser une œuvre sous licence. K-Link et la K-Box ne sont pas un cabinet d\'avocats et ne fournissent pas de conseils légaux.',
+    'description_disclaimer' => 'Nous mettons ici en évidence uniquement quelques unes des caractéristiques principales et des conditions de cette licence. Cette explication n\'est pas la licence elle-même et n\'a pas de valeur légale. Vous devriez minutieusement passer en revue les termes et conditions de la licence avant d\'utiliser une œuvre sous licence. K-Link et la K-Box ne sont pas un cabinet d\'avocats et ne fournissent pas de conseils légaux.',
 
     'deed_intro' => 'Ceci est un résumé (et non pas un substitut) de la <a href=":link" rel="noopener noreferrer nofollow">licence</a>.'
 

--- a/resources/lang/fr/documents.php
+++ b/resources/lang/fr/documents.php
@@ -169,6 +169,7 @@ return [
         
         'restore_dialog_title' => 'Restaurer :document?',
         'restore_dialog_text' => 'Vous allez restaurer ":document"',
+        'restore_version_dialog_text' => 'Vous êtes sur le point de restaurer la version ":document". Ceci va effacer de façon définitive toutes les versions plus récentes.',
         'restore_dialog_title_count' => 'Restaurer :count documents?',
         'restore_dialog_text' => 'Vous allez restaurer ":document"',
         'restore_dialog_text_count' => 'Vous allez restaurer :count fichiers',
@@ -178,6 +179,8 @@ return [
         'restore_success_title' => 'Restauré',
         'restore_error_title' => 'Impossible de restaurer',
         'restore_error_text_generic' => 'Le fichier sélectionné n\'a pas été sorti de la corbeille.',
+        'restore_version_error_text_generic' => 'Impossible de restaurer la version souhaitée de ce fichier.',
+        'restore_version_error_only_one_version' => 'Il n\'existe qu\'une seule version de ce document.',
       
         'restoring' => 'Restauration en cours...',
     ],

--- a/resources/lang/fr/pages.php
+++ b/resources/lang/fr/pages.php
@@ -17,7 +17,7 @@ return [
     'terms_long'  => 'Conditions d\'utilisation',
     'privacy' => 'Confidentialité',
     'contact' => 'Contact',
-    'service_policy' => 'Politique de service',
-    'browserupdate' => 'Aide mise à jour du navigateur',
+    'service_policy' => 'Conditions d\'utilisation',
+    'browserupdate' => 'Aide concernant la mise à jour du navigateur',
 
 ];


### PR DESCRIPTION
One file was missing in the French translation

 k-box/packages/licenses/assets/descriptions/fr/copyright.md

\+ a few other additions and corrections in the French translation (mostly strings related to licenses)
