### PR TITLE
Avoid populating Authors and Uploader with personal data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
 		"jenssegers/agent": "^2.5",
 		"jenssegers/date": "^3.2",
 		"k-box/example-plugin": "*",
-		"k-box/k-search-client-php": "3.2.*",
+		"k-box/k-search-client-php": "3.3.*",
 		"k-box/kbox-plugin-geo": "*",
 		"laravel/framework": "5.5.*",
 		"laravel/tinker": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ddfc6ba838d3afa7c3788421676f902c",
+    "content-hash": "7f86cbaa7853ec8b4ff9954ec2f99a37",
     "packages": [
         {
             "name": "avvertix/materialicons-laravel-bridge",
@@ -1796,16 +1796,16 @@
         },
         {
             "name": "k-box/k-search-client-php",
-            "version": "v3.2.0",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/k-box/k-search-client-php.git",
-                "reference": "4706f4caa30c142023611f99c6281b58951b9cd9"
+                "reference": "18ee437a2886a586fa78cb19f46f6abaf9c69613"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/k-box/k-search-client-php/zipball/4706f4caa30c142023611f99c6281b58951b9cd9",
-                "reference": "4706f4caa30c142023611f99c6281b58951b9cd9",
+                "url": "https://api.github.com/repos/k-box/k-search-client-php/zipball/18ee437a2886a586fa78cb19f46f6abaf9c69613",
+                "reference": "18ee437a2886a586fa78cb19f46f6abaf9c69613",
                 "shasum": ""
             },
             "require": {

--- a/docker-compose.dev.example.yml
+++ b/docker-compose.dev.example.yml
@@ -39,7 +39,7 @@ services:
   ## K-Search
 
   ksearch:
-    image: "docker.klink.asia/images/k-search:3.5.0-1"
+    image: "docker.klink.asia/images/k-search:3.6.0-1"
     ports:
       - 8081:80
     environment:

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -31,7 +31,7 @@ services:
 
   ## The Search Engine API
   ksearch:
-    image: "docker.klink.asia/images/k-search:3.5.0-1"
+    image: "docker.klink.asia/images/k-search:3.6.0-1"
     environment:
       ## Further datails about K-Search configuration in https://github.com/k-box/k-search
       ## Solr search configuration

--- a/tests/Unit/KlinkDocumentDescriptorTest.php
+++ b/tests/Unit/KlinkDocumentDescriptorTest.php
@@ -19,7 +19,7 @@ class KlinkDocumentDescriptorTest extends TestCase
     {
         $descriptor = factory(\KBox\DocumentDescriptor::class)->make([
             // generating an author string that don't respect the format
-            'authors' => 'Hello Author hello@author.com'
+            'authors' => 'Hello Author hello@author.com,Hello Author2 <hello@author2.com>'
         ]);
 
         $klink_descriptor = $descriptor->toKlinkDocumentDescriptor();
@@ -43,8 +43,43 @@ class KlinkDocumentDescriptorTest extends TestCase
         $this->assertEquals($descriptor->thumbnail_uri, $data->properties->thumbnail);
 
         $this->assertNotNull($data->authors);
-        $this->assertCount(1, $data->authors);
         $this->assertContainsOnlyInstancesOf(Author::class, $data->authors);
+        $this->assertCount(2, $data->authors);
+
+        $authors = $data->authors;
+        $this->assertEquals('Hello Author', $authors[0]->name);
+        $this->assertEquals('hello@author.com', $authors[0]->email);
+        $this->assertEquals('Hello Author2', $authors[1]->name);
+        $this->assertEquals('hello@author2.com', $authors[1]->email);
+    }
+
+    public function test_private_document_descriptor_is_anonymized()
+    {
+        $descriptor = factory(\KBox\DocumentDescriptor::class)->make();
+
+        $klink_descriptor = $descriptor->toKlinkDocumentDescriptor();
+
+        $this->assertInstanceOf(KlinkDocumentDescriptor::class, $klink_descriptor);
+        $this->assertEquals('private', $klink_descriptor->visibility());
+        $this->assertEquals('private', $klink_descriptor->getVisibility());
+        $this->assertEquals($descriptor->uuid, $klink_descriptor->uuid());
+        $this->assertEquals($descriptor->uuid, $klink_descriptor->getKlinkId());
+
+        $data = $klink_descriptor->toData();
+        $this->assertInstanceOf(Data::class, $data);
+
+        $this->assertEquals('document', $data->type);
+        $this->assertEquals($descriptor->uuid, $data->uuid);
+        $this->assertEquals($descriptor->hash, $data->hash);
+        $this->assertRegExp('/http(.*)\/files\/(.*)\?t=(.*)/', $data->url);
+        $this->assertStringStartsWith('http:', $data->url);
+        $this->assertEquals($descriptor->title, $data->properties->title);
+        $this->assertEquals($descriptor->mime_type, $data->properties->mime_type);
+        $this->assertEquals($descriptor->thumbnail_uri, $data->properties->thumbnail);
+
+        $this->assertEmpty($data->authors);
+        $this->assertEquals(url('/'), $data->uploader->url);
+        $this->assertEquals(sha1($descriptor->owner->id.$descriptor->owner->name), $data->uploader->name);
     }
 
     public function test_publishing_video_has_streaming_properties()

--- a/tests/Unit/KlinkDocumentDescriptorTest.php
+++ b/tests/Unit/KlinkDocumentDescriptorTest.php
@@ -79,7 +79,7 @@ class KlinkDocumentDescriptorTest extends TestCase
 
         $this->assertEmpty($data->authors);
         $this->assertEquals(url('/'), $data->uploader->url);
-        $this->assertEquals(sha1($descriptor->owner->id.$descriptor->owner->name), $data->uploader->name);
+        $this->assertEquals(sha1($descriptor->owner->id), $data->uploader->name);
     }
 
     public function test_publishing_video_has_streaming_properties()

--- a/workbench/klink/dms-adapter/src/Klink/DmsAdapter/KlinkDocumentDescriptor.php
+++ b/workbench/klink/dms-adapter/src/Klink/DmsAdapter/KlinkDocumentDescriptor.php
@@ -157,7 +157,7 @@ final class KlinkDocumentDescriptor
 
 		// The uploader must be anonymized, therefore if set we use 
 		// the SHA-1 of the identifier and the name combined
-		$uploader->name = $this->descriptor->owner ? sha1($this->descriptor->owner->getKey() . $this->descriptor->owner->name) : null;
+		$uploader->name = $this->descriptor->owner ? sha1($this->descriptor->owner->getKey()) : null;
 		$uploader->url = url('/');
 		
         $data->uploader = $uploader;

--- a/workbench/klink/dms-adapter/src/Klink/DmsAdapter/KlinkDocumentDescriptor.php
+++ b/workbench/klink/dms-adapter/src/Klink/DmsAdapter/KlinkDocumentDescriptor.php
@@ -24,6 +24,7 @@ final class KlinkDocumentDescriptor
 {
 	const DATA_TYPE_DOCUMENT = Data::DATA_TYPE_DOCUMENT;
 	const DATA_TYPE_VIDEO = Data::DATA_TYPE_VIDEO;
+	const AUTHORS_REGEXP = '/(.*)\s(<?\S*@\S*>?)/m'; // format: name followed by a space and then the email address (optionally within angle brackets)
 	
 	/**
 	 * visibility
@@ -136,44 +137,28 @@ final class KlinkDocumentDescriptor
 		$data->uuid = $this->descriptor->uuid;
 		$data->geo_location = Geometries::boundingBoxFromGeoserver($file_properties->get('boundings.geoserver', null)) ?? $file_properties->get('boundings.geojson', null); // add location information if expressed in the file properties
 		
-		$user_owner = $this->descriptor->user_owner;
-		$authors = empty($this->descriptor->authors) ? [$this->descriptor->user_owner] : explode(',', $this->descriptor->authors);
+		$authors = array_from($this->descriptor->authors ?? []);
 		
 		$processed_authors = array_filter(array_map(function($author_string){
-			$author_string = str_replace('&lt;', '<', str_replace('&gt;', '>',$author_string ));
-			$splitted = explode('<', $author_string);
-
-			if(count($splitted) !== 2){
+			preg_match_all(self::AUTHORS_REGEXP, $author_string, $matches, PREG_SET_ORDER, 0);
+			
+			if(count($matches) !== 1){
 				return false;
 			}
 			$author = new Author();
-			$author->name = trim($splitted[0]);
-			$author->email = rtrim(trim($splitted[1]), '>');
+			$author->name = trim($matches[0][1]);
+			$author->email = ltrim(rtrim($matches[0][2], '>'), '<');
 			return $author;
 		}, $authors));
 
-		if(empty($processed_authors)){
-			$processed_authors[] = tap(new Author, function($a) use($user_owner){
-				$splitted = explode('<', $user_owner);
-				$a->name = trim($splitted[0]);
-				$a->email = rtrim(trim($splitted[1]), '>');
-			});
-		}
-
-		// Author is a required field, so if no authors are inserted by humans I will add the owner as an author. 
         $data->authors = $processed_authors;
 		
 		$uploader = new Uploader();
 
-		if($this->descriptor->owner){
-			$uploader->name = !empty($this->descriptor->owner->organization_name) ? $this->descriptor->owner->organization_name : $this->descriptor->user_owner;
-			$uploader->url = !empty($this->descriptor->owner->organization_website) ? $this->descriptor->owner->organization_website : url('/');
-		}
-		else {
-			$uploader->name = $this->descriptor->user_owner;
-			$uploader->url = url('/');
-		}
-		
+		// The uploader must be anonymized, therefore if set we use 
+		// the SHA-1 of the identifier and the name combined
+		$uploader->name = $this->descriptor->owner ? sha1($this->descriptor->owner->getKey() . $this->descriptor->owner->name) : null;
+		$uploader->url = url('/');
 		
         $data->uploader = $uploader;
 


### PR DESCRIPTION
Avoid populating Authors and Uploader with personal data of the document owner

## What does this PR do?

In order to tackle #69 (GDPR) some changes on how we process and display data are required.

This pull continue the work by changing how data is indexed for search and published in the K-Link. In particular authors are populated only if explicitly set and the uploader field no longer include username and email address.

### Related issues

Related to #69

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)