### PR TITLE
Disable tiling on GeoTiff if bands are not of type Byte

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -105,6 +105,12 @@ elixir(function(mix) {
             elixir.config.jsOutput +'/modules/leaflet-control-opacity.js', //output dir
             elixir.config.npmDir //base dir
         )
+        .scripts([
+                "/leaflet.wms/dist/leaflet.wms.js"
+            ],
+            elixir.config.jsOutput +'/modules/leaflet-wms.js', //output dir
+            elixir.config.npmDir //base dir
+        )
     	// Copy pure JS modules to public folder
     	.copyJsModules()
     	.previewJsModules();

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "leaflet": "^1.3.4",
     "leaflet-draw": "^1.0.3",
     "leaflet.control.opacity": "^1.2.0",
+    "leaflet.wms": "^0.2.0",
     "lodash": "~4.17.4",
     "nprogress": "~0.2.0",
     "object.observe": "~0.2.6",

--- a/plugins/geo/src/Previews/GeodataPreviewDriver.php
+++ b/plugins/geo/src/Previews/GeodataPreviewDriver.php
@@ -54,8 +54,25 @@ class GeodataPreviewDriver extends MapPreviewDriver
         $this->view_data['attribution'] = "$file->name {$file->properties->get('geoserver.store', '')}";
         $this->view_data['geojson'] = !$canBeFoundOnGeoserver ? $this->getFileContentAsGeoJson($file) : null;
         $this->view_data['geoserver'] = $canBeFoundOnGeoserver ? $this->geoservice->wmsBaseUrl() : null;
+        $this->view_data['disableTiling'] = $canBeFoundOnGeoserver ? $this->requiresBandStretching($file) : false;
 
         return $this;
+    }
+
+    
+    /**
+     * Check the bands metadata to see if there is at least one band whose type is not Byte
+     */
+    private function requiresBandStretching($file)
+    {
+        $bands = $file->properties->bands ?? [];
+
+        // check if there are bands with type different than Byte
+        $filtered_bands = array_filter($bands, function($band){
+            return isset($band['type']) && $band['type'] !== 'Byte';
+        });
+
+        return !empty($filtered_bands);
     }
 
     private function geoserverBoundingsToLeaflet($boundingBox)

--- a/resources/views/require-config.blade.php
+++ b/resources/views/require-config.blade.php
@@ -14,8 +14,6 @@ require.config({
             nls: 'localization'
         }
     }
-
-    
 });
 
 
@@ -62,6 +60,10 @@ define('plyr', [], function() {
 
 define('Handlebars', [], function() {
     return window.Handlebars;
+});
+
+define('leaflet', ["modules/leaflet"], function(L) {
+    return L;
 });
 
 // -- Global initializations

--- a/yarn.lock
+++ b/yarn.lock
@@ -2188,6 +2188,12 @@ leaflet.control.opacity@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/leaflet.control.opacity/-/leaflet.control.opacity-1.2.0.tgz#9cab5b8186971dcdb0196cc29fb5e74a26c8b750"
 
+leaflet.wms@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/leaflet.wms/-/leaflet.wms-0.2.0.tgz#b467eb24a17efa7909859b46fa726d912e97d2bc"
+  dependencies:
+    uglify-js "^2.7.3"
+
 leaflet@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.3.4.tgz#7f006ea5832603b53d7269ef5c595fd773060a40"
@@ -3823,7 +3829,7 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-uglify-js@^2.6, uglify-js@^2.8.22:
+uglify-js@^2.6, uglify-js@^2.7.3, uglify-js@^2.8.22:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
   dependencies:


### PR DESCRIPTION
## What does this PR do?

Disable WMS tiling on GeoTiff images that do not have normalized bands in the `Byte` range. This should prevent to see images like that.

![image](https://user-images.githubusercontent.com/5672748/47031271-cf0b4f00-d16f-11e8-82b8-746541f38827.png)

As a drawback the loading of such GeoTiff files will require more work from the Browser perspective

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)