### PR TITLE
Fix upload error due to file max size not properly presented

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -11,6 +11,7 @@ use Illuminate\Session\TokenMismatchException;
 use Illuminate\Validation\ValidationException;
 use Klink\DmsAdapter\Exceptions\KlinkException;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Http\Exceptions\PostTooLargeException;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -95,6 +96,14 @@ class Handler extends ExceptionHandler
             }
 
             return redirect()->guest('login');
+        }
+
+        if ($e instanceof PostTooLargeException) {
+            if ($request->expectsJson()) {
+                return response()->json(['error' => trans('errors.413_text')], 413);
+            }
+
+            return trans('errors.413_text');
         }
 
         // if($e instanceof HttpResponseException)

--- a/app/Http/Requests/DocumentAddRequest.php
+++ b/app/Http/Requests/DocumentAddRequest.php
@@ -15,11 +15,10 @@ class DocumentAddRequest extends Request
     public function rules()
     {
         $max_size = config('dms.max_upload_size');
-        $supported_file_types = config('dms.allowed_file_types');
 
         $tests = [
             'group' => 'sometimes|required|exists:groups,id',
-            'document' => 'required|between:0,'.$max_size,
+            'document' => 'required|file|between:0,'.$max_size,
             'document_fullpath' => 'sometimes|required',
             'document_name' => 'sometimes|required',
             'folder_path' => 'sometimes|required|min:1',
@@ -36,5 +35,12 @@ class DocumentAddRequest extends Request
     public function authorize()
     {
         return true; // would be great to handle user check here :)
+    }
+
+    public function messages()
+    {
+        return [
+            'document.uploaded' => trans('errors.upload.file_not_uploaded', ['max_size' => config('dms.max_upload_size').' KB']),
+        ];
     }
 }

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -17,6 +17,7 @@ return [
         'simple' => 'Upload error :description',
         'filenamepolicy' => 'The file :filename does not respect the naming convention.',
         'filealreadyexists' => 'The file :filename already exists.',
+        'file_not_uploaded' => 'The file was not uploaded, please verify that its size is less than :max_size.',
     ],
 
     'filealreadyexists' => [

--- a/resources/lang/ky/errors.php
+++ b/resources/lang/ky/errors.php
@@ -17,6 +17,7 @@ return [
         'simple' => 'Жүктөө учурунда ката :description кетти',
         'filenamepolicy' => 'Файл :filename документ аталыш эрежелерине туура келбейт',
         'filealreadyexists' => 'Файл :filename системага жүктөлгөн',
+        'file_not_uploaded' => 'Файл жүктөлгөн жок, көлөмү :max_size чоң болбош керек',
     ],
     
         'filealreadyexists' => [

--- a/resources/lang/ru/errors.php
+++ b/resources/lang/ru/errors.php
@@ -17,6 +17,7 @@ return [
         'simple' => 'Ошибка загрузки :description',
         'filenamepolicy' => 'Файл :filename не отвечает правилам названия документов.',
         'filealreadyexists' => 'Файл :filename уже существует.',
+        'file_not_uploaded' => 'Файл не загружен, размер файла должен быть меньше :max_size.',
     ],
     
         'filealreadyexists' => [


### PR DESCRIPTION
## What does this PR do?

It fixes the reporting of the failed upload due to file size being greater than the maximum allowed file size.

The error is now reported also with the maximum allowed file size indication

### Related issues

Fixes #2 

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)