### PR TITLE
Stop propagation on drag and drop handler

### DIFF
--- a/resources/assets/js/modules/documents.js
+++ b/resources/assets/js/modules/documents.js
@@ -2070,8 +2070,8 @@ define("modules/documents", ["require", "modernizr", "jquery", "DMS", "modules/s
                                     module.uploads.isUploading = false;
                                     module.uploads.status = "completed";
                                     $('#upload-status').removeClass('visible');
-                                    // DMS.navigateReload();
-                                    // _alert( Lang.trans('documents.upload.all_uploaded'), "", "success");
+                                    DMS.navigateReload();
+                                    _alert( Lang.trans('documents.upload.all_uploaded'), "", "success");
                                 }
 
                             });

--- a/resources/assets/js/modules/documents.js
+++ b/resources/assets/js/modules/documents.js
@@ -117,14 +117,12 @@ define("modules/documents", ["require", "modernizr", "jquery", "DMS", "modules/s
         var dragText = evt.originalEvent.dataTransfer.getData('text');
         evt.originalEvent.dataTransfer.dropEffect = dragText !== 'dms_drag_collection' ? 'copy' : 'none';
 
-        // console.log('DROP', dragText, this);
-
         var files = evt.originalEvent.dataTransfer.files;
         
         // If the dragText is not empty, this means that the file was not
         // dragged in from outside the browser, therefore it is possibly a
         // document or collection.
-        if (files.length && !dragText) {
+        if (dragText !== undefined && dragText.length == 0 && files.length > 0) {
             return;
         }
         
@@ -150,7 +148,8 @@ define("modules/documents", ["require", "modernizr", "jquery", "DMS", "modules/s
         if(dropAction){
             module['menu'][dropAction].call(module, evt, $this.data(), dragText);
         }
-
+        
+        return false;
     });
 
     dragItems.on('dragstart', function(evt){
@@ -1995,6 +1994,8 @@ define("modules/documents", ["require", "modernizr", "jquery", "DMS", "modules/s
                             });
 
                             this.on('drop', function(evt){
+
+                                console.log('File drop, upload', evt);
                                 
                                 if(evt.target){
                                     
@@ -2069,8 +2070,8 @@ define("modules/documents", ["require", "modernizr", "jquery", "DMS", "modules/s
                                     module.uploads.isUploading = false;
                                     module.uploads.status = "completed";
                                     $('#upload-status').removeClass('visible');
-                                    DMS.navigateReload();
-                                    _alert( Lang.trans('documents.upload.all_uploaded'), "", "success");
+                                    // DMS.navigateReload();
+                                    // _alert( Lang.trans('documents.upload.all_uploaded'), "", "success");
                                 }
 
                             });


### PR DESCRIPTION
This pull request aims to have a final fix for #81 by adding a stop propagation and prevent default behavior to the sidebar drag and drop handler