### PR TITLE
Improve automatic php max upload and post size calculation

### DIFF
--- a/docker/configure.sh
+++ b/docker/configure.sh
@@ -45,12 +45,14 @@ function startup_config () {
 
     if [ -z "$KBOX_PHP_POST_MAX_SIZE" ]; then
         # calculating the post max size based on the upload limit
-        KBOX_PHP_POST_MAX_SIZE="${KBOX_UPLOAD_LIMIT+20048}K"
+        KBOX_PHP_POST_MAX_SIZE_CALCULATION=$((KBOX_UPLOAD_LIMIT+20048))
+        KBOX_PHP_POST_MAX_SIZE="${KBOX_PHP_POST_MAX_SIZE_CALCULATION}K"
     fi
 
     if [ -z "$KBOX_PHP_UPLOAD_MAX_FILESIZE" ]; then
         # calculating the upload max filesize based on the upload limit
-        KBOX_PHP_UPLOAD_MAX_FILESIZE="${KBOX_UPLOAD_LIMIT+2048}K"
+        KBOX_PHP_UPLOAD_MAX_FILESIZE_CALCULATION=$((KBOX_UPLOAD_LIMIT+2048))
+        KBOX_PHP_UPLOAD_MAX_FILESIZE="${KBOX_PHP_UPLOAD_MAX_FILESIZE_CALCULATION}K"
     fi
     
     # Set post and upload size for php if customized for the specific deploy
@@ -154,7 +156,7 @@ function wait_command () {
 
     for i in $(seq "$retry_times"); do
         echo "- Waiting for ${command} ... Retry $i"
-        if [[ "$command" ]]; then
+        if [[ "$command" -eq 0 ]]; then
             return 0
         else
             sleep "$sleep_seconds"


### PR DESCRIPTION
## What does this PR do?

Improve the automatic calculation of the `post_max_size` and `upload_max_filesize` PHP settings based on the value of the `KBOX_UPLOAD_LIMIT` environment variable.

Now the user defined maximum file size is increased a bit to cover event additional metadata in POST requests and is slightly increased to prevent upload denial from PHP without a proper error message being presented on the UI.

Before this pull request, if `KBOX_PHP_POST_MAX_SIZE` and `KBOX_PHP_UPLOAD_MAX_FILESIZE` were not defined in the environment, the PHP configuration would not take into account the change to `KBOX_UPLOAD_LIMIT`

### Review checklist

* [x] Are unit tests required?
* [x] Are Documentation changes needed?

**Before merging**

* [x] Is history cleaned up? (or can be squashed on merge?)