### PR TITLE
Geo tiff stretching for thumbnails

### DIFF
--- a/plugins/geo/src/Gdal/Drivers/Driver.php
+++ b/plugins/geo/src/Gdal/Drivers/Driver.php
@@ -72,7 +72,7 @@ abstract class Driver
         $geoFile = GeoFile::from($path);
 
         if($geoFile->type === GeoType::RASTER){
-            throw new Exception("Raster file conversion not supported.");
+            throw new Exception("Raster file conversion not supported. Use convertRaster().");
         }
 
         $alternateLayerName = md5(basename($path));
@@ -94,6 +94,46 @@ abstract class Driver
         \Log::info('conversion to shapefile', compact('options', 'path', 'destination'));
 
         $result = $this->execute(static::VECTOR_CONVERT_EXECUTABLE, [$destination, $path], $options);
+
+        return new SplFileInfo($destination);
+    }
+
+    /**
+     * Convert a raster geographic file into a different format
+     * 
+     * @param string $path
+     * @param string $destination
+     * @param string $format
+     * @param array $options Parameter to pass to the gdal_translate binary
+     * @return SplFileInfo the destination file instance
+     */
+    public function convertRaster($path, $destination, $format, $options = [])
+    {
+        $geoFile = GeoFile::from($path);
+
+        if($geoFile->type === GeoType::VECTOR){
+            throw new Exception("Vector file conversion not supported. Use convert().");
+        }
+
+        $alternateLayerName = md5(basename($path));
+
+        $options = array_merge(["-of \"$format\""], $options);
+
+        // if($format === Gdal::FORMAT_SHAPEFILE){
+        //     $options[] = "-append";
+        //     $options[] = "-nln {$alternateLayerName}";
+        //     $options[] = "-nlt GEOMETRY";
+        //     $options[] = "-skipfailure";
+        // }
+
+        // if(!is_null($crs)){
+        //     $options[] = "-t_srs \"$crs\"";
+        // }
+
+
+        \Log::info('raster file conversion', compact('options', 'path', 'destination'));
+
+        $result = $this->execute(static::RASTER_CONVERT_EXECUTABLE, [$path, $destination], $options);
 
         return new SplFileInfo($destination);
     }

--- a/plugins/geo/src/Gdal/Drivers/Driver.php
+++ b/plugins/geo/src/Gdal/Drivers/Driver.php
@@ -119,20 +119,6 @@ abstract class Driver
 
         $options = array_merge(["-of \"$format\""], $options);
 
-        // if($format === Gdal::FORMAT_SHAPEFILE){
-        //     $options[] = "-append";
-        //     $options[] = "-nln {$alternateLayerName}";
-        //     $options[] = "-nlt GEOMETRY";
-        //     $options[] = "-skipfailure";
-        // }
-
-        // if(!is_null($crs)){
-        //     $options[] = "-t_srs \"$crs\"";
-        // }
-
-
-        \Log::info('raster file conversion', compact('options', 'path', 'destination'));
-
         $result = $this->execute(static::RASTER_CONVERT_EXECUTABLE, [$path, $destination], $options);
 
         return new SplFileInfo($destination);

--- a/plugins/geo/src/Gdal/Drivers/LinuxDriver.php
+++ b/plugins/geo/src/Gdal/Drivers/LinuxDriver.php
@@ -24,6 +24,8 @@ final class LinuxDriver extends Driver
 
     const VECTOR_CONVERT_EXECUTABLE = 'ogr2ogr';
 
+    const RASTER_CONVERT_EXECUTABLE = 'gdal_translate';
+
     protected function execute($command, $inputs = [], $options = [])
     {
         $arguments = array_map(function($in){

--- a/plugins/geo/src/Gdal/Drivers/WindowsDriver.php
+++ b/plugins/geo/src/Gdal/Drivers/WindowsDriver.php
@@ -23,6 +23,8 @@ final class WindowsDriver extends Driver
     const VECTOR_INFO_EXECUTABLE = 'ogrinfo.exe';
     
     const VECTOR_CONVERT_EXECUTABLE = 'ogr2ogr.exe';
+    
+    const RASTER_CONVERT_EXECUTABLE = 'gdal_translate.exe';
 
     protected function execute($command, $inputs = [], $options = [])
     {

--- a/plugins/geo/src/Gdal/Gdal.php
+++ b/plugins/geo/src/Gdal/Gdal.php
@@ -21,6 +21,8 @@ final class Gdal
     const FORMAT_PDF = "PDF";
 
     const FORMAT_SHAPEFILE = "ESRI Shapefile";
+    
+    const FORMAT_PNG = "PNG";
 
 
     /**
@@ -77,7 +79,7 @@ final class Gdal
     }
 
     /**
-     * Convert a file into a different format
+     * Convert a vector file into a different format
      * 
      * @param string $path the file absolute path
      * @param string $format the target file format. See FORMAT constants in this class for available formats
@@ -114,6 +116,23 @@ final class Gdal
 
         return new SplFileInfo($tmpfilename);
 
+    }
+
+    /**
+     * Convert a raster file into a different format
+     * 
+     * @param string $path the file absolute path
+     * @param string $format the target file format. See FORMAT constants in this class for available formats
+     * @param array $options the options to pass to the conversion program
+     * @return SplFileInfo a temporary file that contains the conversion result. Unlink the file when not anymore necessary.
+     */
+    public function convertRaster($path, $format, $options = [])
+    {
+        // creating a temporary filename where the content 
+        // of the converted file is stored
+        $tmpfilename = tempnam($temporaryFolder ?? sys_get_temp_dir(), basename($path));
+
+        return $this->driver()->convertRaster($path, $tmpfilename, $format, $options);
     }
 
     /**

--- a/plugins/geo/src/GeoProperties.php
+++ b/plugins/geo/src/GeoProperties.php
@@ -27,7 +27,7 @@ use Spinen\Geometry\GeometryFacade as Geometry;
  */
 final class GeoProperties extends FileProperties
 {
-    protected $exclude = ['layers', 'boundingBox', 'boundings.geoserver', 'geoserver.layers'];
+    protected $exclude = ['layers', 'boundingBox', 'boundings.geoserver', 'geoserver.layers', 'bands'];
     
 
     private static function parseCrsWkt($wkt)
@@ -47,7 +47,6 @@ final class GeoProperties extends FileProperties
         if(count($matches) !== 2){
             return '';
         }
-        \Log::warning("matches ...", compact('matches'));
 
         $boundingArray = [$matches[0][1], $matches[0][2], $matches[1][1], $matches[1][2]];
 
@@ -91,8 +90,9 @@ final class GeoProperties extends FileProperties
                 'wkt' => null,
                 'original' => json_encode($decoded->get('wgs84Extent', null)),
             ],
+            'bands' => $decoded->get('bands', [])
         ]);
-
+        
         return static::fromCollection($attributes);
     }
 

--- a/plugins/geo/src/Thumbnails/GeoTiffThumbnailGenerator.php
+++ b/plugins/geo/src/Thumbnails/GeoTiffThumbnailGenerator.php
@@ -5,6 +5,7 @@ namespace KBox\Geo\Thumbnails;
 use Log;
 use Imagick;
 use KBox\File;
+use Exception;
 use ImagickException;
 use KBox\Geo\Gdal\Gdal;
 use KBox\Documents\DocumentType;
@@ -20,29 +21,64 @@ class GeoTiffThumbnailGenerator implements ThumbnailGenerator
             throw new Exception('Failed to generate tiff thumbnail: imagemagick is not installed');
         }
 
-        $png = (new Gdal())->convertRaster($file->absolute_path, GDAL::FORMAT_PNG, [
-            '-ot Byte',
-            '-scale',
-            '-outsize 300 0'
-        ]);
+        if($this->requiresBandStretching($file)){
+            // the image consists in a grey scale image with band values not in the Byte [0,255] range
+            // we make sure that band values are then scaled so the thumbnail will be closed to the image preview
+            try{
+                $png = (new Gdal())->convertRaster($file->absolute_path, GDAL::FORMAT_PNG, [
+                    '-ot Byte',
+                    '-scale',
+                    '-outsize 300 0'
+                ]);
 
+                return $this->thumbnailUsingImagick($png->getRealPath());
+
+            } catch (Exception $ex){
+
+                throw new Exception("Failed to generate geotiff thumbnail. {$ex->getMessage()}");
+    
+            } finally {
+                @unlink($png->getRealPath());
+            }
+        }
+
+        return $this->thumbnailUsingImagick($file->absolute_path);
+    }
+
+    /**
+     * Check the bands metadata to see if there is at least one band whose type is not Byte
+     */
+    private function requiresBandStretching($file)
+    {
+        $bands = $file->properties->bands ?? [];
+
+        // check if there are bands with type different than Byte
+        $filtered_bands = array_filter($bands, function($band){
+            return isset($band['type']) && $band['type'] !== 'Byte';
+        });
+
+        return !empty($filtered_bands);
+    }
+
+    private function thumbnailUsingImagick($file_path)
+    {
         try{
             $image = new Imagick();
             $image->setBackgroundColor('white');
             $image->setResolution(300, 300);
-            @$image->readImage($png->getRealPath());
+            @$image->readImage($file_path);
             $image = $image->mergeImageLayers(Imagick::LAYERMETHOD_FLATTEN);
             $image->thumbnailImage(ThumbnailImage::DEFAULT_WIDTH, 0, false, true);
             $image->setImageFormat("png");
+            
+            return ThumbnailImage::load($image)->widen(ThumbnailImage::DEFAULT_WIDTH);
+
         } catch (ImagickException $ex){
 
             throw new Exception("Failed to generate geotiff thumbnail. {$ex->getMessage()}");
 
-        } finally {
-            @unlink($png->getRealPath());
         }
 
-        return ThumbnailImage::load($image)->widen(ThumbnailImage::DEFAULT_WIDTH);
     }
 
     public function isSupported(File $file)

--- a/tests/Plugins/Geo/Unit/GdalTest.php
+++ b/tests/Plugins/Geo/Unit/GdalTest.php
@@ -157,4 +157,32 @@ class GdalTest extends TestCase
         $this->assertEquals('application/zip', $geofile->mimeType);
         $this->assertEquals(GeoFormat::SHAPEFILE_ZIP, $geofile->format);
     }
+
+    public function test_convert_tiff_to_png()
+    {
+        $file = base_path("tests/data/geotiff.tiff");
+
+        $gdal = new Gdal();
+
+        $png = $gdal->convertRaster($file, Gdal::FORMAT_PNG, [
+            '-ot Byte',
+            '-scale',
+            '-outsize 300 0'
+        ]);
+        
+        $this->assertInstanceOf(SplFileInfo::class, $png);
+
+        // read the file magic number to check if is a real png
+        $handle = fopen($png->getRealPath(), 'rb');
+        $data = fread($handle, 1);
+        $data2 = fread($handle, 1);
+        $data3 = fread($handle, 1);
+        $data4 = fread($handle, 1);
+        fclose($handle);
+        unlink($png->getRealPath());
+
+        $magicNumber = current(unpack('a', $data2)).current(unpack('a', $data3)).current(unpack('a', $data4));
+
+        $this->assertEquals('PNG', trim($magicNumber));
+    }
 }

--- a/tests/Plugins/Geo/Unit/GeoTiffThumbnailGeneratorTest.php
+++ b/tests/Plugins/Geo/Unit/GeoTiffThumbnailGeneratorTest.php
@@ -33,6 +33,12 @@ class GeoTiffThumbnailGeneratorTest extends TestCase
                 'Imagick not available or TIFF support not available.'
             );
         }
+
+        if (! (new Gdal())->isInstalled()) {
+            $this->markTestSkipped(
+                'GDal library not installed the system.'
+            );
+        }
     }
 
     public function test_tiff_is_supported()

--- a/tests/Plugins/Geo/Unit/GeoTiffThumbnailGeneratorTest.php
+++ b/tests/Plugins/Geo/Unit/GeoTiffThumbnailGeneratorTest.php
@@ -4,11 +4,12 @@ namespace Tests\Plugins\Geo\Unit;
 
 use Imagick;
 use KBox\File;
+use Tests\TestCase;
+use KBox\Geo\Gdal\Gdal;
 use KBox\Documents\FileHelper;
 use KBox\Documents\Thumbnail\ThumbnailImage;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
-use Tests\TestCase;
 use KBox\Geo\Thumbnails\GeoTiffThumbnailGenerator;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class GeoTiffThumbnailGeneratorTest extends TestCase
 {


### PR DESCRIPTION
## What does this PR do?

Change how GeoTiff thumbnails are created.

Before only Imagick was used.

![image](https://user-images.githubusercontent.com/5672748/46952767-20421280-d08c-11e8-8b7d-cecac447ab17.png)

Some files, however, would obtain a black image. This is caused by the fact that GeoTiff can contain any form of data, from plain integers to more elaborated ones.

In particular the GeoTiff with a band that has values not in `Byte` range, will be re-scaled to have values in `Byte` range. This pre-processing will lead to obtain a better thumbnail, especially for images with plain values inside.

![image](https://user-images.githubusercontent.com/5672748/46952894-7ca53200-d08c-11e8-8aad-864c6bec6117.png)

This process is not applied for preview, which is totally under control of Geoserver

### Review checklist

* [x] Are unit tests required?
* [x] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)