### PR TITLE
Fix sub-collection trashing and deleting

### DIFF
--- a/app/Group.php
+++ b/app/Group.php
@@ -99,6 +99,30 @@ class Group extends Entity implements GroupInterface
     }
 
     /**
+     * Get the project that contains this collection.
+     *
+     * @return KBox\Project|null the project that contains the collection, or null if not in project or personal
+     */
+    public function getProject()
+    {
+        if ($this->is_private) {
+            return null;
+        }
+
+        if (! is_null($this->project)) {
+            return $this->project;
+        }
+
+        $project_root = $this->withAncestors()->has('project')->with('project')->first();
+
+        if (! is_null($project_root)) {
+            return $project_root->project;
+        }
+
+        return null;
+    }
+
+    /**
      * [documents description]
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany [description]
      */
@@ -118,6 +142,11 @@ class Group extends Entity implements GroupInterface
     public function scopeWithDescendants()
     {
         return $this->joinClosureBy('descendant');
+    }
+    
+    public function scopeWithAncestors()
+    {
+        return $this->joinClosureBy('ancestor');
     }
 
     public function shares()

--- a/docs/user/en/documents/trash.md
+++ b/docs/user/en/documents/trash.md
@@ -7,8 +7,7 @@ The trash contains every document and collection you delete. It gives you a seco
 
 The picture above shows an example of the trash content.
 
-When you delete a collection also the sub-collections are deleted.
-
+When you trash a collection also the sub-collections are trashed.
 
 > The administrator trash shows everything that has been trashed, so pay close attention
 
@@ -21,6 +20,7 @@ You can permanently delete a single document or a collection by using the mouse 
 
 The current release cannot permanently delete a selection of collections and documents at the same time.
 
+Trashed collections can only be permanently deleted by its creator, or the project manager if they were in a project.
 
 ## Empty the trash
 

--- a/resources/lang/en/groups.php
+++ b/resources/lang/en/groups.php
@@ -109,8 +109,12 @@ return [
         
         'cannot_delete_general_error' => 'Cannot delete the specified elements. Nothing has been deleted.',
         
+        'forbidden_trash_personal_collection' => 'You did not create :collection, therefore you cannot trash it.',
+        'forbidden_delete_personal_collection' => 'You did not create :collection, therefore you cannot delete it.',
         'forbidden_delete_collection' => 'The collection :collection cannot be deleted. You are not allowed to operate on Collections.',
         'forbidden_delete_project_collection' => 'The collection :collection cannot be deleted as it is in a project where you do not have the edit permissions.',
+        'forbidden_delete_project_collection_not_creator' => 'You are not the creator of the collection :collection, therefore you cannot delete it.',
+        'forbidden_delete_project_collection_not_manager' => 'You are not the manager of the project that contained :collection, therefore you cannot delete it.',
     ],
     
     'move' => [

--- a/tests/Unit/CollectionsTest.php
+++ b/tests/Unit/CollectionsTest.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace Tests\Unit;
+
+use KBox\Group;
+use Tests\TestCase;
+use KBox\Capability;
+use KBox\Exceptions\ForbiddenException;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class CollectionsTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_trashing_personal_collections_trash_also_descendants()
+    {
+        $service = app('Klink\DmsDocuments\DocumentsService');
+        
+        $user = tap(factory('KBox\User')->create(), function ($user) {
+            $user->addCapabilities(Capability::$PARTNER);
+        });
+    
+        //create a hierarchy
+        $collection_root = $service->createGroup($user, 'collection_level_one', null, null, true);
+        $collection_level_one = $service->createGroup($user, 'collection_level_one', null, $collection_root, true);
+        $collection_level_two = $service->createGroup($user, 'collection_level_two', null, $collection_root, true);
+        $collection_level_three = $service->createGroup($user, 'collection_level_three', null, $collection_level_one, true);
+        $collection_level_four = $service->createGroup($user, 'collection_level_four', null, $collection_level_three, true);
+
+        $this->assertEquals(4, $collection_root->getDescendants()->count());
+
+        // delete a collection close to the top
+
+        $trashed = $service->deleteGroup($user, $collection_level_one);
+
+        // assert that target collection and all sub-collections are deleted
+
+        $collection = $collection_root->fresh();
+
+        $this->assertTrue($trashed);
+        $this->assertEquals(1, $collection->getDescendants()->count());
+    }
+
+    public function test_trashing_project_collection_trash_also_descendants()
+    {
+        $service = app('Klink\DmsDocuments\DocumentsService');
+        
+        $manager = tap(factory('KBox\User')->create(), function ($user) {
+            $user->addCapabilities(Capability::$PROJECT_MANAGER_NO_CLEAN_TRASH);
+        });
+        $user = tap(factory('KBox\User')->create(), function ($user) {
+            $user->addCapabilities(Capability::$PARTNER);
+        });
+
+        $project = factory('KBox\Project')->create([
+            'user_id' => $manager->id
+        ]);
+
+        $project->users()->attach($user);
+            
+        //create a hierarchy
+        $collection_level_one = $service->createGroup($manager, 'collection_level_one', null, $project->collection, false);
+        $collection_level_two = $service->createGroup($manager, 'collection_level_two', null, $project->collection, false);
+        $collection_level_three = $service->createGroup($manager, 'collection_level_three', null, $collection_level_one, false);
+        $collection_level_four = $service->createGroup($manager, 'collection_level_four', null, $collection_level_three, false);
+
+        $this->assertEquals(4, $project->collection->getDescendants()->count());
+
+        // delete a collection close to the top
+
+        $trashed = $service->deleteGroup($user, $collection_level_one);
+
+        // assert that target collection and all sub-collections are deleted
+
+        $collection = $project->collection->fresh();
+
+        $this->assertTrue($trashed);
+        $this->assertEquals(1, $collection->getDescendants()->count());
+    }
+
+    public function test_manager_can_permanently_delete_collections_in_project()
+    {
+        $service = app('Klink\DmsDocuments\DocumentsService');
+        
+        $manager = tap(factory('KBox\User')->create(), function ($user) {
+            $user->addCapabilities(Capability::$PROJECT_MANAGER_NO_CLEAN_TRASH);
+        });
+        $user = tap(factory('KBox\User')->create(), function ($user) {
+            $user->addCapabilities(Capability::$PARTNER);
+        });
+
+        $project = factory('KBox\Project')->create([
+            'user_id' => $manager->id
+        ]);
+        $project->users()->attach($user);
+            
+        //create a hierarchy
+        $collection_level_one = $service->createGroup($manager, 'collection_level_one', null, $project->collection, false);
+        $collection_level_two = $service->createGroup($user, 'collection_level_two', null, $project->collection, false);
+        $collection_level_three = $service->createGroup($user, 'collection_level_three', null, $collection_level_one, false);
+        $collection_level_four = $service->createGroup($user, 'collection_level_four', null, $collection_level_three, false);
+
+        $this->assertEquals(4, $project->collection->getDescendants()->count());
+
+        // delete a collection close to the top
+        $trashed = $service->permanentlyDeleteGroup($collection_level_one, $manager);
+
+        // assert that target collection and all sub-collections are deleted
+
+        $collection = $project->collection->fresh();
+
+        $this->assertTrue($trashed);
+        $this->assertEquals(1, $collection->getDescendants()->count());
+    }
+
+    public function test_partner_cannot_permanently_delete_collections_in_project()
+    {
+        $service = app('Klink\DmsDocuments\DocumentsService');
+        
+        $manager = tap(factory('KBox\User')->create(), function ($user) {
+            $user->addCapabilities(Capability::$PROJECT_MANAGER_NO_CLEAN_TRASH);
+        });
+        $user = tap(factory('KBox\User')->create(), function ($user) {
+            $user->addCapabilities(Capability::$PARTNER);
+        });
+
+        $project = factory('KBox\Project')->create([
+            'user_id' => $manager->id
+        ]);
+        $project->users()->attach($user);
+            
+        //create a hierarchy
+        $collection_level_one = $service->createGroup($user, 'collection_level_one', null, $project->collection, false);
+        $collection_level_two = $service->createGroup($user, 'collection_level_two', null, $project->collection, false);
+        $collection_level_three = $service->createGroup($user, 'collection_level_three', null, $collection_level_one, false);
+        $collection_level_four = $service->createGroup($user, 'collection_level_four', null, $collection_level_three, false);
+
+        $this->assertEquals(4, $project->collection->getDescendants()->count());
+
+        try {
+            $trashed = $service->permanentlyDeleteGroup($collection_level_one, $user);
+            $this->fail('Expected forbidden exception');
+        } catch (ForbiddenException $ex) {
+            $this->assertEquals(trans('groups.delete.forbidden_delete_project_collection_not_manager', ['collection' => $collection_level_one->name]), $ex->getMessage());
+        }
+    }
+
+    public function test_user_cannot_trash_my_personal_collection()
+    {
+        $service = app('Klink\DmsDocuments\DocumentsService');
+        
+        $creator = tap(factory('KBox\User')->create(), function ($user) {
+            $user->addCapabilities(Capability::$PARTNER);
+        });
+        $user = tap(factory('KBox\User')->create(), function ($user) {
+            $user->addCapabilities(Capability::$PARTNER);
+        });
+            
+        //create a hierarchy
+        $collection_root = $service->createGroup($creator, 'collection_level_one', null, null);
+        $collection_level_one = $service->createGroup($creator, 'collection_level_one', null, $collection_root);
+        $collection_level_two = $service->createGroup($creator, 'collection_level_two', null, $collection_root);
+        $collection_level_three = $service->createGroup($creator, 'collection_level_three', null, $collection_level_one);
+        $collection_level_four = $service->createGroup($creator, 'collection_level_four', null, $collection_level_three);
+
+        $this->assertEquals(4, $collection_root->getDescendants()->count());
+
+        
+        // delete a collection close to the top
+        try {
+            $service->deleteGroup($user, $collection_level_one);
+            $this->fail('Expected exception, but trash continued');
+        } catch (ForbiddenException $ex) {
+            $this->assertEquals(trans('groups.delete.forbidden_trash_personal_collection', ['collection' => $collection_level_one->name]), $ex->getMessage());
+        }
+    }
+
+    public function test_user_cannot_permanently_delete_my_trashed_personal_collection()
+    {
+        $service = app('Klink\DmsDocuments\DocumentsService');
+        
+        $creator = tap(factory('KBox\User')->create(), function ($user) {
+            $user->addCapabilities(Capability::$PARTNER);
+        });
+        $user = tap(factory('KBox\User')->create(), function ($user) {
+            $user->addCapabilities(Capability::$PARTNER);
+        });
+            
+        //create a hierarchy
+        $collection_root = $service->createGroup($creator, 'collection_level_one', null, null);
+        $collection_level_one = $service->createGroup($creator, 'collection_level_one', null, $collection_root);
+        $collection_level_two = $service->createGroup($creator, 'collection_level_two', null, $collection_root);
+        $collection_level_three = $service->createGroup($creator, 'collection_level_three', null, $collection_level_one);
+        $collection_level_four = $service->createGroup($creator, 'collection_level_four', null, $collection_level_three);
+
+        $service->deleteGroup($creator, $collection_level_one);
+
+        $this->assertEquals(1, $collection_root->getDescendants()->count());
+
+        try {
+            $collection = Group::withTrashed()->findOrFail($collection_level_one->id);
+            $service->permanentlyDeleteGroup($collection, $user);
+            $this->fail('Expected exception, but delete continued');
+        } catch (ForbiddenException $ex) {
+            $this->assertEquals(trans('groups.delete.forbidden_trash_personal_collection', ['collection' => $collection_level_one->name]), $ex->getMessage());
+        }
+    }
+}

--- a/workbench/klink/dms-documents/src/Klink/DmsDocuments/DocumentsService.php
+++ b/workbench/klink/dms-documents/src/Klink/DmsDocuments/DocumentsService.php
@@ -695,8 +695,8 @@ class DocumentsService
             $is_creator = $user->id == $group->user_id;
             $is_manager = !is_null($project) ? $project->user_id == $user->id : false;
     
-            if (! $is_creator || ! $is_manager) {
-                throw new ForbiddenException(trans( ! $is_creator ? 'groups.delete.forbidden_delete_project_collection_not_creator' : 'groups.delete.forbidden_delete_project_collection_not_manager', ['collection' => $group->name]));
+            if (! ($is_creator || $is_manager)) {
+                throw new ForbiddenException(trans( ! $is_manager ? 'groups.delete.forbidden_delete_project_collection_not_manager' : 'groups.delete.forbidden_delete_project_collection_not_creator', ['collection' => $group->name]));
             }
 
         }


### PR DESCRIPTION
## What does this MR do?

Fix collection trashing and delete if collections where in a project.

It defines that all users can trash a project collection, but only the creator or the project manager can permanently delete.

It also make sure that sub-collections are always trashed if the containing collection can be trashed.

The following localization strings have been added

- `groups.delete.forbidden_trash_personal_collection`
- `groups.delete.'forbidden_delete_personal_collection`
- `groups.delete.forbidden_delete_project_collection_not_creator`
- `groups.delete.forbidden_delete_project_collection_not_manager`

### Related issues

no related issues

### Review checklist

* [x] Are unit tests required? Yes, done
* [x] Are Documentation changes needed? Yes, done

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)