### PR TITLE
Fix application key not set after fast restart.

### DIFF
--- a/docker/configure.sh
+++ b/docker/configure.sh
@@ -77,6 +77,7 @@ function write_config() {
 	EOM
 
     # generate APP_KEY if not already set
+    php artisan config:clear
     php artisan kbox:key
 
 	echo "- ENV file written! $KLINK_DMS_DIR/.env"


### PR DESCRIPTION
Clear the configuration cache after writing the new env file, as it might contain old values