### PR TITLE
Fix plugins page visible when plugin flag disabled

### DIFF
--- a/app/Http/Controllers/Plugins/PluginsController.php
+++ b/app/Http/Controllers/Plugins/PluginsController.php
@@ -20,6 +20,8 @@ class PluginsController extends Controller
         $this->middleware('auth');
 
         $this->middleware('capabilities');
+        
+        $this->middleware('flags:plugins');
 
         $this->manager = $manager;
     }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -58,6 +58,7 @@ class Kernel extends HttpKernel
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \KBox\Http\Middleware\RedirectIfAuthenticated::class,
         'capabilities' => \KBox\Http\Middleware\RedirectIfForbidden::class,
+        'flags' => \KBox\Http\Middleware\VerifyFlag::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
     ];
 }

--- a/app/Http/Middleware/VerifyFlag.php
+++ b/app/Http/Middleware/VerifyFlag.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace KBox\Http\Middleware;
+
+use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * Check if a feature flag is enabled before letting the request pass
+ */
+class VerifyFlag
+{
+    /**
+     * Create a new filter instance.
+     *
+     * @param  Guard  $auth
+     * @return void
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, $next, $flag)
+    {
+        if (flags($flag)) {
+            return $next($request);
+        }
+            
+        if ($request->wantsJson()) {
+            return new JsonResponse(['error' => trans('errors.forbidden_exception')], 403);
+        }
+        return response()->make(view('errors.403', []), 200);
+    }
+}

--- a/routes/plugins.php
+++ b/routes/plugins.php
@@ -8,7 +8,7 @@ use KBox\Http\Controllers\Plugins\PluginsController;
 |--------------------------------------------------------------------------
 */
 
-Route::group(['as' => 'administration.', 'prefix' => 'administration'], function () {
+Route::group(['as' => 'administration.', 'prefix' => 'administration', 'middleware' => ['flags:plugins']], function () {
 
     // Plugins related routes
     Route::resource('/plugins', PluginsController::class, ['only' => ['index'/*, 'show', 'edit'*/, 'update', 'destroy']]);

--- a/tests/Feature/Plugins/PluginsControllerTest.php
+++ b/tests/Feature/Plugins/PluginsControllerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Plugins;
 
 use KBox\User;
+use KBox\Flags;
 use Tests\TestCase;
 use KBox\Capability;
 use KBox\Plugins\PluginManager;
@@ -57,6 +58,8 @@ class PluginsControllerTest extends TestCase
 
     public function test_discovered_plugins_are_presented()
     {
+        Flags::enable(Flags::PLUGINS);
+        
         $user = tap(factory(User::class)->create(), function ($u) {
             $u->addCapabilities(Capability::$ADMIN);
         });

--- a/tests/Unit/Middleware/VerifyFlagMiddlewareTest.php
+++ b/tests/Unit/Middleware/VerifyFlagMiddlewareTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Unit\Middleware;
+
+use KBox\Flags;
+use Tests\TestCase;
+use Illuminate\Http\Request;
+use KBox\Http\Middleware\VerifyFlag;
+use Illuminate\Foundation\Testing\TestResponse;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class VerifyFlagMiddlewareTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_request_denied_if_flag_disabled()
+    {
+        Flags::disable(Flags::PLUGINS);
+
+        $request = new Request;
+
+        $middleware = new VerifyFlag();
+
+        $next = new class {
+            // anonymous invokable class to track a state for the next closure
+            public $called = false;
+
+            public function __invoke($args)
+            {
+                $this->called = true;
+                return $args;
+            }
+        };
+
+        $response = TestResponse::fromBaseResponse($middleware->handle($request, $next, Flags::PLUGINS));
+
+        $this->assertFalse($next->called);
+        $response->assertStatus(200);
+        $response->assertViewIs('errors.403');
+    }
+
+    public function test_request_accepted_if_flag_enabled()
+    {
+        Flags::enable(Flags::PLUGINS);
+
+        $request = new Request;
+
+        $middleware = new VerifyFlag();
+
+        $next = new class {
+            // anonymous invokable class to track a state for the next closure
+            public $called = false;
+
+            public function __invoke($args)
+            {
+                $this->called = true;
+                return $args;
+            }
+        };
+
+        $response = $middleware->handle($request, $next, Flags::PLUGINS);
+
+        $this->assertTrue($next->called);
+        $this->assertSame($response, $request);
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Fix plugins page visible when plugin flag disabled

### Review checklist

* [x] Are unit tests required?
* [x] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)