### PR TITLE
Auto remove permission highlight after 2 seconds

### DIFF
--- a/resources/views/administration/users/form.blade.php
+++ b/resources/views/administration/users/form.blade.php
@@ -104,17 +104,30 @@
     
     <script>
         
-        require(["jquery", 'lodash'], function(_$, __){
+        require(["jquery", 'lodash'], function(_$){
 
           var list = _$('.checkbox-list');
-          
+          var timeout = null;
+
           _$('.user-grab').on('mouseover', function(evt){
              
              var tp = _$(this).data('type');
+
+             if(timeout){
+                clearTimeout(timeout);
+            }
              
              list.find('.highlighted').removeClass('highlighted');
              list.find('.' + tp +'').addClass('highlighted');
              
+            timeout = setTimeout(function (){
+                list.find('.highlighted').removeClass('highlighted');
+
+                if(timeout){
+                    clearTimeout(timeout);
+                }
+            }, 2000);
+
              evt.preventDefault();
              return false; 
           });


### PR DESCRIPTION
## What does this PR do?

Auto remove the highlight of the permissions pertaining to a specific user role after 2 seconds

![remove-permission-highlight](https://user-images.githubusercontent.com/5672748/53817088-0f276e80-3f65-11e9-8795-3c6443db872d.gif)


### Related issues

Fixes #35

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)