### PR TITLE
Fix starred loading with trashed documents

### DIFF
--- a/app/Http/Controllers/SharingController.php
+++ b/app/Http/Controllers/SharingController.php
@@ -171,7 +171,7 @@ class SharingController extends Controller
 
         $documents_req = is_array($documents_input) ? $documents_input : array_filter(explode(',', $request->input('documents', '')));
 
-        $documents = DocumentDescriptor::whereIn('id', $documents_req)->get();
+        $documents = DocumentDescriptor::withTrashed()->whereIn('id', $documents_req)->get();
 
         $groups = Group::whereIn('id', $groups_req)->get();
 

--- a/app/Starred.php
+++ b/app/Starred.php
@@ -63,7 +63,7 @@ class Starred extends Model
      */
     public function document()
     {
-        return $this->belongsTo('KBox\DocumentDescriptor', 'document_id');
+        return $this->belongsTo('KBox\DocumentDescriptor', 'document_id')->withTrashed();
     }
 
     /**

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Visibility search parameter. Now if not public or private an InvalidArgumentException is thrown
+- Listing starred documents when a document is in the trash
 
 ### Removed
 

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -106,8 +106,12 @@ $factory->define(KBox\DocumentDescriptor::class, function (Faker\Generator $fake
 
 $factory->define(KBox\Starred::class, function (Faker\Generator $faker) {
     return [
-      'user_id' => factory(KBox\User::class)->create()->id,
-      'document_id' => factory(KBox\DocumentDescriptor::class)->create()->id
+      'user_id' => function () {
+          return factory(KBox\User::class)->create()->id;
+       },
+      'document_id' => function() { 
+          return factory(KBox\DocumentDescriptor::class)->create()->id;
+      }
     ];
 });
 

--- a/resources/lang/en/starred.php
+++ b/resources/lang/en/starred.php
@@ -28,4 +28,6 @@ return [
         'invalidargumentexception' => 'Sorry, I cannot add the star. (:exception)',
     ],
 
+    'starred_in_trash' => 'This document is in the trash',
+
 ];

--- a/resources/views/components/list-item.blade.php
+++ b/resources/views/components/list-item.blade.php
@@ -65,16 +65,25 @@
         
         <div class="item__badges">
         
-        @if(isset($starrable) && $starrable && isset($local_document_id) && (!isset($trashed) || (isset($trashed) && !$trashed)))
+        @if(isset($starrable) && $starrable && isset($local_document_id) && (!isset($context) || (isset($context) && $context!=='trash')))
 
             <button data-action="star" 
                 class="item__star @if($is_public) item__star--public @endif @if( $starred ) item__star--starred @endif"
                 @if($star!== false) data-id="{{$star}}" @endif
                 data-doc="{{$local_document_id}}" 
-                data-visibility="{{$visibility}}">
-                @materialicon('toggle', 'star', 'star star--starred', ['alt' => trans('starred.remove')])
-                @materialicon('toggle', 'star_border', 'star star--not-starred', ['alt' => trans('starred.add')])
+                data-visibility="{{$visibility}}"
+                title="{{ $star!== false ? trans('starred.remove') : trans('starred.add') }}">
+                @materialicon('toggle', 'star', 'star star--starred', ['title' => trans('starred.remove')])
+                @materialicon('toggle', 'star_border', 'star star--not-starred', ['title' => trans('starred.add')])
             </button>
+
+            @if(isset($trashed) && $trashed)
+
+                <div class="item__badge" title="{{ trans('starred.starred_in_trash') }}">
+                    @materialicon('action', 'delete')
+                </div>
+
+            @endif
 
         @endif
 

--- a/resources/views/documents/descriptor.blade.php
+++ b/resources/views/documents/descriptor.blade.php
@@ -34,7 +34,7 @@
 			'shared_on' => isset($share_created_at_timestamp) ? $share_created_at_timestamp : false,
 			'shared_on_diff' => isset($share_created_at) ? $share_created_at : false,
 			'shared' => $item->isShared(),
-			'starrable' => isset($is_starrable) ? $is_starrable : false,
+			'starrable' => isset($is_starrable) && (!isset($context) || isset($context) && $context !== 'trash') ? $is_starrable : false,
 			'starred' => isset($is_starred) ? $is_starred : false,
 		])
 

--- a/tests/StarredTest.php
+++ b/tests/StarredTest.php
@@ -133,4 +133,22 @@ class StarredTest extends BrowserKitTestCase
         
         $this->assertEquals($expected_count, Starred::count());
     }
+
+    public function test_starred_page_loads_with_trashed_documents()
+    {
+        $this->withKlinkAdapterFake();
+        
+        $user = $this->createUser(Capability::$PARTNER);
+        
+        $starred = factory('KBox\Starred', 3)->create(['user_id' => $user->id]);
+
+        $starred->first()->document->delete();
+
+        $this->actingAs($user);
+        
+        $this->visit(route('documents.starred.index'));
+        
+        $this->assertResponseOk();
+        $this->seePageIs(route('documents.starred.index'));
+    }
 }

--- a/tests/StarredTest.php
+++ b/tests/StarredTest.php
@@ -151,4 +151,34 @@ class StarredTest extends BrowserKitTestCase
         $this->assertResponseOk();
         $this->seePageIs(route('documents.starred.index'));
     }
+
+    public function test_remove_star_from_trashed_documents()
+    {
+        $this->withKlinkAdapterFake();
+        
+        $user = $this->createUser(Capability::$PARTNER);
+        
+        $expected_count = Starred::count();
+        
+        $starred = factory('KBox\Starred')->create(['user_id' => $user->id]);
+
+        $starred->document->delete();
+
+        $this->actingAs($user);
+        \Session::start(); // Start a session for the current test
+        
+        $this->visit(route('documents.starred.index'));
+
+        $this->delete(route('documents.starred.destroy', [
+                'id' => $starred->id,
+                '_token' => csrf_token()])
+             )
+             ->seeJson([
+                 'status' => 'ok'
+             ]);
+        
+        $this->assertResponseOk();
+        
+        $this->assertEquals($expected_count, Starred::count());
+    }
 }


### PR DESCRIPTION
This pull request prevent loading errors of the starred section, in case a starred document is located in the trash.

Closes #86 