### PR TITLE
Add oEmbed support for documents

### DIFF
--- a/app/Http/Controllers/Document/DocumentEmbedController.php
+++ b/app/Http/Controllers/Document/DocumentEmbedController.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace KBox\Http\Controllers\Document;
+
+use Log;
+use Exception;
+use Throwable;
+use KBox\File;
+use KBox\DocumentDescriptor;
+use Illuminate\Http\Request;
+use KBox\Documents\Services\PreviewService;
+use KBox\Exceptions\ForbiddenException;
+use KBox\Documents\Services\DocumentsService;
+use Illuminate\Auth\AuthenticationException;
+use KBox\Documents\Preview\Exception\UnsupportedFileException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use KBox\Documents\Preview\Exception\PreviewGenerationException;
+
+class DocumentEmbedController extends DocumentAccessController
+{
+    /**
+     * @var KBox\Documents\Services\PreviewService
+     */
+    private $previewService = null;
+
+    public function __construct(PreviewService $preview, DocumentsService $documentsService)
+    {
+        $this->previewService = $preview;
+        parent::__construct($documentsService);
+    }
+
+    public function show(Request $request, $uuid, $versionUuid = null)
+    {
+        try {
+            list($document, $file) = $this->getDocument($request, $uuid, $versionUuid);
+
+            return $this->embedDocument($document, $file);
+        } catch (AuthenticationException $ex) {
+            return view('errors.login');
+        } catch (ForbiddenException $ex) {
+            return view('errors.403', ['reason' => 'ForbiddenException: '.$ex->getMessage()]);
+        } catch (ModelNotFoundException $ex) {
+            return view('errors.404', ['reason' => trans('errors.document_not_found')]);
+        }
+    }
+
+    private function embedDocument(DocumentDescriptor $doc, File $version = null)
+    {
+        /* File */ $file = $version ?? $doc->file;
+
+        $render = null;
+        $preview = null;
+        $preview_errors = null;
+
+        $view_data = [
+            'document' => $doc,
+            'file' => $file,
+            'version' => $version,
+            'filename_for_download' => $version ? $version->name : $doc->title,
+            'pagetitle' => trans('documents.preview.page_title', ['document' => $doc->title]),
+            'body_classes' => "preview",
+        ];
+
+        try {
+            if ($doc->isFileUploadComplete() && $doc->status === DocumentDescriptor::STATUS_COMPLETED) {
+                $preview = $this->previewService->preview($file);
+
+                if (method_exists($preview, 'with')) {
+                    $preview->with($view_data);
+                }
+
+                return view('documents.embed', array_merge($view_data, [
+                    'previewable' => $preview,
+                    'filename_for_download' => $version ? $version->name : $doc->title,
+                    ]));
+            }
+                
+            return view('documents.embed', array_merge($view_data, [
+                'preview_errors' => trans('documents.preview.file_not_ready')
+            ]));
+        } catch (UnsupportedFileException $pex) {
+            $preview_errors = trans('documents.preview.not_supported');
+        } catch (PreviewGenerationException $pex) {
+            Log::error('Preview Generation, failure', ['error' => $pex, 'file' => $file]);
+            $preview_errors = trans('documents.preview.error', ['document' => $doc->title]);
+        } catch (Exception $pex) {
+            Log::error('Preview Generation, failure', ['error' => $pex, 'file' => $file]);
+            $preview_errors = trans('documents.preview.error', ['document' => $doc->title]);
+        } catch (Throwable $pex) {
+            Log::error('Preview Generation, failure', ['error' => $pex, 'file' => $file]);
+            $preview_errors = trans('documents.preview.error', ['document' => $doc->title]);
+        }
+
+        return view('documents.embed', array_merge($view_data, [
+            'preview_errors' => $preview_errors,
+        ]));
+    }
+}

--- a/app/Http/Controllers/OembedController.php
+++ b/app/Http/Controllers/OembedController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace KBox\Http\Controllers;
+
+use KBox\DocumentDescriptor;
+use Illuminate\Http\Request;
+
+class OembedController extends Controller
+{
+    /**
+     * Return the oEmbed (https://oembed.com/) response for the specified request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function show(Request $request)
+    {
+        $format = $request->input('format', 'json');
+        $url = $request->input('url', '');
+        $maxwidth = $request->input('maxwidth', 960);
+        $maxheight = $request->input('maxheight', 540);
+
+        // if format is not json, abort
+        abort_if($format !== 'json', 501);
+
+        // Get the document id from the given URL
+        $base_url = route('documents.preview', '').'/';
+
+        // if the url don't start with this application URL, or
+        // contains query parameters => abort
+        abort_unless(starts_with($url, $base_url), 404);
+        abort_if(str_contains($url, '?') || str_contains($url, '#'), 404);
+        
+        $id = e(str_replace($base_url, '', $url));
+
+        $document = DocumentDescriptor::whereUuid($id)->first();
+
+        // if document not found simply return
+        abort_if(is_null($document), 404);
+
+        $width = e(min([480, $maxwidth]));
+        $height = e(min([360, $maxheight]));
+
+        // the URL that will be used in the resulting iframe to show the embed
+        $embed_url = route('documents.embed', $document->uuid);
+
+        $data = [
+            "version" => "1.0",
+            "type" => "rich",
+            "provider_name" => config('app.name'),
+            "provider_url" => config('app.url'),
+            "width" => $width,
+            "height" => $height,
+            "title" => e($document->title), // optional
+            "html" => "<iframe width=\"$width\" height=\"$height\" src=\"$embed_url\" class=\"kbox_embed_iframe\" frameborder=\"0\" allowfullscreen></iframe>",
+        ];
+
+        return response()->json($data, 200);
+    }
+}

--- a/docker/nginx-default.conf
+++ b/docker/nginx-default.conf
@@ -39,7 +39,7 @@ server {
 
     ## Default headers, in part oriented for recurity
     ## https://peteris.rocks/blog/exotic-http-headers/
-    add_header 'X-Frame-Options' 'SAMEORIGIN' always;
+    # add_header 'X-Frame-Options' 'SAMEORIGIN' always;
     add_header 'X-XSS-Protection' '1; mode=block' always;
     add_header 'X-Content-Type-Options' 'nosniff' always;
 

--- a/docker/nginx-default.conf
+++ b/docker/nginx-default.conf
@@ -32,10 +32,10 @@ server {
     ##   http://nginx.org/en/docs/http/ngx_http_headers_module.html and 
     ##   http://tech.osteel.me/posts/2015/07/19/handling-cors-with-nginx.html 
 
-    # add_header 'Access-Control-Allow-Origin' $http_origin always;
-    # add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
-    # add_header 'Access-Control-Allow-Credentials' 'true' always;
-    # add_header 'Access-Control-Allow-Headers' 'Origin,Content-Type,Accept,Authorization' always;
+    add_header 'Access-Control-Allow-Origin' $http_origin always;
+    add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
+    add_header 'Access-Control-Allow-Credentials' 'true' always;
+    add_header 'Access-Control-Allow-Headers' 'Origin,Content-Type,Accept,Authorization' always;
 
     ## Default headers, in part oriented for recurity
     ## https://peteris.rocks/blog/exotic-http-headers/
@@ -68,19 +68,19 @@ server {
 
     location / {
 
-        # if ($request_method = 'OPTIONS') {
-        #     # continue of the CORS related headers
-        #     add_header 'Access-Control-Allow-Origin' $http_origin always;
-        #     add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
-        #     add_header 'Access-Control-Allow-Credentials' 'true';
-        #     add_header 'Access-Control-Allow-Headers' 'Origin,Content-Type,Accept,Authorization';
+        if ($request_method = 'OPTIONS') {
+            # continue of the CORS related headers
+            add_header 'Access-Control-Allow-Origin' $http_origin always;
+            add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
+            add_header 'Access-Control-Allow-Credentials' 'true';
+            add_header 'Access-Control-Allow-Headers' 'Origin,Content-Type,Accept,Authorization';
             
-        #     # Tell client that this pre-flight info is valid for 20 days
-        #     add_header 'Access-Control-Max-Age' 1728000;
-        #     add_header 'Content-Type' 'text/plain charset=UTF-8';
-        #     add_header 'Content-Length' 0;
-        #     return 204;
-        # }
+            # Tell client that this pre-flight info is valid for 20 days
+            add_header 'Access-Control-Max-Age' 1728000;
+            add_header 'Content-Type' 'text/plain charset=UTF-8';
+            add_header 'Content-Length' 0;
+            return 204;
+        }
 
         try_files $uri $uri /index.php?$query_string;
 

--- a/docs/developer/api/oembed.md
+++ b/docs/developer/api/oembed.md
@@ -1,0 +1,60 @@
+# oEmbed
+
+K-Box supports oEmbed, a clever system for making it easy to embed rich content into websites. 
+An example of oEmbed is when you drop a YouTube video URL on its own line in (say) a blog post, and it will get replaced with an actual embedded video.
+
+This is also how K-Box oEmbed works, just drop a document preview URL into the content area of an oEmbed-enabled site and it will be converted into an Embedded Preview automatically.
+
+## How It Works
+
+The oEmbed spec is pretty simple: an endpoint that accepts one URL parameter: another URL.
+
+The K-Box expose this endpoint on `/api/oembed`:
+
+```
+https://instance.k-box.net/api/oembed?url=URL-TO-DOCUMENT-HERE
+```
+
+
+If `URL-TO-DOCUMENT-HERE` is a valid Document preview URL, it will return a JSON response, like:
+
+```json
+{
+  type: "rich",
+  version: "1.0",
+  provider_name: "K-Box",
+  provider_url: "http://instance.k-box.net",
+  title: "Climate change resilience in rural areas",
+  height: "480",
+  width: "360",
+  html: "<iframe width=\"480\" height=\"360\" src=\"http://instance.k-box.net/d/embed/UUID\" class=\"kbox_embed_iframe\" frameborder=\"0\" allowfullscreen></iframe>"
+}
+```
+
+We return a _"rich"_ content type, meaning supporting sites should use the HTML we return to display the content. That HTML, in our case, is an HTTPS `<iframe>` with the Embedded Preview. 
+Sites that support oEmbed will take that HTML we return and drop it onto the page.
+
+
+## HTTPS
+
+You can make the oEmbed call over HTTP or HTTPS. Either way, the returned `iframe` will be HTTPS.
+
+
+## Limitations
+
+- We only allow `/d/show/` URL's.
+- You can't customize the Embed style.
+
+
+## Specifics about Using oEmbed in CMSs
+
+Content Management Systems (CMS), like WordPress, support oEmbed. But they work off an internal "whitelist" of sites. 
+If K-Box document URLs are not transforming into the Embedded Preview means that the CMS does not have the oEmbed URL whitelisted.
+
+In WordPress adding oEmbed support for K-Box is a one liner in your theme's `functions.php` file:
+
+```php
+wp_oembed_add_provider('http://instance.k-box.net/d/show/*', 'https://instance.k-box.net/api/oembed');
+```
+
+Or perhaps even better, you can create a plugin to enable support. This is a good way to go, so that support persists no matter what theme you use.

--- a/packages/contentprocessing/assets/js/preview.js
+++ b/packages/contentprocessing/assets/js/preview.js
@@ -47,28 +47,31 @@ define(function () {
 
     }
 
-    detailsBtn.addEventListener('click', function(e){
+    if(detailsBtn){
 
-        if(!sidebarOpen){
-
-            detailsBtn.classList.add(DETAILS_BUTTON_EXPANDED_CLASS);
-            sidebar.classList.add(SIDEBAR_VISIBLE_CLASS);
-            preview.classList.add(PREVIEW_STATE_SIDEBAR_OPEN);
-            previewArea.style.width = previewAreaOriginalWidth - 344 +"px";
-            
-            sidebarOpen = true;
-        }
-        else {
-            
-            detailsBtn.classList.remove(DETAILS_BUTTON_EXPANDED_CLASS);
-            preview.classList.remove(PREVIEW_STATE_SIDEBAR_OPEN);
-            sidebar.classList.remove(SIDEBAR_VISIBLE_CLASS);
-            previewArea.style.width = "";
-
-            sidebarOpen = false;
-        }
-
-    });
+        detailsBtn.addEventListener('click', function(e){
+    
+            if(!sidebarOpen){
+    
+                detailsBtn.classList.add(DETAILS_BUTTON_EXPANDED_CLASS);
+                sidebar.classList.add(SIDEBAR_VISIBLE_CLASS);
+                preview.classList.add(PREVIEW_STATE_SIDEBAR_OPEN);
+                previewArea.style.width = previewAreaOriginalWidth - 344 +"px";
+                
+                sidebarOpen = true;
+            }
+            else {
+                
+                detailsBtn.classList.remove(DETAILS_BUTTON_EXPANDED_CLASS);
+                preview.classList.remove(PREVIEW_STATE_SIDEBAR_OPEN);
+                sidebar.classList.remove(SIDEBAR_VISIBLE_CLASS);
+                previewArea.style.width = "";
+    
+                sidebarOpen = false;
+            }
+    
+        });
+    }
 
     $("[data-action=showCopyrightUsageDescription]").click(function () {
         handleLicenseDetailsShowHide();

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -82,6 +82,9 @@ return [
     '401_title' => 'You cannot view the page - K-Box',
     '401_text' => 'You <strong>cannot</strong> view the page.<br/> Please acquire the <strong>access</strong> permissions first.',
     
+    'login_title' => 'Please login - K-Box',
+    'login_text' => 'You need to be logged-in to view the document.',
+    
     '403_title' => 'You do not have the permission to view the page',
     '403_text' => 'You <strong>cannot</strong> view the page.<br/> Please acquire the <strong>access</strong> permissions first.',
 

--- a/resources/views/documents/embed.blade.php
+++ b/resources/views/documents/embed.blade.php
@@ -1,0 +1,79 @@
+@extends('global')
+
+
+@section('header')
+
+@overwrite
+
+
+@section('content')
+
+	<div class="preview js-preview">
+    
+    <div class="preview__header">
+	
+		<a class="logo white" href="{{url('/')}}" target="_blank" noreferrer>
+			@include('headers.logo')
+		</a>
+
+        <div class="preview__title-container">
+
+            <span class="preview__title">{{ $document->title }}
+			
+				@if($version)
+					&nbsp;/&nbsp;{{ $version->name }}
+				@endif
+			</span>            
+        
+        </div>
+    
+    </div>
+
+
+    <div class="preview__body">
+
+        <div class="preview__area js-preview-area">
+
+            <div class="preview__content js-preview-content">
+
+				@if(isset($preview_errors) && !is_null($preview_errors))
+
+					<div class="disclaimer">
+
+						<h4>{{ $preview_errors }}</h4>
+					
+					
+						<a class="button button-primary" href="{{DmsRouting::download($document, $version)}}" target="_blank" download="{{ $filename_for_download }}">
+							{{trans('panels.download_btn')}}
+						</a>
+					
+					</div>
+
+				@else
+
+					{!! $previewable !!}
+
+				@endif
+
+            </div>
+		</div>
+    </div>
+</div>
+
+
+</div>
+	
+
+@stop
+
+@section('scripts')
+
+	<script>
+	require(['modules/preview'], function(Preview){
+
+		Preview.load();
+	});
+	</script>
+
+@stop
+

--- a/resources/views/documents/preview.blade.php
+++ b/resources/views/documents/preview.blade.php
@@ -5,6 +5,9 @@
 
 @overwrite
 
+@push('meta')
+<link rel="alternate" type="application/json+oembed" href="{{ route('oembed', ['url' => DmsRouting::preview($document, $version), 'format' => 'json']) }}" title="{{ $document->title }}">
+@endpush
 
 @section('content')
 

--- a/resources/views/errors/http-error.blade.php
+++ b/resources/views/errors/http-error.blade.php
@@ -67,9 +67,12 @@
                 </p>
                 @endif
                 <p>&nbsp;</p>
+
+                @section('actions')
                 <div>
                     <a class="button" href="{{ redirect()->back()->getTargetUrl() }}">{{ trans('errors.go_back_btn') }}</a>
                 </div>
+                @show
 			</div>
 		</div>
         

--- a/resources/views/errors/login.blade.php
+++ b/resources/views/errors/login.blade.php
@@ -1,0 +1,22 @@
+@extends('errors.http-error')
+
+@section('title')
+
+	{{trans('errors.login_title')}}
+
+@stop
+
+@section('content')
+
+	{!!trans('errors.login_text')!!}
+    
+@stop
+
+
+@section('actions')
+<div>
+	<a class="button" target="_blank" noreferrer href="{{ url('/') }}">{{ trans('login.form.submit') }}</a>
+</div>
+@endsection
+
+

--- a/resources/views/global.blade.php
+++ b/resources/views/global.blade.php
@@ -42,6 +42,8 @@
 		<meta name="msapplication-TileImage" content="{{ url('/') }}/mstile-144x144.png?v=1">
 		<meta name="theme-color" content="#ffffff">
 
+		@stack('meta')
+
 		@include('analytics')
 
 	</head>

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,3 +16,6 @@ use Illuminate\Http\Request;
 // Route::middleware('auth:api')->get('/user', function (Request $request) {
 //     return $request->user();
 // });
+
+// OEmbed Endpoint route. See https://oembed.com/
+Route::middleware('throttle:60,1')->get('/oembed', 'OembedController@show')->name('oembed');

--- a/routes/web.php
+++ b/routes/web.php
@@ -123,6 +123,12 @@ Route::get('/d/thumbnail/{uuid}/{versionUuid?}', [
     'as' => 'documents.thumbnail',
 ]);
 
+// Embed route to be used by the OEmbed feature
+Route::get('/d/embed/{uuid}/{versionUuid?}', [
+    'uses' => 'Document\DocumentEmbedController@show',
+    'as' => 'documents.embed',
+]);
+
 Route::group(['as' => 'documents.', 'prefix' => 'documents'], function () {
     Route::resource('groups', 'Document\GroupsController');
 

--- a/tests/Feature/DocumentEmbedControllerTest.php
+++ b/tests/Feature/DocumentEmbedControllerTest.php
@@ -1,0 +1,297 @@
+<?php
+
+namespace Tests\Feature;
+
+use KBox\File;
+use KBox\User;
+use KBox\Project;
+use Carbon\Carbon;
+use Tests\TestCase;
+use KBox\Capability;
+use KBox\Publication;
+use KBox\DocumentDescriptor;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class DocumentEmbedControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+    
+    public function test_embed_is_loaded_for_document_in_project_when_user_has_access_to_the_project()
+    {
+        $this->withKlinkAdapterFake();
+        
+        $service = app('KBox\Documents\Services\DocumentsService');
+
+        $project = factory(Project::class)->create();
+
+        $manager = $project->manager;
+
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+        
+        $project->users()->attach($user->id);
+
+        $document = factory(DocumentDescriptor::class)->create(['owner_id' => $manager->id]);
+        $service->addDocumentToGroup($manager, $document, $project->collection);
+        
+        $url = route('documents.embed', ['uuid' => $document->uuid]);
+
+        $response = $this->actingAs($user)->get($url);
+        
+        $response->assertStatus(200);
+
+        $response->assertViewIs('documents.embed');
+    }
+
+    public function test_embed_is_forbidden_if_user_do_not_have_access_to_document_in_project()
+    {
+        $this->withKlinkAdapterFake();
+        
+        $service = app('KBox\Documents\Services\DocumentsService');
+
+        $project = factory(Project::class)->create();
+
+        $manager = $project->manager;
+
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $document = factory(DocumentDescriptor::class)->create(['owner_id' => $manager->id]);
+        $service->addDocumentToGroup($manager, $document, $project->collection);
+        
+        $url = route('documents.embed', ['uuid' => $document->uuid]);
+
+        $response = $this->actingAs($user)->get($url);
+
+        $response->assertViewIs('errors.403');
+    }
+
+    public function test_embed_is_loaded_for_shared_document()
+    {
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PROJECT_MANAGER_NO_CLEAN_TRASH);
+        });
+        $user_accessing_the_document = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $document = factory(DocumentDescriptor::class)->create(['owner_id' => $user->id]);
+
+        $document->shares()->create([
+            'user_id' => $user->id,
+            'sharedwith_id' => $user_accessing_the_document->id, //the id
+            'sharedwith_type' => get_class($user_accessing_the_document), //the class
+            'token' => hash('sha512', '$token_content'),
+        ]);
+
+        $url = route('documents.embed', ['uuid' => $document->uuid]);
+
+        $response = $this->actingAs($user_accessing_the_document)->get($url);
+
+        $response->assertViewIs('documents.embed');
+    }
+
+    public function test_public_document_can_be_previewed_after_login()
+    {
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PROJECT_MANAGER);
+        });
+        $user_accessing_the_document = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $document = factory(DocumentDescriptor::class)->create(['owner_id' => $user->id, 'is_public' => true]);
+        
+        Publication::unguard(); // as fields are not mass assignable
+        
+        $document->publications()->create([
+            'published_at' => Carbon::now()
+        ]);
+        
+        $url = route('documents.embed', ['uuid' => $document->uuid]);
+
+        $response = $this->actingAs($user_accessing_the_document)->get($url);
+
+        $response->assertViewIs('documents.embed');
+    }
+
+    public function test_public_document_can_be_previewed_without_login()
+    {
+        $this->withKlinkAdapterFake();
+
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PROJECT_MANAGER);
+        });
+        $user_accessing_the_document = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $service = app('KBox\Documents\Services\DocumentsService');
+
+        $document = factory(DocumentDescriptor::class)->create(['owner_id' => $user->id, 'is_public' => true]);
+
+        Publication::unguard(); // as fields are not mass assignable
+        
+        $document->publications()->create([
+            'published_at' => Carbon::now()
+        ]);
+
+        $project1 = factory(Project::class)->create(['user_id' => $user->id]);
+        $project1->users()->attach($user_accessing_the_document->id);
+
+        $project1_child1 = $project1->collection;
+        $service->addDocumentToGroup($user, $document, $project1_child1);
+
+        $url = route('documents.embed', ['uuid' => $document->uuid]);
+        
+        $response = $this->get($url);
+
+        $response->assertViewIs('documents.embed');
+    }
+    
+    public function test_document_cannot_be_previewed_if_personal_of_another_user()
+    {
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PROJECT_MANAGER);
+        });
+        $user_accessing_the_document = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $document = factory(DocumentDescriptor::class)->create(['owner_id' => $user->id]);
+
+        $url = route('documents.embed', ['uuid' => $document->uuid]);
+
+        $response = $this->actingAs($user_accessing_the_document)->get($url);
+
+        $response->assertViewIs('errors.403');
+    }
+
+    public function test_user_can_preview_own_document()
+    {
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PROJECT_MANAGER);
+        });
+
+        $document = factory(DocumentDescriptor::class)->create(['owner_id' => $user->id, 'is_public' => false]);
+
+        $url = route('documents.embed', ['uuid' => $document->uuid]);
+
+        $response = $this->actingAs($user)->get($url);
+
+        $response->assertViewIs('documents.embed');
+    }
+    
+    public function test_document_preview_is_available_even_if_owner_is_disabled()
+    {
+        $this->withKlinkAdapterFake();
+
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PROJECT_MANAGER);
+        });
+        $user_accessing_the_document = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+        
+        $service = app('KBox\Documents\Services\DocumentsService');
+
+        $document = factory(DocumentDescriptor::class)->create(['owner_id' => $user->id]);
+
+        $project1 = factory(Project::class)->create(['user_id' => $user->id]);
+        $project1->users()->attach($user_accessing_the_document->id);
+
+        $project1_child1 = $project1->collection;
+        $service->addDocumentToGroup($user, $document, $project1_child1);
+        
+        $url = route('documents.embed', ['uuid' => $document->uuid]);
+
+        $user->delete();
+
+        $response = $this->actingAs($user_accessing_the_document)->get($url);
+        
+        $response->assertStatus(200);
+
+        $response->assertViewIs('documents.embed');
+    }
+
+    public function test_redirect_to_login_if_document_not_accessible_and_user_not_authenticated()
+    {
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PROJECT_MANAGER);
+        });
+        $user_accessing_the_document = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $document = factory(DocumentDescriptor::class)->create(['owner_id' => $user->id, 'is_public' => false]);
+
+        $url = route('documents.embed', ['uuid' => $document->uuid]);
+
+        $response = $this->get($url);
+
+        $response->assertViewIs('errors.login');
+    }
+
+    public function test_forbidden_return_if_the_document_is_not_accessible_and_the_user_is_logged_in()
+    {
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PROJECT_MANAGER);
+        });
+        $user_accessing_the_document = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $document = factory(DocumentDescriptor::class)->create(['owner_id' => $user->id, 'is_public' => false]);
+
+        $url = route('documents.embed', ['uuid' => $document->uuid]);
+
+        $response = $this->actingAs($user_accessing_the_document)->get($url);
+
+        $response->assertViewIs('errors.403');
+    }
+
+    public function test_not_found_page_is_returned_if_file_is_trashed()
+    {
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PROJECT_MANAGER);
+        });
+        
+        $document = factory(DocumentDescriptor::class)->create(['owner_id' => $user->id, 'is_public' => false]);
+        
+        $document->file_id = null;
+        $document->save();
+        
+        $url = route('documents.embed', ['uuid' => $document->uuid]);
+
+        $response = $this->actingAs($user)->get($url);
+
+        $response->assertViewIs('errors.404');
+    }
+
+    public function test_embed_specific_file_version_is_possible()
+    {
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PROJECT_MANAGER);
+        });
+
+        $document = factory(DocumentDescriptor::class)->create(['owner_id' => $user->id, 'is_public' => false]);
+
+        $last_version = $document->file;
+
+        $first_version = factory(File::class)->create([
+            'mime_type' => 'text/html',
+        ]);
+
+        $last_version->revision_of = $first_version->id;
+        $last_version->save();
+
+        $url = route('documents.embed', ['uuid' => $document->uuid, 'versionUuid' => $first_version->uuid]);
+
+        $response = $this->actingAs($user)->get($url);
+
+        $response->assertViewIs('documents.embed');
+        $this->assertTrue($response->data('file')->is($first_version));
+    }
+}

--- a/tests/Feature/OembedControllerTest.php
+++ b/tests/Feature/OembedControllerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Tests\Feature;
+
+use KBox\User;
+use Tests\TestCase;
+use KBox\Capability;
+use KBox\DocumentDescriptor;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Storage;
+
+class OembedControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private function create_document()
+    {
+        Storage::fake('local');
+        
+        $this->withKlinkAdapterFake();
+
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $document = factory(DocumentDescriptor::class)->create(['owner_id' => $user->id]);
+        $document->document_uri = null;
+        $document->save();
+
+        return $document;
+    }
+
+    public function generate_invalid_urls()
+    {
+        return [
+            ['http://localhost/hello'],
+            ['http://localhost/hello/1025'],
+            ['https://localhost/hello/1025'],
+            ['ftp://localhost/hello/1025'],
+            ['javascript://localhost/hello/1025'],
+            ['javascript:void(0)'],
+            ['javascript:void(0)'],
+            ['http://localhost:8000/d/show/10?hello=true'],
+            ['http://localhost:8000/d/show/10#something'],
+            ['http://localhost:8000/d/show/10#\'DROP TABLE *'],
+            ['http://localhost:8000/d/show/#\'DROP TABLE *'],
+            [urlencode('http://localhost/hello')],
+        ];
+    }
+
+    public function test_oembed_json_is_returned()
+    {
+        $document = $this->create_document();
+        
+        $response = $this->json('GET', 'api/oembed?format=json&url='.urlencode($document->document_uri));
+        
+        $response
+            ->assertStatus(200)
+            ->assertJson([
+                'version' => '1.0',
+                'type' => 'rich',
+                'provider_name' => config('app.name'),
+                'provider_url' => config('app.url'),
+                'title' => e($document->title),
+                'html' => "<iframe width=\"480\" height=\"360\" src=\"http://localhost/d/embed/$document->uuid\" class=\"kbox_embed_iframe\" frameborder=\"0\" allowfullscreen></iframe>"
+            ])
+            ->assertJsonStructure([
+                "version",
+                "type",
+                "provider_name",
+                "provider_url",
+                "width",
+                "height",
+                "title",
+                "html",
+            ]);
+    }
+
+    public function test_oembed_respect_maxwith_and_height()
+    {
+        $document = $this->create_document();
+        
+        $response = $this->json('GET', 'api/oembed?format=json&maxwidth=100&maxheight=100&url='.urlencode($document->document_uri));
+        
+        $response
+            ->assertStatus(200)
+            ->assertJson([
+                'version' => '1.0',
+                'type' => 'rich',
+                'width' => 100,
+                'height' => 100,
+            ])
+            ->assertJsonStructure([
+                "version",
+                "type",
+                "provider_name",
+                "provider_url",
+                "width",
+                "height",
+                "title",
+                "html",
+            ]);
+    }
+    
+    public function test_oembed_return_not_implemented_for_xml_format()
+    {
+        $response = $this->json('GET', 'api/oembed?format=xml&url='.urlencode('http://localhost/hello'));
+        
+        $response->assertStatus(501);
+    }
+    
+    /**
+     * @dataProvider generate_invalid_urls
+     */
+    public function test_oembed_return_not_found_for_invalid_urls($url)
+    {
+        $response = $this->json('GET', 'api/oembed?format=json&url='.urlencode($url));
+            
+        $response->assertStatus(404);
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Add [oEmbed](https://oembed.com/) support for embedding document preview into websites.

The oEmbed api url respond on `api/oembed` and will deliver a "rich" card. 

### Review checklist

* [x] Are unit tests required?
* [x] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)