### PR TITLE
Fix delete shared collection undefined page

### DIFF
--- a/packages/contentprocessing/src/Services/DocumentsService.php
+++ b/packages/contentprocessing/src/Services/DocumentsService.php
@@ -1160,6 +1160,10 @@ class DocumentsService
             throw new ForbiddenException(trans('groups.delete.forbidden_delete_collection', ['collection' => $group->name]));
         }
 
+        if ($group->shares()->count() > 0 && $user->id != $group->user_id) {
+            throw new ForbiddenException(trans('groups.delete.forbidden_delete_shared_collection', ['collection' => $group->name]));
+        }
+
         if ($group->is_private && $user->id != $group->user_id) {
             throw new ForbiddenException(trans('groups.delete.forbidden_trash_personal_collection', ['collection' => $group->name]));
         }

--- a/resources/lang/en/groups.php
+++ b/resources/lang/en/groups.php
@@ -110,6 +110,7 @@ return [
         'cannot_delete_general_error' => 'Cannot delete the specified elements. Nothing has been deleted.',
         
         'forbidden_trash_personal_collection' => 'You did not create :collection, therefore you cannot trash it.',
+        'forbidden_delete_shared_collection' => '":collection" has been shared with you, therefore you cannot trash it.',
         'forbidden_delete_personal_collection' => 'You did not create :collection, therefore you cannot delete it.',
         'forbidden_delete_collection' => 'The collection :collection cannot be deleted. You are not allowed to operate on Collections.',
         'forbidden_delete_project_collection' => 'The collection :collection cannot be deleted as it is in a project where you do not have the edit permissions.',

--- a/resources/views/components/list-item.blade.php
+++ b/resources/views/components/list-item.blade.php
@@ -59,7 +59,7 @@
         @endif
 
 
-        <a href="{{ $url }}" class="item__link" rel="noopener" target="_blank" title="{{ $name }}">
+        <a href="{{ $url }}" class="item__link @if($type==='group') js-tree-item-inner @endif" rel="noopener" target="_blank" title="{{ $name }}">
             {{ $name }}
         </a>
         


### PR DESCRIPTION
## What does this PR do?

Fix an issue that caused a not found page when attempting to delete a shared collection.

The shared collection cannot be trashed by the receiver of a share and now this is also reported in the error message

### Review checklist

* [x] Are unit tests required?
* [x] Are Documentation changes needed?

**Before merging**

* [x] Is history cleaned up? (or can be squashed on merge?)