### PR TITLE
Open spatial filters instead of default ones if geo_location is set

### DIFF
--- a/plugins/geo/src/Http/Controllers/GeoDocumentsController.php
+++ b/plugins/geo/src/Http/Controllers/GeoDocumentsController.php
@@ -77,6 +77,8 @@ class GeoDocumentsController extends Controller
             return response()->json($results);
         }
 
+        $filters = $results->filters();
+
         return view('geo::documents.geo', [
             'pagetitle' => trans('geo::section.page_title'),
             'filter' => trans('geo::section.page_title'),
@@ -85,9 +87,9 @@ class GeoDocumentsController extends Controller
             'pagination' => $results,
             'search_terms' => $req->term,
             'facets' => $results->facets(),
-            'filters' => $results->filters(),
-            'spatial_filters' => Geometries::arrayAsLatLngBounds($results->filters()['geo_location'] ?? null) ?? 'null',
-            'other_filters' => $this->processOtherFilters(collect($results->filters())->except('geo_location')),
+            'filters' => $filters,
+            'spatial_filters' => Geometries::arrayAsLatLngBounds($filters['geo_location'] ?? null) ?? 'null',
+            'other_filters' => $this->processOtherFilters(collect($filters)->except('geo_location')),
         ]);
     }
 

--- a/plugins/geo/views/documents/geo.blade.php
+++ b/plugins/geo/views/documents/geo.blade.php
@@ -46,10 +46,13 @@
 
 	require(['modules/spatial_filters'], function(SF){
 
+		console.log(Documents);
+
 		SF.init({
 			filter: {!! $spatial_filters !!},
 			otherFilters: {!! json_encode($other_filters) !!},
-			searchTerms: @if($search_terms) {"s": "{{ $search_terms }}"} @else null @endif
+			searchTerms: @if($search_terms) {"s": "{{ $search_terms }}"} @else null @endif,
+			autoload: Documents._mapFiltersVisible
 		});
 
 	});

--- a/resources/assets/js/modules/documents.js
+++ b/resources/assets/js/modules/documents.js
@@ -796,7 +796,21 @@ define("modules/documents", ["require", "modernizr", "jquery", "DMS", "modules/s
             if(args.filter ==='public' || args.filter ==='private'){
                 module.context.visibility = args.filter; 
             }
-            module._filtersVisible = !$.isArray(module.context.filters);
+
+            // filters array, ok
+
+            if($.isPlainObject(module.context.filters) && Object.keys(module.context.filters).length > 0){
+                
+                module._filtersVisible = module.context.filters.geo_location ? false : true;
+
+                if(module.context.filters.geo_location){
+                    module._mapFiltersVisible = !module._mapFiltersVisible;
+                }
+            }
+            else {
+                module._filtersVisible = false;
+            }
+
             _updateBinds();
 
             // If the highlight parameter is present, 

--- a/resources/assets/js/modules/spatial_filters.js
+++ b/resources/assets/js/modules/spatial_filters.js
@@ -91,6 +91,15 @@ define("modules/spatial_filters", ["require", "modernizr", "jquery", "DMS", "mod
         _mapLoaded = true;
     }
 
+    function requireMap()
+    {
+        if(!_mapLoaded){
+            _require(["modules/leaflet-draw"], function(){
+                loadMap();
+            });
+        }
+    }
+
     var module = {
 
         init: function(options)
@@ -103,14 +112,13 @@ define("modules/spatial_filters", ["require", "modernizr", "jquery", "DMS", "mod
             }
 
             console.log("initializing map");
+
+            if(options.autoload){
+                requireMap();
+            }
             
             _pageArea.on('spatialfilters:open', function(evt){
-                
-                if(!_mapLoaded){
-                    _require(["modules/leaflet-draw"], function(){
-                        loadMap();
-                    });
-                }
+                requireMap();
             });
             _pageArea.on('spatialfilters:close', function(evt){
                 


### PR DESCRIPTION
## What does this PR do?

Open spatial filters panel instead of default filters if `geo_location` filter is used


### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)