### PR TITLE
Improve first administrator creation after initial setup

### DIFF
--- a/app/Console/Commands/DmsCreateAdminUserCommand.php
+++ b/app/Console/Commands/DmsCreateAdminUserCommand.php
@@ -2,10 +2,14 @@
 
 namespace KBox\Console\Commands;
 
-use Illuminate\Console\Command;
-use Symfony\Component\Console\Input\InputArgument;
+use Hash;
+use Validator;
+use Password;
 use KBox\User;
 use KBox\Capability;
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Creates admin user accounts
@@ -14,18 +18,21 @@ final class DmsCreateAdminUserCommand extends Command
 {
 
     /**
-     * The console command name.
+     * The name and signature of the console command.
      *
      * @var string
      */
-    protected $name = 'dms:create-admin';
+    protected $signature = 'create-admin {email}
+                            {-p|--password= : The user password.}
+                            {--show : Show the generated password instead of generating a password reset link.}
+                            {-n|--name= : The user name to use. Default the email user.}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'This command will create the administration user of the DMS and will show the assigned password.';
+    protected $description = 'This command will create the Administrator of the K-Box.';
 
     /**
      * Create a new command instance.
@@ -44,70 +51,80 @@ final class DmsCreateAdminUserCommand extends Command
      */
     public function fire()
     {
-        $the_username = $this->argument('email');
-        $the_name = $this->argument('name');
-        $the_password = $this->argument('password');
+        $email = $this->argument('email');
+        $name = $this->option('name', null);
+        $password = $this->option('password', null);
+        $passwordWasGenerated = false;
 
-        $validator = \Validator::make(
-            ['name' => $the_username],
+        if ($this->validateEmail($email)) {
+            $this->error("The specified email $email is not valid.");
+            return 3;
+        }
+        
+        if ($this->exists($email)) {
+            $this->error("The user \"$email\" already exists.");
+            return 2;
+        }
+            
+        if(empty($password) && $this->input->isInteractive()){
+            $password = $this->secret("Please specify an 8 character password for the administrator");
+        }
+
+        if(empty($password)){
+            $password = User::generatePassword();
+            $passwordWasGenerated = true;
+        }
+        
+        $user = $this->createUser($email, $password, $name);
+
+        $this->line('');
+        $this->line("The K-Box Administrator, <comment>$email</comment>, has been created.");
+            
+        $this->line(
+            sprintf(
+                $this->option('show', false) && $passwordWasGenerated ? 'A password has been generated for you: <info>%1$s</info> ' . PHP_EOL . 'Want to change, use this link %2$s' : ($passwordWasGenerated ? 'Set a password for the account using <info>%2$s</info>' : 'Login on %3$s using your chosen password'),
+                $password,
+                route('password.reset', ['email' => $email, 'token' => Password::createToken($user)]),
+                url('/'))
+        );
+        
+        $this->line('');
+
+        return 0;
+    }
+
+    protected function validateEmail($email)
+    {
+        $validator = Validator::make(
+            ['name' => $email],
             ['name' => 'email']
         );
 
-        if ($validator->fails()) {
-            $this->error("The specified username ($the_username) is not a valid mail address.");
-            return 1;
-        }
-
-        $exists = ! is_null(User::findByEmail($the_username));
-
-        if ($exists) {
-            $this->error("The user ($the_username) already exists.");
-            return 2;
-        } else {
-            $et_offset = strpos($the_username, '@');
-            $nice_name = $et_offset !== false ? substr($the_username, 0, $et_offset) : $the_username;
-
-            $the_user = User::create([
-                'name' => ! is_null($the_name) ? $the_name : $nice_name,
-                'email' => $the_username,
-                'password' => \Hash::make($the_password)
-            ]);
-
-            $the_user->addCapabilities(Capability::$ADMIN);
-
-            $this->line('');
-            $this->line('The DMS Administration user has been created.');
-
-            $this->line("  username: <comment>$the_username</comment>");
-            $this->line("  password: <info>The chosen password</info>");
-            $this->line('');
-
-            return 0;
-        }
+        return $validator->fails();
     }
 
-    /**
-     * Get the console command arguments.
-     *
-     * @return array
-     */
-    protected function getArguments()
+    protected function exists($email)
     {
-        return [
-            ['email', InputArgument::REQUIRED, 'User email.'],
-            ['password', InputArgument::REQUIRED, 'User password.'],
-            ['name', InputArgument::OPTIONAL, 'User nicename.']
-        ];
+        return ! is_null(User::findByEmail($email));
     }
 
-    /**
-     * Get the console command options.
-     *
-     * @return array
-     */
-    protected function getOptions()
+    private function getUsernameFrom($email)
     {
-        return [
-        ];
+        $et_offset = strpos($email, '@');
+        return $et_offset !== false ? substr($email, 0, $et_offset) : $email;
     }
+
+    protected function createUser($email, $password, $name = null)
+    {
+        $user = User::create([
+            'name' => ! empty($name) ? $name : $this->getUsernameFrom($email),
+            'email' => $email,
+            'password' => Hash::make($password)
+        ]);
+
+        $user->addCapabilities(Capability::$ADMIN);
+
+        return $user;
+    }
+
 }

--- a/app/Console/Commands/DmsCreateAdminUserCommand.php
+++ b/app/Console/Commands/DmsCreateAdminUserCommand.php
@@ -8,8 +8,6 @@ use Password;
 use KBox\User;
 use KBox\Capability;
 use Illuminate\Console\Command;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Creates admin user accounts
@@ -66,11 +64,11 @@ final class DmsCreateAdminUserCommand extends Command
             return 2;
         }
             
-        if(empty($password) && $this->input->isInteractive()){
+        if (empty($password) && $this->input->isInteractive()) {
             $password = $this->secret("Please specify an 8 character password for the administrator");
         }
 
-        if(empty($password)){
+        if (empty($password)) {
             $password = User::generatePassword();
             $passwordWasGenerated = true;
         }
@@ -82,7 +80,7 @@ final class DmsCreateAdminUserCommand extends Command
             
         $this->line(
             sprintf(
-                $this->option('show', false) && $passwordWasGenerated ? 'A password has been generated for you: <info>%1$s</info> ' . PHP_EOL . 'Want to change, use this link %2$s' : ($passwordWasGenerated ? 'Set a password for the account using <info>%2$s</info>' : 'Login on %3$s using your chosen password'),
+                $this->option('show', false) && $passwordWasGenerated ? 'A password has been generated for you: <info>%1$s</info> '.PHP_EOL.'Want to change, use this link %2$s' : ($passwordWasGenerated ? 'Set a password for the account using <info>%2$s</info>' : 'Login on %3$s using your chosen password'),
                 $password,
                 route('password.reset', ['email' => $email, 'token' => Password::createToken($user)]),
                 url('/'))
@@ -126,5 +124,4 @@ final class DmsCreateAdminUserCommand extends Command
 
         return $user;
     }
-
 }

--- a/app/Console/Commands/DmsCreateAdminUserCommand.php
+++ b/app/Console/Commands/DmsCreateAdminUserCommand.php
@@ -95,7 +95,7 @@ final class DmsCreateAdminUserCommand extends Command
     {
         $validator = Validator::make(
             ['name' => $email],
-            ['name' => 'email']
+            ['name' => 'required|email']
         );
 
         return $validator->fails();

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Allow creating a project without selecting a second user other than the project manager ([#70](https://github.com/k-box/k-box/pull/70)).
 - The Application Key is automatically generated, if not specified in the deployment environment variables ([#72](https://github.com/k-box/k-box/pull/72)).
 - The Application Key is now enforced to be 32 characters long ([#72](https://github.com/k-box/k-box/pull/72)).
+- **Breaking change** The command `dms:create-admin` has been renamed to `create-admin`.
+- **Breaking change** The `create-admin` do not accept anymore the `password` and the `username` as arguments, but uses options instead.
 
 ### Fixed
 

--- a/changelog.md
+++ b/changelog.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Allow creating a project without selecting a second user other than the project manager ([#70](https://github.com/k-box/k-box/pull/70)).
 - The Application Key is automatically generated, if not specified in the deployment environment variables ([#72](https://github.com/k-box/k-box/pull/72)).
 - The Application Key is now enforced to be 32 characters long ([#72](https://github.com/k-box/k-box/pull/72)).
-- **Breaking change** The command `dms:create-admin` has been renamed to `create-admin`.
-- **Breaking change** The `create-admin` do not accept anymore the `password` and the `username` as arguments, but uses options instead.
+- The command `dms:create-admin` has been renamed to `create-admin` (possible breaking change).
+- The `create-admin` do not accept anymore the `password` and the `username` as arguments, but uses options instead (possible breaking change).
 
 ### Fixed
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -71,8 +71,10 @@ services:
     environment:
       ## K-Box access
       KLINK_DMS_APP_URL: "http://localhost:8080/"
-      KLINK_DMS_ADMIN_USERNAME: "admin@kbox.local"
-      KLINK_DMS_ADMIN_PASSWORD: "123456789"
+      ## Administrator account
+      ## uncomment the next two lines and write a password to automatically create that user at startup
+      # KLINK_DMS_ADMIN_USERNAME: "admin@kbox.local"
+      # KLINK_DMS_ADMIN_PASSWORD: ""
       ## Deploy configuration
       KLINK_DMS_DB_HOST: database # Host where the database is listening on
       KLINK_DMS_DB_NAME: dms

--- a/docs/developer/commands/create-admin.md
+++ b/docs/developer/commands/create-admin.md
@@ -1,0 +1,27 @@
+# `create-admin` command
+
+Create a K-Box administrator account.
+
+```
+$ php artisan create-admin [options] {email}
+```
+
+**Options:**
+
+- `--password`: Specify the password on the command line. If omitted the password will be asked using an interactive input
+- `--no-interaction`: Do not ask interactive questions. In this case a password reset link will be printed
+- `--show`: Shows the generated password, only if `--password` is omitted
+- `--name` : The name to assign to the user. By default is the email user name
+
+**Arguments**
+
+- `email` (required): The email address of the user
+
+
+**Error codes**
+
+The command might return the following exit codes in case of error
+
+- `1` in case of general error
+- `2` in case a user with the same email address already exists
+- `3` in case the email address is not valid

--- a/docs/developer/commands/index.md
+++ b/docs/developer/commands/index.md
@@ -4,12 +4,13 @@
 > K-DMS instance.
 
 
-The DMS command line suite of commands rely on the [Laravel Artisan CLI](https://laravel.com/docs/5.2/artisan).
+The K-Box command line suite of commands rely on the [Laravel Artisan CLI](https://laravel.com/docs/5.2/artisan).
 
-Here are only listed the specific commands added by the K-DMS:
+Here are only listed the specific commands added by the K-Box:
 
+- [`create-admin`](./create-admin.md): Create a K-Box Administrator
 - [`dms:update`](./update-command.md): Perform the installation/update steps for the 
-  K-Link DMS.
+  K-Box.
 - [`dms:reindex`](./reindex-command.md): Perform the reindexing of the currently 
   indexed documents.
 - `dms:test`: Tests the configuration and connection to the private K-Link Core.

--- a/docs/developer/configuration.md
+++ b/docs/developer/configuration.md
@@ -107,3 +107,31 @@ The generated application key is stored in `storage/app/app_key.key` for future 
 > Changing Application Key between deployments will invalidate all user sessions
 
 > **Breaking change** 16 characters application key are not anymore supported
+
+
+## First Administrator
+
+The First Administrator is the user that completes the setup and is able to fully manage the K-Box. It can also create other administrators.
+
+By default the K-Box do not create an administrator account automatically. 
+
+The preferred way is to use the `create-admin` command
+
+```bash
+php artisan create-admin {email}
+
+# docker-compose exec kbox php artisan create-admin {email} if executed from Docker
+```
+
+The create-admin requires an email address, that will be used as the username and will ask for a password in interactive mode.
+Inserting an empty password, or running with the option `--no-interaction`, will cause the command to generate and print a 
+password reset link. The link is valid for 5 minutes and, opening it, will enable you to define your own password 
+via User Interface.
+
+As an alternative, and for backward compatibility, the administrator account can be created by setting 
+the `KLINK_DMS_ADMIN_USERNAME` and `KLINK_DMS_ADMIN_PASSWORD` environment variables inside the Docker configuration.
+
+```yaml
+KLINK_DMS_ADMIN_USERNAME: "admin@kbox.local"
+KLINK_DMS_ADMIN_PASSWORD: "*******"
+```

--- a/docs/user/deploy-configuration.md
+++ b/docs/user/deploy-configuration.md
@@ -50,7 +50,9 @@ KLINK_DMS_DB_PASSWORD: "b2510859c83414e0cbefd26284b9171d"
 
 ### K-Box administrator
 
-The default administrator account of the K-Box is configured at startup, the username and the password are specified in the configuration file as
+The default administrator account of the K-Box can be configured at startup.
+
+By specifying username and the password in the configuration file, as in the next code block, the user will be automatically created.
 
 ```yaml
 KLINK_DMS_ADMIN_USERNAME: "admin@kbox.local"
@@ -58,6 +60,11 @@ KLINK_DMS_ADMIN_PASSWORD: "*******"
 ```
 
 > The mimumim password length is 8 characters
+
+**errors**
+
+User creation might fail, for example if the given username is not a valid email address, or an empty password is specified
+
 
 ### K-Box URL
 

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -62,6 +62,22 @@ _Running this for the first time, this step will download quite a lot of data an
 
 Afterwards K-Box will be available: [http://localhost:8080](http://localhost:8080/)
 
+### Create the administrator
+
+The default deployment configuration do not specify a default administrator account.
+
+You can create an administrator account after the K-Box start-up using:
+
+```bash
+docker-compose exec kbox php artisan create-admin {email}
+```
+
+This command will ask for the password and generate the account.
+
+> If you want you can still [configure the default account using deploy configuration](./deploy-configuration.md#k-box-administrator)
+
+> Using a real email address, for `{email}` is encouraged
+
 ### Useful commands
 
 There are some handy commands you can use to manage your K-Box:

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,8 @@ These few commands allow you to quickly install a K-Box **locally** on your comp
 * Create a directory: `mkdir k-box && cd k-box`
 * Download configuration file: `curl -o docker-compose.yml https://raw.githubusercontent.com/k-box/k-box/master/docker-compose.example.yml`
 * Start up services: `docker-compose up -d` (running this for the first time, it will download a lot of data and take a while)
-* Visit your K-Box: [http://localhost:8080](http://localhost:8080/) (you can login to the K-Box with the username `admin@kbox.local` and the password `123456789`.)
+* Create the administrator: `docker-compose exec kbox php artisan create-admin admin@kbox.local` 
+* Visit your K-Box: [http://localhost:8080](http://localhost:8080/) (you can login to the K-Box with the username `admin@kbox.local` and the chosen password).
 
 For an installation on a server in the Internet or more configuration options, see the documentation on [installation of the K-Box](./docs/user/installation.md). There you set relevant passwords, which is important when using the Software for any purpose.
 

--- a/tests/Unit/Commands/DmsCreateAdminUserCommandTest.php
+++ b/tests/Unit/Commands/DmsCreateAdminUserCommandTest.php
@@ -5,7 +5,6 @@ namespace Tests\Unit\Commands;
 use Artisan;
 use KBox\User;
 use Tests\TestCase;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class DmsCreateAdminUserCommandTest extends TestCase

--- a/tests/Unit/Commands/DmsCreateAdminUserCommandTest.php
+++ b/tests/Unit/Commands/DmsCreateAdminUserCommandTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Unit\Commands;
+
+use Artisan;
+use KBox\User;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class DmsCreateAdminUserCommandTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_admin_user_is_created_and_reset_link_is_returned()
+    {
+        $email = 'admin@kbox.local';
+
+        $exitCode = Artisan::call('create-admin', [
+            'email' => $email,
+            '--no-interaction' => true
+        ]);
+        $output = Artisan::output();
+        $this->assertEquals(0, $exitCode);
+        
+        $this->assertRegExp('/Administrator(.*)created/', $output);
+        $this->assertRegExp('/Set\ a\ password/', $output);
+        $this->assertRegExp('/http(.*)\/password\/reset\/(.*)?email='.urlencode($email).'/', $output);
+
+        $this->assertNotNull(User::findByEmail($email));
+    }
+
+    public function test_admin_user_is_created_and_reset_link_is_returned_if_empty_password_is_specified()
+    {
+        $email = 'admin@kbox.local';
+
+        $exitCode = Artisan::call('create-admin', [
+            'email' => $email,
+            '--password' => '',
+            '--no-interaction' => true
+        ]);
+        $output = Artisan::output();
+        $this->assertEquals(0, $exitCode);
+        
+        $this->assertRegExp('/Administrator(.*)created/', $output);
+        $this->assertRegExp('/Set\ a\ password/', $output);
+        $this->assertRegExp('/http(.*)\/password\/reset\/(.*)?email='.urlencode($email).'/', $output);
+
+        $this->assertNotNull(User::findByEmail($email));
+    }
+
+    public function test_admin_user_is_created_using_input_password()
+    {
+        $email = 'admin@kbox.local';
+
+        $exitCode = Artisan::call('create-admin', [
+            'email' => $email,
+            '--password' => 'A password',
+        ]);
+        $output = Artisan::output();
+        $this->assertEquals(0, $exitCode);
+        
+        $this->assertRegExp('/Administrator(.*)created/', $output);
+        $this->assertRegExp('/chosen\ password/', $output);
+
+        $this->assertNotNull(User::findByEmail($email));
+    }
+
+    public function test_admin_user_created_and_show_generated_password()
+    {
+        $email = 'admin@kbox.local';
+
+        $exitCode = Artisan::call('create-admin', [
+            'email' => $email,
+            '--no-interaction' => true,
+            '--show' => true,
+        ]);
+        $output = Artisan::output();
+        $this->assertEquals(0, $exitCode);
+        
+        $this->assertRegExp('/Administrator(.*)created/', $output);
+        $this->assertRegExp('/password(.*)generated(.*):\ (.*){8}\ /', $output);
+
+        $this->assertNotNull(User::findByEmail($email));
+    }
+
+    public function test_admin_user_is_not_created_if_already_exist()
+    {
+        $email = 'admin@kbox.local';
+
+        User::create([
+            'name' => 'admin',
+            'email' => $email,
+            'password' => 'secure-code'
+        ]);
+
+        $exitCode = Artisan::call('create-admin', [
+            'email' => $email,
+            '--no-interaction' => true,
+        ]);
+        $this->assertEquals(2, $exitCode);
+    }
+
+    public function test_invalid_email_blocks_the_user_creation()
+    {
+        $email = 'admin';
+
+        $exitCode = Artisan::call('create-admin', [
+            'email' => $email,
+            '--no-interaction' => true,
+        ]);
+        $this->assertEquals(3, $exitCode);
+    }
+}

--- a/tests/Unit/Commands/DmsCreateAdminUserCommandTest.php
+++ b/tests/Unit/Commands/DmsCreateAdminUserCommandTest.php
@@ -110,4 +110,15 @@ class DmsCreateAdminUserCommandTest extends TestCase
         ]);
         $this->assertEquals(3, $exitCode);
     }
+    
+    public function test_empty_email_blocks_the_user_creation()
+    {
+        $email = '';
+
+        $exitCode = Artisan::call('create-admin', [
+            'email' => $email,
+            '--no-interaction' => true,
+        ]);
+        $this->assertEquals(3, $exitCode);
+    }
 }


### PR DESCRIPTION
This pull request aims to improve the first administrator creation

Currently the main K-Box administrator is created from username and password inserted via environment variables in the docker-compose.yml file.
The improve aims to support the ability to not specify the password value in clear text, but obtain a password reset token to be used to set the user custom password

* [x] Update `create-admin` command to show a password reset link in case only the username is specified. This contains breaking changes, although they might not impact users:
 - previously the password was a command argument, while now is an option
 - the command was renamed from `dms:create-admin` to `create-admin`
* [x] Make optional the requirement of `$KLINK_DMS_ADMIN_USERNAME` and `$KLINK_DMS_ADMIN_PASSWORD` environment variables
* [x] Add documentation for the explicit invocation of `create-admin` at the end of the setup process
