### PR TITLE
Update Nginx installation and fix gpg key errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,10 +68,10 @@ RUN locale-gen "en_US.UTF-8" \
 ### The installation procedure is heavily inspired from https://github.com/nginxinc/docker-nginx
 RUN set -e; \
 	NGINX_GPGKEY=573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62; \
-	NGINX_VERSION=1.14.0-1~stretch; \
+	NGINX_VERSION=1.14.1-1~stretch; \
 	found=''; \
 	apt-get update; \
-	apt-get install -y gnupg; \
+	apt-get install --no-install-recommends --no-install-suggests -y gnupg1 apt-transport-https ca-certificates; \
 	for server in \
 		ha.pool.sks-keyservers.net \
 		hkp://keyserver.ubuntu.com:80 \


### PR DESCRIPTION
## What does this PR do?

Update NGINX installation following the official NGINX Dockerfile.

This should fix also an error found while grabbing GPG keys on latest PHP images based on Debian Stretch. 

### Review checklist

* [x] Are unit tests required?
* [x] Are Documentation changes needed?

**Before merging**

* [x] Is history cleaned up? (or can be squashed on merge?)