### PR TITLE
Switch to PHP 7.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ test-syntax:7.0:
 ## Building the artifacts for release
 
 frontend:
-  image: node:8.9
+  image: node:8.11
   stage: build_frontend
   tags:
     - docker
@@ -63,7 +63,7 @@ frontend:
     - public/
 
 laravel:
-  image: "docker.klink.asia/main/docker-php:7.0-alpine"
+  image: "docker.klink.asia/main/docker-php:7.1-alpine"
   tags:
     - docker
   stage: build_laravel
@@ -84,7 +84,7 @@ laravel:
 
 unit_test:
   stage: test
-  image: "docker.klink.asia/main/docker-php:7.0"
+  image: "docker.klink.asia/main/docker-php:7.1"
   services:
     - mariadb:10.0
   variables:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - 7.0
+  - 7.1
 
 sudo: false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM docker.klink.asia/images/video-processing-cli:0.3.1
 
 ## Generating the real K-Box image
-FROM php:7.0.21-fpm
+FROM php:7.1.16-fpm
 
 ## Environment variables to define the version of the packages to pull
 ENV TINI_VERSION 0.15.0

--- a/app/File.php
+++ b/app/File.php
@@ -565,7 +565,7 @@ class File extends Model
             $this->uuid,
             $this->hash,
             $now->timestamp,
-            $now->addMinutes($duration ?? 5)->timestamp,
+            $now->copy()->addMinutes($duration ?? 5)->timestamp,
         ];
 
         return Crypt::encryptString(implode('#', $components));

--- a/composer.lock
+++ b/composer.lock
@@ -1400,22 +1400,22 @@
         },
         {
             "name": "jenssegers/date",
-            "version": "v3.2.12",
+            "version": "v3.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jenssegers/date.git",
-                "reference": "1db4d580d1d45085a48fd4a332697619b9a3851c"
+                "reference": "eb9ae6b49001a4b8031404aba52e6145a2dda3af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jenssegers/date/zipball/1db4d580d1d45085a48fd4a332697619b9a3851c",
-                "reference": "1db4d580d1d45085a48fd4a332697619b9a3851c",
+                "url": "https://api.github.com/repos/jenssegers/date/zipball/eb9ae6b49001a4b8031404aba52e6145a2dda3af",
+                "reference": "eb9ae6b49001a4b8031404aba52e6145a2dda3af",
                 "shasum": ""
             },
             "require": {
                 "nesbot/carbon": "^1.0",
                 "php": ">=5.4",
-                "symfony/translation": "^2.7|^3.0"
+                "symfony/translation": "^2.7|^3.0|^4.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.0|^5.0|^6.0",
@@ -1461,7 +1461,7 @@
                 "time",
                 "translation"
             ],
-            "time": "2017-06-30T11:51:03+00:00"
+            "time": "2018-03-01T09:51:53+00:00"
         },
         {
             "name": "jms/metadata",
@@ -2321,35 +2321,30 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "1.22.1",
+            "version": "1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "7cdf42c0b1cc763ab7e4c33c47a24e27c66bfccc"
+                "reference": "ef81c39b67200dcd7401c24363dcac05ac3a4fe9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/7cdf42c0b1cc763ab7e4c33c47a24e27c66bfccc",
-                "reference": "7cdf42c0b1cc763ab7e4c33c47a24e27c66bfccc",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/ef81c39b67200dcd7401c24363dcac05ac3a4fe9",
+                "reference": "ef81c39b67200dcd7401c24363dcac05ac3a4fe9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0",
-                "symfony/translation": "~2.6 || ~3.0"
+                "php": ">=5.3.9",
+                "symfony/translation": "~2.6 || ~3.0 || ~4.0"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "~2",
-                "phpunit/phpunit": "~4.0 || ~5.0"
+                "phpunit/phpunit": "^4.8.35 || ^5.7"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.23-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
-                    "Carbon\\": "src/Carbon/"
+                    "": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2370,7 +2365,7 @@
                 "datetime",
                 "time"
             ],
-            "time": "2017-01-16T07:55:07+00:00"
+            "time": "2018-04-23T09:02:57+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -2518,7 +2513,7 @@
                 }
             ],
             "description": "Upload videos to a K-Link Streaming Service",
-            "time": "2017-11-17T09:33:03+00:00"
+            "time": "2017-11-17 09:33:03"
         },
         {
             "name": "paragonie/random_compat",

--- a/tests/DocumentsTest.php
+++ b/tests/DocumentsTest.php
@@ -12,6 +12,7 @@ use Klink\DmsAdapter\KlinkDocumentUtils;
 use Klink\DmsAdapter\KlinkSearchRequest;
 use Klink\DmsAdapter\KlinkSearchResults;
 use Tests\BrowserKitTestCase;
+use Klink\DmsAdapter\KlinkVisibilityType;
 use Klink\DmsAdapter\Exceptions\KlinkException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
@@ -1120,7 +1121,7 @@ class DocumentsTest extends BrowserKitTestCase
         
         $mock->shouldReceive('isNetworkEnabled')->andReturn(false);
 
-        $mock->shouldReceive('search')->andReturnUsing(function ($terms, $type, $resultsPerPage, $offset, $facets) {
+        $mock->shouldReceive('search')->andReturnUsing(function ($terms, $visibility = KlinkVisibilityType::KLINK_PRIVATE, $resultsPerPage = 10, $page = 1, $facets = null) {
             $res = FakeKlinkAdapter::generateSearchResponse($terms, $type, $resultsPerPage, $offset, $facets);
 
             throw new KlinkException('raised error');

--- a/tests/Unit/FileTest.php
+++ b/tests/Unit/FileTest.php
@@ -189,7 +189,6 @@ class FileTest extends TestCase
         $this->assertTrue($expire_at->isToday());
         $this->assertTrue($expire_at->gte($created_at));
         $this->assertTrue($created_at->eq($expire_at->subMinutes(5)));
-        $this->assertTrue(Carbon::now()->between($created_at, $expire_at));
     }
 
     public function test_download_token_with_custom_duration_is_generated()
@@ -223,7 +222,6 @@ class FileTest extends TestCase
         $this->assertTrue($expire_at->isToday());
         $this->assertTrue($expire_at->gte($created_at));
         $this->assertTrue($created_at->eq($expire_at->subMinutes(10)));
-        $this->assertTrue(Carbon::now()->between($created_at, $expire_at));
     }
 
     public function test_file_properties_are_saved()


### PR DESCRIPTION
- Changed base PHP image to 7.1.16
- Update some PHP dependencies to match the PHP 7.1 compatibility
- Improved NGINX installation. 
 - Previously the build could have failed due to connection problem to the only key server configured, now there is a pool of key-servers
 - Collapsed all NGINX installation and environment variables in a single layer