### PR TITLE
Add GeoServer WMS proxy

### DIFF
--- a/plugins/geo/routes/routes.php
+++ b/plugins/geo/routes/routes.php
@@ -27,3 +27,5 @@ Route::get('/providers/{id}/edit', 'GeoPluginMapProvidersController@edit')->name
 Route::delete('/providers/{id}', 'GeoPluginMapProvidersController@destroy')->name('mapproviders.delete');
 
 Route::get('/documents', 'GeoDocumentsController@index')->name('geodocuments');
+
+Route::get('/wms', 'WebMapServiceController@show')->name('wms');

--- a/plugins/geo/src/Http/Controllers/WebMapServiceController.php
+++ b/plugins/geo/src/Http/Controllers/WebMapServiceController.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace KBox\Geo\Http\Controllers;
+
+use Log;
+use KBox\User;
+use KBox\File;
+use KBox\Geo\GeoService;
+use KBox\DocumentDescriptor;
+use Illuminate\Http\Request;
+use Illuminate\Contracts\Auth\Guard;
+use KBox\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Cache;
+use KBox\Documents\Services\DocumentsService;
+use KBox\Http\Controllers\Document\DocumentAccessController;
+
+use Intervention\Image\Facades\Image as ImageFacade;
+
+class WebMapServiceController extends Controller
+{
+    
+    /**
+     * 
+     * @var \KBox\Documents\Services\DocumentsService
+     */
+    private $documents = null;
+
+    private $geoservice = null;
+
+    private $formatMapping = [
+        'image/png' => 'png',
+        'image/png8' => 'png',
+        'image/jpeg' => 'jpg',
+        'image/gif' => 'gif',
+    ];
+
+    /**
+     * Create a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct(DocumentsService $documentsService, GeoService $geoservice)
+    {
+    
+        $this->middleware('flags:plugins');
+
+        $this->documents = $documentsService;
+
+        $this->geoservice = $geoservice;
+    }
+
+    protected function verifyUserHasAccess($user, $file)
+    {
+        $doc = $file->document;
+
+        if (is_null($doc) || (! is_null($doc) && ! $doc->isMine())) {
+            throw new ModelNotFoundException();
+        }
+
+        if (! ($doc->isPublished() || $doc->hasPendingPublications() || $doc->hasPublicLink()) && is_null($user)) {
+            Log::warning('WebMapServiceController, requested a document that is not public and user is not authenticated', ['url' => $request->url()]);
+
+            throw new AuthenticationException();
+        }
+        if ($doc->trashed()) {
+            throw new ModelNotFoundException();
+        }
+
+        $collections = $doc->groups;
+        $is_in_collection = false;
+
+        if (! is_null($collections) && ! $collections->isEmpty() && ! is_null($user)) {
+            $serv = $this->documentsService;
+
+            $filtered = $collections->filter(function ($c) use ($serv, $user) {
+                return $serv->isCollectionAccessible($user, $c);
+            });
+            
+            $is_in_collection = ! $filtered->isEmpty();
+        }
+
+        $is_shared = $doc->hasPublicLink() ? true : (! is_null($user) ? $doc->shares()->sharedWithMe($user)->count() > 0 : false);
+
+        $owner = ! is_null($user) && ! is_null($doc->owner) ? $doc->owner->id === $user->id || $user->isContentManager() : (is_null($doc->owner) ? true : false);
+
+        if (! ($is_in_collection || $is_shared || $doc->isPublic() || $owner || $doc->hasPendingPublications())) {
+            throw new ForbiddenException('not shared, not in collection, not public or private of the user');
+        }
+
+        return true;
+    }
+
+    /**
+     * Proxy the Web Map Service (WMS) request to
+     * the configured GeoServer
+     *
+     * @return Response
+     */
+    public function show(Guard $auth, Request $request)
+    {
+        $user = $auth->user();
+
+        $layers = $request->input('layers', '');
+        $fingerprint = $this->fingerprint($request);
+
+        $uuid = trim(str_after($layers, ':'));
+
+        if(!$uuid){
+            return $this->createEmptyResponse($request);
+        }
+
+        $file = File::whereUuid($uuid)->first();
+
+        if(!$file){
+            return $this->createEmptyResponse($request);
+        }
+
+        $this->verifyUserHasAccess($user, $file);
+        
+        $canBeFoundOnGeoserver = !is_null($file->properties->get('geoserver.store', null));
+        
+        if(!$canBeFoundOnGeoserver){
+            return $this->createEmptyResponse($request);
+        }
+
+
+        return Cache::remember($fingerprint, 10, function() use($request) {
+            $parameters = $request->only(
+                'bbox',
+                'format',
+                'height',
+                'width',
+                'id',
+                'layers',
+                'request',
+                'service',
+                'srs',
+                'styles',
+                'transparent',
+                'version',
+                'query_layers',
+                'info_format',
+                'exceptions',
+                'x',
+                'y',
+                'i',
+                'j'
+            );
+    
+            try{
+    
+                return $this->geoservice->proxyWmsRequest($parameters);
+    
+            }catch(Exception $ex)
+            {
+                Log::error('Unable to proxy GeoServer request', ['params' => $parameters, 'error' => $ex]);
+    
+                return $this->createEmptyResponse($request);
+            }
+        });
+        
+        
+
+    }
+
+    private function fingerprint($request)
+    {
+        return sha1(implode('|', 
+            array_values($request->only(
+                'bbox','format','height','width','id','layers',
+                'request','service','srs','styles','transparent',
+                'version','query_layers','info_format',
+                'exceptions','x','y','i','j'
+            ))
+        ));
+    }
+
+
+    private function createEmptyResponse($request)
+    {
+        $info_format = $request->input('info_format', null);
+
+        if($info_format === 'application/json'){
+            return response()->json([]);
+        }
+
+        $format = $request->input('format', 'image/png');
+        $width = $request->input('width', 256);
+        $height = $request->input('hei$height', 256);
+
+        return $this->respondWithEmptyImage($width, $height, $format);
+    }
+
+
+    private function respondWithEmptyImage($width = 256, $height = 256, $format = 'image/png')
+    {
+        $img = ImageFacade::canvas($width, $height);
+
+        return $img->response($this->formatMapping[$format] ?? 'png');
+    }
+}

--- a/plugins/geo/src/Http/Controllers/WebMapServiceController.php
+++ b/plugins/geo/src/Http/Controllers/WebMapServiceController.php
@@ -58,8 +58,6 @@ class WebMapServiceController extends Controller
         }
 
         if (! ($doc->isPublished() || $doc->hasPendingPublications() || $doc->hasPublicLink()) && is_null($user)) {
-            Log::warning('WebMapServiceController, requested a document that is not public and user is not authenticated', ['url' => $request->url()]);
-
             throw new AuthenticationException();
         }
         if ($doc->trashed()) {

--- a/plugins/geo/src/Previews/GeodataPreviewDriver.php
+++ b/plugins/geo/src/Previews/GeodataPreviewDriver.php
@@ -53,7 +53,7 @@ class GeodataPreviewDriver extends MapPreviewDriver
         $this->view_data['styles'] = "";
         $this->view_data['attribution'] = "$file->name";
         $this->view_data['geojson'] = !$canBeFoundOnGeoserver ? $this->getFileContentAsGeoJson($file) : null;
-        $this->view_data['geoserver'] = $canBeFoundOnGeoserver ? $this->geoservice->wmsBaseUrl() : null;
+        $this->view_data['geoserver'] = $canBeFoundOnGeoserver ? route('plugins.k-box-kbox-plugin-geo.wms') : null;
         $this->view_data['disableTiling'] = $canBeFoundOnGeoserver ? $this->requiresBandStretching($file) : false;
 
         return $this;


### PR DESCRIPTION
## What does this PR do?

This pull requests add a proxy layer to all WMS calls generated by the Geo plugin.

WMS requests now are served by the K-Box and handed over to GeoServer only if the authentication is successful.

This is an architectural decision governed by various factors:

- We are not ready to transform the K-Box into an OAuth provider for letting GeoServer authenticate all requests
- We want to keep the deployment of K-Box and GeoServer as simple as possible
- We want to preserve the ability to use a single GeoServer for multiple K-Boxes

After an internal round of discussion, and knowing that OAuth can be added later, we decided to proxy the requests to the GeoServer. In this way 

- the authentication and authorization stack is performed within the K-Box
- Geoserver do not need to be exposed to the public, but can be confined into a Docker network or a VPN (giving also a bit more security to the Geoserver instance as only the WMS endpoint is partially exposed)


_Is it slow_. As you might think proxying a request to obtain an image is slower that making the request to the producer, but at the same time give some nice possibility of using caching headers and various strategies. From preliminary testing the first request is slower than the original one. The proxy also caches the responses for 10 minutes so interacting with the map by panning and zooming should not be affected by the initial slowness of the request proxying.

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)