### PR TITLE
Make K-Link guest search disabled by default

### DIFF
--- a/app/Http/Composers/HeadersComposer.php
+++ b/app/Http/Composers/HeadersComposer.php
@@ -51,7 +51,7 @@ class HeadersComposer
 
         $route_name = \Route::currentRouteName();
 
-        $is_klink_public_enabled = network_enabled();
+        $is_klink_public_enabled = config('dms.are_guest_public_search_enabled') && network_enabled();
 
         $show_search = (! $is_logged && $is_klink_public_enabled && ! starts_with($route_name, 'password') && ! str_contains($route_name, 'help') && ! starts_with($route_name, 'terms') && ! str_contains($route_name, 'contact')) ||
                         ($is_logged && ! is_null($route_name) && ! starts_with($route_name, 'admin') &&

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -47,6 +47,10 @@ class SearchController extends Controller
      */
     public function index(Guard $auth, Request $request)
     {
+        if (! $auth->check() && ! config('dms.are_guest_public_search_enabled')) {
+            abort(403);
+        }
+
         $is_klink_public_enabled = ! ! Option::option(Option::PUBLIC_CORE_ENABLED, false);
 
         if (! $is_klink_public_enabled) {

--- a/config/dms.php
+++ b/config/dms.php
@@ -47,14 +47,14 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Guest public searches
+    | Guest K-Link searches
     |--------------------------------------------------------------------------
     |
-    | Tell if the DMS will allow guest user to perform public search over K-Link
+    | Tell if the K-Box will allows K-Link search for non-logged in users
     |
     | @var boolean
     */
-    'are_guest_public_search_enabled' => env('KBOX_ENABLE_GUEST_NETWORK_SEARCH', env('DMS_ARE_GUEST_PUBLIC_SEARCH_ENABLED', true)),
+    'are_guest_public_search_enabled' => env('KBOX_ENABLE_GUEST_NETWORK_SEARCH', env('DMS_ARE_GUEST_PUBLIC_SEARCH_ENABLED', false)),
 
     'core' => [
 

--- a/docs/developer/configuration.md
+++ b/docs/developer/configuration.md
@@ -32,7 +32,7 @@ The next table shows the K-Box specific configuration parameters:
 | `KBOX_DB_HOST` (`DB_HOST`)            |          | string  | 127.0.0.1     | The database sever host |
 | `KBOX_DB_TABLE_PREFIX` (`DB_TABLE_PREFIX`) |     | string  | kdms_         | The table prefix for each database table. To increse the security of the installation set you own value |
 | `KBOX_SEARCH_SERVICE_URL`             | ✓        | url     |               | The URL of the K-Search that will deliver the full text search service. |
-| `KBOX_ENABLE_GUEST_NETWORK_SEARCH`    |           | boolean | true          | Enable guests to search over the configures K-Link Network |
+| `KBOX_ENABLE_GUEST_NETWORK_SEARCH`    |           | boolean | false          | Enable guests to search over the configured K-Link |
 | `KBOX_UPLOAD_LIMIT` (`UPLOAD_LIMIT`)  |           | integer | 204800         | Maximum allowed file size for upload. Expressed in KB |
 | `KBOX_MAIL_ENCRYPTION`                |           | string  | tls           | The mail encryption to use. Set to an empty string to allow insecure connections |
 | `KBOX_MAIL_DRIVER`                    |           | string  | smtp          | The Email driver. See [Configuring E-Mail](../user/en/administration/settings/mail.md) |

--- a/tests/Feature/KlinkGuestSearchTest.php
+++ b/tests/Feature/KlinkGuestSearchTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature;
+
+use KBox\User;
+use KBox\Option;
+use Tests\TestCase;
+use KBox\Capability;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class KlinkGuestSearchTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_search_not_presented_on_login_page_if_guest_search_disabled()
+    {
+        config(['dms.are_guest_public_search_enabled' => false]);
+        
+        $response = $this->get('/login');
+
+        $response->assertViewHas('show_search', false);
+        $response->assertDontSee('name="s"');
+    }
+
+    public function test_search_page_forbidden_if_guest_search_disabled()
+    {
+        config(['dms.are_guest_public_search_enabled' => false]);
+        
+        $response = $this->get('/search');
+
+        $response->assertStatus(403);
+    }
+
+    public function test_search_not_presented_on_login_page_if_klink_not_configured()
+    {
+        Option::option(Option::PUBLIC_CORE_ENABLED, false);
+        config(['dms.are_guest_public_search_enabled' => true]);
+        
+        $response = $this->get('/login');
+
+        $response->assertViewHas('show_search', false);
+        $response->assertDontSee('name="s"');
+    }
+
+    public function test_search_page_forbidden_if_klink_not_configured()
+    {
+        Option::option(Option::PUBLIC_CORE_ENABLED, false);
+        config(['dms.are_guest_public_search_enabled' => true]);
+        
+        $response = $this->get('/search');
+
+        $response->assertStatus(403);
+    }
+
+    public function test_search_page_forbidden_if_klink_not_configured_and_user_authenticated()
+    {
+        Option::option(Option::PUBLIC_CORE_ENABLED, false);
+        config(['dms.are_guest_public_search_enabled' => true]);
+
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+        
+        $response = $this->actingAs($user)->get('/search');
+
+        $response->assertStatus(403);
+    }
+
+    public function test_login_page_show_klink_search_if_enabled()
+    {
+        Option::put(Option::PUBLIC_CORE_ENABLED, true);
+        config(['dms.are_guest_public_search_enabled' => true]);
+        
+        $response = $this->get('/login');
+
+        $response->assertStatus(200);
+        $response->assertSee('name="s"');
+    }
+}

--- a/tests/Feature/KlinkGuestSearchTest.php
+++ b/tests/Feature/KlinkGuestSearchTest.php
@@ -33,8 +33,19 @@ class KlinkGuestSearchTest extends TestCase
 
     public function test_search_not_presented_on_login_page_if_klink_not_configured()
     {
-        Option::option(Option::PUBLIC_CORE_ENABLED, false);
+        Option::put(Option::PUBLIC_CORE_ENABLED, false);
         config(['dms.are_guest_public_search_enabled' => true]);
+        
+        $response = $this->get('/login');
+
+        $response->assertViewHas('show_search', false);
+        $response->assertDontSee('name="s"');
+    }
+
+    public function test_search_not_presented_on_login_page_when_klink_enabled()
+    {
+        Option::put(Option::PUBLIC_CORE_ENABLED, true);
+        config(['dms.are_guest_public_search_enabled' => false]);
         
         $response = $this->get('/login');
 


### PR DESCRIPTION
## What does this PR do?

Change the default behavior to disallow search on K-Link from not logged in users. This pull request change the default value of `are_guest_public_search_enabled` to `false`. In order to enable search on K-Link as non-authenticated user the environment variable `KBOX_ENABLE_GUEST_NETWORK_SEARCH` needs to be explicitly set to `true`.

**This can be considered a breaking change** from the deployment perspective

### Review checklist

* [x] Are unit tests required?
* [x] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)