### PR TITLE
Made visibility validation to throw InvalidArgumentException 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Visibility search parameter. Now if not public or private an InvalidArgumentException is thrown
+
 ### Removed
 
 - Filter button from Trash, as search and filtering is not supported

--- a/tests/Unit/SearchRequestTest.php
+++ b/tests/Unit/SearchRequestTest.php
@@ -247,6 +247,5 @@ class SearchRequestTest extends TestCase
                 'visibility' => 'public and 1>1',
             ]
         ));
-
     }
 }

--- a/tests/Unit/SearchRequestTest.php
+++ b/tests/Unit/SearchRequestTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use Tests\TestCase;
+use InvalidArgumentException;
 use Klink\DmsAdapter\KlinkFacets;
 use Klink\DmsAdapter\KlinkFilters;
 use Klink\DmsSearch\SearchRequest;
@@ -235,5 +236,17 @@ class SearchRequestTest extends TestCase
         
         $this->assertNotEmpty($facets_built);
         $this->assertCount(4, $facets_built);
+    }
+
+    public function test_unsupported_visibility_is_handled()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $req = SearchRequest::create($this->createValidHttpRequest(
+            [
+                'visibility' => 'public and 1>1',
+            ]
+        ));
+
     }
 }

--- a/workbench/klink/dms-adapter/src/Klink/DmsAdapter/KlinkVisibilityType.php
+++ b/workbench/klink/dms-adapter/src/Klink/DmsAdapter/KlinkVisibilityType.php
@@ -2,6 +2,8 @@
 
 namespace Klink\DmsAdapter;
 
+use InvalidArgumentException;
+
 /**
  * Define the available types of document visibility.
  *
@@ -29,7 +31,7 @@ final class KlinkVisibilityType
 	 * Perform a parse of the given string into a visibility constant
 	 * @param string $string the value to be transformed into a KlinkVisibilityType
 	 * @return KlinkVisibilityType
-	 * @throws InvalidArgumentException if the passed string is not a valid visibility
+	 * @throws \InvalidArgumentException if the passed string is not a valid visibility
 	 */
 	public static function fromString( $string ){
 
@@ -40,7 +42,7 @@ final class KlinkVisibilityType
 			return KlinkVisibilityType::KLINK_PUBLIC;
 		}
 
-		throw new InvalidArgumentException("Wrong enumeration value");
+		throw new InvalidArgumentException("Unsupported visibility. Given $string");
 		
 
 	}


### PR DESCRIPTION
This pull request made the `KlinkVisibilityType` enumeration to correctly throw `InvalidArgumentException` if a not-supported visibility is given


Closes #85 