### PR TITLE
Fix share button hidden while document is indexing

### DIFF
--- a/resources/views/documents/edit.blade.php
+++ b/resources/views/documents/edit.blade.php
@@ -171,15 +171,10 @@
 				</button>
 			@endif
 
-			@if($document->isMine() && $document->isIndexed() && $can_make_public && network_enabled())
-
-			<div class="c-form__field">
-
-				@if($can_share || $can_make_public)
-				<button class="button js-open-share-dialog" data-id="{{$document->id}}">@materialicon('social','people', 'button__icon'){{ trans('panels.sharing_settings_btn') }}</button>
-				@endif
-			</div>
-
+			@if($document->isMine() && ($can_share || $can_make_public && network_enabled()))
+				<div class="c-form__field">
+					<button class="button js-open-share-dialog" data-id="{{$document->id}}">@materialicon('social','people', 'button__icon'){{ trans('panels.sharing_settings_btn') }}</button>
+				</div>
 			@endif
 			
 


### PR DESCRIPTION
Fixes #208 

## What does this PR do?

Fix the disappearing "share" button from the document edit page when indexing is in progress

### Review checklist

* [x] Are unit tests required?
* [x] Are Documentation changes needed?

**Before merging**

* [x] Is history cleaned up? (or can be squashed on merge?)