### PR TITLE
Check notices array to exists before cycling them

### DIFF
--- a/resources/views/dashboard/notices.blade.php
+++ b/resources/views/dashboard/notices.blade.php
@@ -4,21 +4,25 @@
 
 <div class="row">
 
-	@foreach($error_notices as $notice)
-
+	@if(isset($error_notices))
+		@foreach($error_notices as $notice)
+		
 		<div class="c-message c-message--error">
 			{!!$notice!!}
 		</div>
-
-	@endforeach
+		
+		@endforeach
+	@endif
 	
-	@foreach($notices as $notice)
-
-		<div class="c-message">
-			{!!$notice!!}
-		</div>
-
-	@endforeach
+	@if(isset($notices))
+		@foreach($notices as $notice)
+		
+			<div class="c-message">
+				{!!$notice!!}
+			</div>
+		
+		@endforeach
+	@endif
 
 </div>
 


### PR DESCRIPTION
This pull request add an existence check to two arrays in the `notices.blade.php` file as the template might be reused without passing the whole set of variables