### PR TITLE
GDPR clean personal data from detail panels

### DIFF
--- a/app/DocumentDescriptor.php
+++ b/app/DocumentDescriptor.php
@@ -216,7 +216,7 @@ class DocumentDescriptor extends Model
 
     public function owner()
     {
-        return $this->belongsTo(\KBox\User::class, 'owner_id', 'id');
+        return $this->belongsTo(\KBox\User::class, 'owner_id', 'id')->withTrashed();
     }
 
     /**

--- a/app/Http/Controllers/Document/DocumentPreviewController.php
+++ b/app/Http/Controllers/Document/DocumentPreviewController.php
@@ -6,6 +6,7 @@ use Log;
 use Exception;
 use Throwable;
 use KBox\File;
+use KBox\Capability;
 use KBox\DocumentDescriptor;
 use Illuminate\Http\Request;
 use KBox\Documents\Properties\Presenter;
@@ -71,6 +72,7 @@ class DocumentPreviewController extends DocumentAccessController
             'filename_for_download' => $version ? $version->name : $doc->title,
             'pagetitle' => trans('documents.preview.page_title', ['document' => $doc->title]),
             'body_classes' => "preview",
+            'user_can_edit' => optional(auth()->user())->can_capability(Capability::EDIT_DOCUMENT) ?? false,
         ];
 
         try {

--- a/resources/lang/en/units.php
+++ b/resources/lang/en/units.php
@@ -23,6 +23,6 @@ return [
     'older' => 'Older',
      // translators: Do not translate this. This expression is the date formatting string. Please refer to http://php.net/manual/en/function.date.php
     'date_format' => 'd M Y',
-    'date_format_full' => 'l j F Y H:i:s',
+    'date_format_full' => 'l j F Y H:i',
 
 ];

--- a/resources/lang/fr/units.php
+++ b/resources/lang/fr/units.php
@@ -23,6 +23,6 @@ return [
     'older' => 'Plus ancien',
      // translators: Do not translate this. This expression is the date formatting string. Please refer to http://php.net/manual/en/function.date.php
     'date_format' => 'd M Y',
-    'date_format_full' => 'l j F Y H:i:s',
+    'date_format_full' => 'l j F Y H:i',
 
 ];

--- a/resources/lang/ky/units.php
+++ b/resources/lang/ky/units.php
@@ -23,6 +23,6 @@ return [
     'older' => 'Эски',
     // translators: Do not translate this. This expression is the date formatting string. Please refer to http://php.net/manual/en/function.date.php
     'date_format' => 'd M Y',
-    'date_format_full' => 'l j F Y H:i:s',
+    'date_format_full' => 'l j F Y H:i',
 
 ];

--- a/resources/lang/ru/units.php
+++ b/resources/lang/ru/units.php
@@ -23,6 +23,6 @@ return [
     'older' => 'Старее',
     // translators: Do not translate this. This expression is the date formatting string. Please refer to http://php.net/manual/en/function.date.php
     'date_format' => 'd M Y',
-    'date_format_full' => 'l j F Y H:i:s',
+    'date_format_full' => 'l j F Y H:i',
 
 ];

--- a/resources/lang/tg/units.php
+++ b/resources/lang/tg/units.php
@@ -23,5 +23,5 @@ return [
     'older' => 'Кӯҳна',
      // translators: Do not translate this. This expression is the date formatting string. Please refer to http://php.net/manual/en/function.date.php
     'date_format' => 'd M Y',
-    'date_format_full' => 'l j F Y H:i:s',
+    'date_format_full' => 'l j F Y H:i',
 ];

--- a/resources/views/documents/partials/preview_properties.blade.php
+++ b/resources/views/documents/partials/preview_properties.blade.php
@@ -1,5 +1,5 @@
         
-			<div class="file-properties">
+<div class="file-properties">
 	@if(isset($stars_count) && !$document->trashed())
 
 		<div class="stars">
@@ -25,69 +25,21 @@
 		@include('documents.partials.license', ['license' => $document->copyright_usage, 'owner' => $document->copyright_owner])
 	</div>
 		
-
-	<div class="file-properties__property">
-		<span class="file-properties__label">{{trans('panels.groups_section_title')}}</span>
-		@include('documents.partials.collections', [
-			'document_is_trashed' => $document->trashed(),
-			'user_can_edit_public_groups' => false,
-			'user_can_edit_private_groups' => false,
-			'document_id' =>  $document->id,
-			'collections' => $groups ?? null,
-			'use_groups_page' => $use_groups_page ?? false,
-			'is_in_collection' => $is_in_collection ?? false
-		])
-	</div>
-	
-	<div class="file-properties__property">
-		<span class="file-properties__label">{{trans('panels.meta.authors')}}</span>
-		<span class="file-properties__value">{{ isset($document) ? $document->authors : '' }}</span>
-	</div>
-	
-	<div class="file-properties__property">
-		<span class="file-properties__label">{{trans('panels.meta.institution')}}</span>
-		<span class="file-properties__value">{{ isset($document) && !is_null($document->institution) ? $document->institution->name : '' }}</span>
-	</div>
-	
-	<div class="file-properties__property">
-		<span class="file-properties__label">{{trans('panels.meta.main_contact')}}</span>
-		<span class="file-properties__value">{{ isset($document) ? $document->user_owner : '' }}</span>
-	</div>
-	
-	<div class="file-properties__property">
-		<span class="file-properties__label">{{trans('panels.meta.language')}}</span>
-		<span class="file-properties__value">{{ isset($document) && !empty($document->language) ? trans('languages.' . $document->language) : trans('languages.no_language') }}</span>
-	</div>
-	
-	<div class="file-properties__property">
-		<span class="file-properties__label">{{trans('panels.meta.added_on')}}</span>
-		<span class="file-properties__value">{{ isset($document) ? $document->getCreatedAt(true) : '' }}</span>
-	</div>
-
-	@if($document->trashed())
+	@auth
 		<div class="file-properties__property">
-			<span class="file-properties__label">{{trans('panels.meta.deleted_on')}}</span>
-			<span class="file-properties__value">{{ isset($document) ? $document->getDeletedAt(true) : '' }}</span>
+			<span class="file-properties__label">{{trans('panels.groups_section_title')}}</span>
+			@include('documents.partials.collections', [
+				'document_is_trashed' => $document->trashed(),
+				'user_can_edit_public_groups' => false,
+				'user_can_edit_private_groups' => false,
+				'document_id' =>  $document->id,
+				'collections' => $groups ?? null,
+				'use_groups_page' => $use_groups_page ?? false,
+				'is_in_collection' => $is_in_collection ?? false
+				])
 		</div>
-	@endif
-
-	@if($document->isFileUploadComplete())
-		<div class="file-properties__property">
-			<span class="file-properties__label">{{trans('panels.meta.size')}}</span>
-			<span class="file-properties__value">{{ isset($document) ? KBox\Documents\Services\DocumentsService::human_filesize($document->file->size) : '' }}</span>
-		</div>
-	@endif
-
-	<div class="file-properties__property">
-		<span class="file-properties__label">{{trans('panels.meta.uploaded_by')}}</span>
-		<span class="file-properties__value">{{ isset($document) ? $document->user_uploader : '' }}</span>
-	</div>
-
+	@endauth
 	
-	@if(isset($properties) && method_exists($properties, 'toHtml'))
+	@include('documents.partials.properties')
 	
-		{{ $properties }}
-
-	@endif
-
 </div>

--- a/resources/views/documents/partials/properties.blade.php
+++ b/resources/views/documents/partials/properties.blade.php
@@ -1,0 +1,58 @@
+
+<div class="meta info">
+
+	<h4 class="c-panel__section">{{trans('panels.info_section_title')}}</h4>
+
+	<div class="c-panel__meta">
+		<div class="c-panel__label">{{trans('panels.meta.uploaded_by')}}</div>
+		
+		{{ optional($document->owner)->name ?? '-' }}
+	</div>
+
+	<div class="c-panel__meta">
+		<div class="c-panel__label">{{trans('panels.meta.added_on')}}</div>
+		
+		{{$document->getCreatedAt(true)}}
+	</div>
+
+	<div class="c-panel__meta">
+		<div class="c-panel__label">{{trans('documents.descriptor.last_modified')}}</div>
+			
+		{{$document->getUpdatedAt(true)}}
+	</div>
+
+	@if($document->trashed())
+
+		<div class="c-panel__meta">
+			<div class="c-panel__label">{{trans('panels.meta.deleted_on')}}</div>
+
+			{{$document->getDeletedAt(true)}}
+		</div>
+
+	@endif
+
+	<div class="c-panel__meta">
+		<div class="c-panel__label">{{trans('panels.meta.language')}}</div>
+		
+		{{!empty($document->language) && in_array($document->language, config('dms.language_whitelist')) ? trans('languages.' . $document->language) : trans('languages.no_language')}}
+	</div>
+	
+
+	@if(!is_null($document->file))
+
+	<div class="c-panel__meta">
+		<div class="c-panel__label">{{trans('panels.meta.size')}}</div>
+			
+		{{KBox\Documents\Services\DocumentsService::human_filesize($document->file->size)}}
+	</div>
+
+	@endif
+
+	@if(isset($properties) && method_exists($properties, 'toHtml'))
+	
+		{{ $properties }}
+
+	@endif
+	
+</div>
+

--- a/resources/views/documents/partials/properties.blade.php
+++ b/resources/views/documents/partials/properties.blade.php
@@ -3,11 +3,13 @@
 
 	<h4 class="c-panel__section">{{trans('panels.info_section_title')}}</h4>
 
-	<div class="c-panel__meta">
-		<div class="c-panel__label">{{trans('panels.meta.uploaded_by')}}</div>
-		
-		{{ optional($document->owner)->name ?? '-' }}
-	</div>
+	@auth	
+		<div class="c-panel__meta">
+			<div class="c-panel__label">{{trans('panels.meta.uploaded_by')}}</div>
+			
+			{{ optional($document->owner)->name ?? '-' }}
+		</div>
+	@endauth
 
 	<div class="c-panel__meta">
 		<div class="c-panel__label">{{trans('panels.meta.added_on')}}</div>

--- a/resources/views/documents/preview.blade.php
+++ b/resources/views/documents/preview.blade.php
@@ -35,7 +35,9 @@
         <div class="preview__actions">
 		
 			@auth
-				<a class="preview__button js-preview-edit-button"  title="{{trans('panels.edit_btn_title')}}" href="{{ route('documents.edit', $document->id)}}">{{ trans('panels.edit_btn') }}</a>
+				@if(isset($user_can_edit) && $user_can_edit)
+					<a class="preview__button js-preview-edit-button"  title="{{trans('panels.edit_btn_title')}}" href="{{ route('documents.edit', $document->id)}}">{{ trans('panels.edit_btn') }}</a>
+				@endif
 			@endauth
 			
             <a class="preview__button js-preview-download-button"  href="{{DmsRouting::download($document, $version)}}" download="{{ $filename_for_download }}">{{ trans('panels.download_btn') }}</a>

--- a/resources/views/documents/preview.blade.php
+++ b/resources/views/documents/preview.blade.php
@@ -33,7 +33,11 @@
         </div>
 
         <div class="preview__actions">
-        
+		
+			@auth
+				<a class="preview__button js-preview-edit-button"  title="{{trans('panels.edit_btn_title')}}" href="{{ route('documents.edit', $document->id)}}">{{ trans('panels.edit_btn') }}</a>
+			@endauth
+			
             <a class="preview__button js-preview-download-button"  href="{{DmsRouting::download($document, $version)}}" download="{{ $filename_for_download }}">{{ trans('panels.download_btn') }}</a>
             
             <button class="preview__button preview__button--expandable js-preview-details-button"><span class="preview__button-close">{{ trans('preview::actions.close') }}</span>{{ trans('preview::actions.details') }}</button>

--- a/resources/views/panels/document.blade.php
+++ b/resources/views/panels/document.blade.php
@@ -135,7 +135,7 @@
 
 @endif
 
-	@if($is_user_logged)
+	@auth
 
 		<div class="meta collections">
 			<h4 class="c-panel__section">{{trans('panels.groups_section_title')}}</h4>
@@ -152,7 +152,7 @@
 
 		</div>
         
-    @endif
+    @endauth
     
     @if($is_user_logged && $item->isMine())
 
@@ -174,121 +174,8 @@
 
 		</div>
 
-		
-
 	@endif
 
-	<div class="meta info">
+	@include('documents.partials.properties', ['document' => $item])
 
-		<h4 class="c-panel__section">{{trans('panels.info_section_title')}}</h4>
-
-
-		<div class="c-panel__meta">
-			<div class="c-panel__label">
-				{{trans('panels.meta.authors')}}
-			</div>
-			
-				
-				{{$item->authors}}
-
-			
-		</div>
-		<div class="c-panel__meta">
-			<div class="c-panel__label">
-				{{trans('panels.meta.main_contact')}}
-			</div>
-			
-				
-				{{$item->user_owner}}
-
-			
-		</div>
-		<div class="c-panel__meta">
-			<div class="c-panel__label">
-				{{trans('panels.meta.language')}}
-			</div>
-			
-			{{!empty($item->language) && in_array($item->language, config('dms.language_whitelist')) ? trans('languages.' . $item->language) : trans('languages.no_language')}}
-			
-		</div>
-		<div class="c-panel__meta">
-			<div class="c-panel__label">
-				{{trans('panels.meta.added_on')}}
-			</div>
-			
-				
-				{{$item->getCreatedAt(true)}}
-
-			
-		</div>
-
-		@if($item->trashed())
-
-		<div class="c-panel__meta">
-			<div class="c-panel__label">
-				{{trans('panels.meta.deleted_on')}}
-			</div>
-			
-				
-				{{$item->getDeletedAt(true)}}
-
-			
-		</div>
-
-		@endif
-
-		@if(!is_null($item->file))
-
-		<div class="c-panel__meta">
-			<div class="c-panel__label">
-				{{trans('panels.meta.size')}}
-			</div>
-			
-				
-				{{KBox\Documents\Services\DocumentsService::human_filesize($item->file->size)}}
-
-		</div>
-
-		@endif
-
-
-		
-
-		<div class="c-panel__meta">
-			<div class="c-panel__label">
-				{{trans('panels.meta.uploaded_by')}}
-			</div>
-			
-			@if($item->owner)
-
-				{{ $item->owner->name }}
-
-				@if($item->owner->organization_name)
-					@if($item->owner->organization_website)
-
-						(<a href="{{$item->owner->organization_website}}">{{ $item->owner->organization_name }}</a>)
-
-					@else
-
-						({{ $item->owner->organization_name }})
-
-					@endif
-				@endif
-			
-			@else
-				
-				{{ $item->user_uploader }}
-
-			@endif
-
-		</div>
-
-		
-		@if(isset($properties) && method_exists($properties, 'toHtml'))
-		
-			{{ $properties }}
-
-		@endif
-		
-	</div>
 </div>


### PR DESCRIPTION
## What does this PR do?

In order to tackle #69 (GDPR) some changes on how we process and display data are required.

This pull request start the work by changing how file/document properties are displayed. In particular

- document owner email and organization is not presented anymore as we do not have explicit consent
- main contact and uploaded by are covered by the same entry as they have usually the same value, which is the original uploader of the file

The same property listing now applies to the details panel in the document section and on the details panel presented in the preview

![image](https://user-images.githubusercontent.com/5672748/47568877-87848000-d932-11e8-852b-81c429b9f6d6.png)


### Related issues

Related to #69 

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)