### PR TITLE
Remove alternate content hash calculation

### DIFF
--- a/packages/contentprocessing/src/Services/DocumentsService.php
+++ b/packages/contentprocessing/src/Services/DocumentsService.php
@@ -123,10 +123,6 @@ class DocumentsService
         $original_hash = $klink_descriptor->hash();
 
         $content = $this->getFileContentForIndexing($file);
-
-        if (! is_file($content)) {
-            $klink_descriptor->setHash(KlinkDocumentUtils::generateHash($content));
-        }
         
         $document = new KlinkDocument($klink_descriptor, $content);
         
@@ -171,10 +167,6 @@ class DocumentsService
         $content = $this->getFileContentForIndexing($file);
 
         $original_hash = $klink_descriptor->hash();
-
-        if (! is_file($content)) {
-            $klink_descriptor->setHash(KlinkDocumentUtils::generateHash($content));
-        }
         
         $document = new KlinkDocument($klink_descriptor, $content);
         


### PR DESCRIPTION
Remove alternate content hash calculation to let file being downloadable from K-Link

## What does this PR do?

Remove the calculation of the hash of the textual content that is sent when publishing a unsupported file. The K-Search 3.5.0 is able to deal with such scenario.

Sending the hash would prevent the file being downloadable directly from the K-Link using the /files endpoint

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)