### PR TITLE
Language whitelist

### DIFF
--- a/app/DocumentsElaboration/Actions/GuessLanguage.php
+++ b/app/DocumentsElaboration/Actions/GuessLanguage.php
@@ -47,17 +47,20 @@ class GuessLanguage extends Action
         try {
 
             // blacklisting the languages with less than 4 milion users except from Tajik and Kyrgyz
-            $language_code = $guesser->guess($text, ['cat','sot','kat','bcl','glg','lao','lit','umb','tsn','vec','nso','ban','bug','knc','kng','ibb','lug','ace','bam','tzm','ydd','kmb','lun','shn','war','dyu','wol','nds','mkd','vmw','zgh','ewe','khk','slv','ayr','bem','emk','bci','bum','epo','pam','tiv','tpi','ven','ssw','nyn','kbd','iii','yao','lav','quz','src','rup','sco','tso','rmy','men','fon','nhn','dip','kde','snn','kbp','tem','toi','est','snk','cjk','ada','aii','quy','rmn','bin','gaa','ndo']);
+            $language_code = $guesser->guess($text); //, ['cat','sot','kat','bcl','glg','lao','lit','umb','tsn','vec','nso','ban','bug','knc','kng','ibb','lug','ace','bam','tzm','ydd','kmb','lun','shn','war','dyu','wol','nds','mkd','vmw','zgh','ewe','khk','slv','ayr','bem','emk','bci','bum','epo','pam','tiv','tpi','ven','ssw','nyn','kbd','iii','yao','lav','quz','src','rup','sco','tso','rmy','men','fon','nhn','dip','kde','snn','kbp','tem','toi','est','snk','cjk','ada','aii','quy','rmn','bin','gaa','ndo']);
         
             // transform the language code to ISO 639-1
             $language = LanguageLoader::where('iso_639_3', '=', $language_code);
 
             if ($language) {
                 $language = array_first($language);
-    
-                $descriptor->language = $language['iso_639_1'];
-    
-                $descriptor->save();
+                $iso_639_1 = $language['iso_639_1'];
+
+                if(in_array($iso_639_1, config('dms.language_whitelist'))){
+                    $descriptor->language = $iso_639_1;
+        
+                    $descriptor->save();
+                }
             } else {
                 Log::warning("Cannot find language from ISO code $language_code");
             }

--- a/app/DocumentsElaboration/Actions/GuessLanguage.php
+++ b/app/DocumentsElaboration/Actions/GuessLanguage.php
@@ -56,7 +56,7 @@ class GuessLanguage extends Action
                 $language = array_first($language);
                 $iso_639_1 = $language['iso_639_1'];
 
-                if(in_array($iso_639_1, config('dms.language_whitelist'))){
+                if (in_array($iso_639_1, config('dms.language_whitelist'))) {
                     $descriptor->language = $iso_639_1;
         
                     $descriptor->save();

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -227,15 +227,15 @@ if (! function_exists('array_from')) {
      */
     function array_from($value)
     {
-        if(is_null($value) || empty($value)){
+        if (is_null($value) || empty($value)) {
             return [];
         }
 
-        if(is_array($value)){
+        if (is_array($value)) {
             return $value;
         }
 
-        if(!is_string($value)){
+        if (! is_string($value)) {
             return [];
         }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -217,3 +217,28 @@ if (! function_exists('debugger') && env('APP_ENV') !== 'production') {
         eval('\Psy\Shell::debug(isset($mixed) && !is_null($mixed) ? $mixed : get_defined_vars());');
     }
 }
+
+if (! function_exists('array_from')) {
+    /**
+     * Create an array from a given comma separated string
+     *
+     * @param string $value
+     * @return array
+     */
+    function array_from($value)
+    {
+        if(is_null($value) || empty($value)){
+            return [];
+        }
+
+        if(is_array($value)){
+            return $value;
+        }
+
+        if(!is_string($value)){
+            return [];
+        }
+
+        return explode(',', $value);
+    }
+}

--- a/config/dms.php
+++ b/config/dms.php
@@ -165,9 +165,9 @@ return [
     |
     | default: 'en', 'de', 'it', 'fr', 'ky', 'ru', 'tg'
     | acceptable value: array of iso_639_1 language codes
-    | 
-    | if configured via environment variable, the acceptable value 
-    | is a string of comma separated iso_639_1 language codes 
+    |
+    | if configured via environment variable, the acceptable value
+    | is a string of comma separated iso_639_1 language codes
     | e.g. en,ru,de
     |
     | Set to null or empty array if the whitelist should be disabled

--- a/config/dms.php
+++ b/config/dms.php
@@ -158,18 +158,24 @@ return [
     
     /*
     |--------------------------------------------------------------------------
-    | Limit languages filters to
+    | Language whitelist
     |--------------------------------------------------------------------------
     |
-    | Use this option to limit the usable language filters
+    | Use this option to limit the  usable language filters
     |
-    | default: false
-    | acceptable value: array of comma separated language codes e.g. en,ru,de
+    | default: 'en', 'de', 'it', 'fr', 'ky', 'ru', 'tg'
+    | acceptable value: array of iso_639_1 language codes
+    | 
+    | if configured via environment variable, the acceptable value 
+    | is a string of comma separated iso_639_1 language codes 
+    | e.g. en,ru,de
     |
-    | @var boolean|string
+    | Set to null or empty array if the whitelist should be disabled
+    |
+    | @var array
     */
     
-    'limit_languages_to' => getenv('DMS_LIMIT_LANGUAGES_TO') ?: 'en,de,it,fr,ky,ru',
+    'language_whitelist' => array_from(env('KBOX_LANGUAGE_WHITELIST', env('DMS_LIMIT_LANGUAGES_TO', ['en', 'de', 'it', 'fr', 'ky', 'ru', 'tg']))),
     
     /*
     |--------------------------------------------------------------------------

--- a/packages/language-guesser/src/Contracts/LanguageGuesser.php
+++ b/packages/language-guesser/src/Contracts/LanguageGuesser.php
@@ -10,17 +10,8 @@ interface LanguageGuesser
      * Guess the language of a text
      *
      * @param string $text
-     * @param array $blacklist
      * @return string the ISO 639-1 code
      */
-    public function guess($text, $blacklist = []);
+    public function guess($text);
     
-    // /**
-    //  * Guess the language of a text
-    //  *
-    //  * @param string $text
-    //  * @param array $blacklist
-    //  * @return array the array of languages identified, the key is the language code, while the value is the probability
-    //  */
-    // public function guessAll($text, $blacklist = []);
 }

--- a/packages/language-guesser/src/Contracts/LanguageGuesser.php
+++ b/packages/language-guesser/src/Contracts/LanguageGuesser.php
@@ -13,5 +13,4 @@ interface LanguageGuesser
      * @return string the ISO 639-1 code
      */
     public function guess($text);
-    
 }

--- a/packages/language-guesser/src/LanguageGuesserFactory.php
+++ b/packages/language-guesser/src/LanguageGuesserFactory.php
@@ -21,6 +21,6 @@ class LanguageGuesserFactory
 
     public static function isInstalled()
     {
-       return LanguageCli::isInstalled();
+        return LanguageCli::isInstalled();
     }
 }

--- a/packages/language-guesser/src/LanguageGuesserFactory.php
+++ b/packages/language-guesser/src/LanguageGuesserFactory.php
@@ -21,7 +21,6 @@ class LanguageGuesserFactory
 
     public static function isInstalled()
     {
-        // LanguageGuesserFactory
        return LanguageCli::isInstalled();
     }
 }

--- a/packages/language-guesser/src/LocalLanguageGuesser.php
+++ b/packages/language-guesser/src/LocalLanguageGuesser.php
@@ -7,11 +7,19 @@ use OneOffTech\LanguageGuesser\Contracts\LanguageGuesser as LanguageGuesserContr
 
 class LocalLanguageGuesser implements LanguageGuesserContract
 {
-    public function guess($text, $blacklist = [])
+    /**
+     * Language blacklist.
+     * The languages to exclude from the guessing. 
+     * In this case we exclude languages with less than 4 milion users 
+     * except from Tajik and Kirgiz
+     */
+    private $blacklist = ['cat','sot','kat','bcl','glg','lao','lit','umb','tsn','vec','nso','ban','bug','knc','kng','ibb','lug','ace','bam','tzm','ydd','kmb','lun','shn','war','dyu','wol','nds','mkd','vmw','zgh','ewe','khk','slv','ayr','bem','emk','bci','bum','epo','pam','tiv','tpi','ven','ssw','nyn','kbd','iii','yao','lav','quz','src','rup','sco','tso','rmy','men','fon','nhn','dip','kde','snn','kbp','tem','toi','est','snk','cjk','ada','aii','quy','rmn','bin','gaa','ndo'];
+
+    public function guess($text)
     {
-        $cli = new LanguageCli($text, false, $blacklist);
+        $cli = new LanguageCli($text, false, $this->blacklist);
         $out = $cli->run();
-       
+
         return substr(trim($out), 0, 3);
     }
 

--- a/packages/language-guesser/src/LocalLanguageGuesser.php
+++ b/packages/language-guesser/src/LocalLanguageGuesser.php
@@ -9,8 +9,8 @@ class LocalLanguageGuesser implements LanguageGuesserContract
 {
     /**
      * Language blacklist.
-     * The languages to exclude from the guessing. 
-     * In this case we exclude languages with less than 4 milion users 
+     * The languages to exclude from the guessing.
+     * In this case we exclude languages with less than 4 milion users
      * except from Tajik and Kirgiz
      */
     private $blacklist = ['cat','sot','kat','bcl','glg','lao','lit','umb','tsn','vec','nso','ban','bug','knc','kng','ibb','lug','ace','bam','tzm','ydd','kmb','lun','shn','war','dyu','wol','nds','mkd','vmw','zgh','ewe','khk','slv','ayr','bem','emk','bci','bum','epo','pam','tiv','tpi','ven','ssw','nyn','kbd','iii','yao','lav','quz','src','rup','sco','tso','rmy','men','fon','nhn','dip','kde','snn','kbp','tem','toi','est','snk','cjk','ada','aii','quy','rmn','bin','gaa','ndo'];

--- a/resources/views/documents/descriptor.blade.php
+++ b/resources/views/documents/descriptor.blade.php
@@ -29,7 +29,7 @@
 			'created_at' => $item->getCreatedAt(true),
 			'modified_at_diff' => $item->getUpdatedAtHumanDiff(),
 			'created_at_diff' => $item->getCreatedAt(),
-			'language' => isset($item->language) ? $item->language : '',
+			'language' => isset($item->language) && in_array($item->language, config('dms.language_whitelist')) ? $item->language : '',
 			'shared_by' => isset($shared_by) ? $shared_by : false,
 			'shared_on' => isset($share_created_at_timestamp) ? $share_created_at_timestamp : false,
 			'shared_on_diff' => isset($share_created_at) ? $share_created_at : false,

--- a/resources/views/documents/edit.blade.php
+++ b/resources/views/documents/edit.blade.php
@@ -141,7 +141,7 @@
 	            <span class="field-error">{{ implode(",", $errors->get('language'))  }}</span>
 	        @endif
 			<select class="c-form__input c-form__input--larger" id="language" name="language" @if(!$document->isMine() || !$can_edit_document) disabled @endif>
-			<option disabled value="__" @if($document->language == '__' || !$document->language) selected @endif>{{trans('languages.no_language')}}</option>
+			<option disabled value="__" @if($document->language == '__' || !$document->language || !in_array($document->language, config('dms.language_whitelist'))) selected @endif>{{trans('languages.no_language')}}</option>
 			<option value="en" @if($document->language == 'en') selected @endif>{{trans('languages.en')}}</option>
 			<option value="ru" @if($document->language == 'ru') selected @endif>{{trans('languages.ru')}}</option>
 			<option value="tg" @if($document->language == 'tg') selected @endif>{{trans('languages.tg')}}</option>

--- a/resources/views/panels/document.blade.php
+++ b/resources/views/panels/document.blade.php
@@ -198,8 +198,8 @@
 				{{trans('panels.meta.language')}}
 			</div>
 			
-				{{!empty($item->language) ? trans('languages.' . $item->language) : trans('languages.no_language')}}
-			</div>
+			{{!empty($item->language) && in_array($item->language, config('dms.language_whitelist')) ? trans('languages.' . $item->language) : trans('languages.no_language')}}
+			
 		</div>
 		<div class="c-panel__meta">
 			<div class="c-panel__label">

--- a/tests/Feature/GuessLanguageTest.php
+++ b/tests/Feature/GuessLanguageTest.php
@@ -145,4 +145,21 @@ class GuessLanguageTest extends TestCase
         $this->assertEquals(2, strlen($descriptor->language));
         $this->assertEquals('it', $descriptor->language);
     }
+
+    public function test_language_guesser_respect_language_whitelist()
+    {
+        config(['dms.language_whitelist' => ['de']]);
+        // create descriptor with text file
+        $descriptor = $this->generateDescriptorForFile(base_path('tests/data/example-with-multiline.docx'));
+
+        // instantiate the GuessLanguage action
+        $action = new GuessLanguage();
+
+        $out_descriptor = $action->run($descriptor);
+
+        // obtaining a fresh copy to confirm that the action saved the language in the database
+        $descriptor = $descriptor->fresh();
+
+        $this->assertNull($descriptor->language);
+    }
 }

--- a/tests/Unit/ArrayFromHelperTest.php
+++ b/tests/Unit/ArrayFromHelperTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class ArrayFromHelperTest extends TestCase
+{
+    public function test_array_from_string()
+    {
+        $result = array_from('hello,i,am,a,string');
+
+        $this->assertEquals(['hello','i','am','a','string'], $result);
+    }
+    public function test_array_from_boolean()
+    {
+        $result = array_from(true);
+
+        $this->assertEquals([], $result);
+    }
+    public function test_array_from_number()
+    {
+        $result = array_from(100);
+
+        $this->assertEquals([], $result);
+    }
+    public function test_array_from_null()
+    {
+        $result = array_from(null);
+
+        $this->assertEquals([], $result);
+    }
+    public function test_array_from_object()
+    {
+        $result = array_from($this);
+
+        $this->assertEquals([], $result);
+    }
+    public function test_array_from_array()
+    {
+        $result = array_from(['en', 'es']);
+
+        $this->assertEquals(['en', 'es'], $result);
+    }
+}

--- a/tests/Unit/ArrayFromHelperTest.php
+++ b/tests/Unit/ArrayFromHelperTest.php
@@ -3,8 +3,6 @@
 namespace Tests\Unit;
 
 use Tests\TestCase;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class ArrayFromHelperTest extends TestCase
 {

--- a/workbench/klink/dms-search/src/Klink/DmsSearch/SearchService.php
+++ b/workbench/klink/dms-search/src/Klink/DmsSearch/SearchService.php
@@ -250,35 +250,29 @@ class SearchService
     }
     
     /**
-     * Limits the language facets based on the configuration `dms.limit_languages_to`
+     * Limits the language facets based on the configured whitelist
      */
     public function limitFacets($facets)
     {
-//         $config = \Config::get('dms.limit_languages_to', false);
+        $whitelist = array_merge(config('dms.language_whitelist', []), ['__']);
         
-// dump($facets);
+        $lang_facets = array_first($facets, function ($value, $key) {
+            return $key === KlinkFacets::LANGUAGE;
+        }, null);
+    
+        if (empty($lang_facets)) {
+            return $facets;
+        }
+        
+        $items_to_keep = [];
+        
+        foreach ($lang_facets as $item) {
+            if (in_array($item->value, $whitelist)) {
+                $items_to_keep[] = $item;
+            }
+        }
 
-//         if ($config !== false && is_string($config) && ! is_null($facets)) {
-//             $langs = explode(',', $config);
-            
-//             $lang_facet = $value = array_first($facets, function ($value, $key) {
-//                 return $value->name === KlinkFacets::LANGUAGE;
-//             }, null);
-                
-//             if (is_null($lang_facet)) {
-//                 return $facets;
-//             }
-            
-//             $items_to_keep = [];
-            
-//             foreach ($lang_facet->items as $item) {
-//                 if (in_array($item->term, $langs)) {
-//                     $items_to_keep[] = $item;
-//                 }
-//             }
-            
-//             $lang_facet->items = $items_to_keep;
-//         }
+        $facets[KlinkFacets::LANGUAGE] = $items_to_keep;
         
         return $facets;
     }


### PR DESCRIPTION
## What does this PR do?

- Enable language whitelist
- Uses only languages contained in the whitelist to determine if the language recognition result can be used
- Prevent to show language filters for un-supported languages

### Related issues

Fixes #42

### Review checklist

* [x] Are unit tests required? yes, some
* [x] Are Documentation changes needed? No changes required

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)