### PR TITLE
Generate url instead of using cached one when indexing

### DIFF
--- a/app/DocumentDescriptor.php
+++ b/app/DocumentDescriptor.php
@@ -520,7 +520,7 @@ class DocumentDescriptor extends Model
 
     public function getDocumentUriAttribute($value = null)
     {
-        if (! $value) {
+        if ($this->file_id) {
             return route('documents.preview', ['uuid' => $this->uuid]);
         }
 
@@ -529,7 +529,7 @@ class DocumentDescriptor extends Model
 
     public function getThumbnailUriAttribute($value = null)
     {
-        if (! $value) {
+        if ($this->file_id) {
             return route('documents.thumbnail', ['uuid' => $this->uuid]);
         }
 

--- a/tests/Unit/KlinkDocumentDescriptorTest.php
+++ b/tests/Unit/KlinkDocumentDescriptorTest.php
@@ -82,6 +82,34 @@ class KlinkDocumentDescriptorTest extends TestCase
         $this->assertEquals(sha1($descriptor->owner->id), $data->uploader->name);
     }
 
+    public function test_document_descriptor_can_be_converted_to_public_descriptor()
+    {
+        $descriptor = factory(\KBox\DocumentDescriptor::class)->create();
+
+        $klink_descriptor = $descriptor->toKlinkDocumentDescriptor(true);
+
+        $this->assertInstanceOf(KlinkDocumentDescriptor::class, $klink_descriptor);
+        $this->assertEquals('public', $klink_descriptor->visibility());
+        $this->assertEquals('public', $klink_descriptor->getVisibility());
+        $this->assertEquals($descriptor->uuid, $klink_descriptor->uuid());
+        $this->assertEquals($descriptor->uuid, $klink_descriptor->getKlinkId());
+
+        $data = $klink_descriptor->toData();
+        $this->assertInstanceOf(Data::class, $data);
+
+        $this->assertEquals('document', $data->type);
+        $this->assertEquals($descriptor->uuid, $data->uuid);
+        $this->assertEquals($descriptor->hash, $data->hash);
+        $this->assertEquals(route('documents.preview', ['id' => $descriptor->uuid]), $data->url);
+        $this->assertEquals($descriptor->title, $data->properties->title);
+        $this->assertEquals($descriptor->mime_type, $data->properties->mime_type);
+        $this->assertEquals(route('documents.thumbnail', ['id' => $descriptor->uuid]), $data->properties->thumbnail);
+
+        $this->assertEmpty($data->authors);
+        $this->assertEquals(url('/'), $data->uploader->url);
+        $this->assertEquals(sha1($descriptor->owner->id), $data->uploader->name);
+    }
+
     public function test_publishing_video_has_streaming_properties()
     {
         $streaming_url = 'https://streaming.service/play/123';

--- a/tests/Unit/KlinkDocumentTest.php
+++ b/tests/Unit/KlinkDocumentTest.php
@@ -52,7 +52,8 @@ class KlinkDocumentTest extends TestCase
 
         $data = $document->getDescriptor()->toData();
         
-        $this->assertEquals('https://some.location/1', $data->url);
+        $this->assertNotEquals('https://some.location/1', $data->url);
+        $this->assertEquals(route('documents.preview', ['id' => $descriptor->uuid]), $data->url);
     }
     
     public function test_document_data_returns_null_for_supported_data()


### PR DESCRIPTION
## What does this PR do?

Fixes the use of old cached document and thumbnail urls when indexing/reindexing public files

### Review checklist

* [x] Are unit tests required?
* [x] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)