### PR TITLE
Support Markdown format in document abstract

### DIFF
--- a/app/DocumentDescriptor.php
+++ b/app/DocumentDescriptor.php
@@ -2,6 +2,7 @@
 
 namespace KBox;
 
+use Markdown;
 use KBox\Traits\Publishable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -534,6 +535,15 @@ class DocumentDescriptor extends Model
         }
 
         return $value;
+    }
+
+    public function getAbstractHtmlAttribute($value = null)
+    {
+        if (empty($this->abstract)) {
+            return '';
+        }
+
+        return Markdown::convertToHtml($this->abstract);
     }
 
     // --- convert to/from KlinkDocumentDescriptor

--- a/resources/assets/less/partials/new/_structure.less
+++ b/resources/assets/less/partials/new/_structure.less
@@ -311,6 +311,14 @@ table {
     width: 100%;
 }
 
+.c-form__input--width-2\/3 {
+    width: 70%;
+}
+
+.c-form__input--height-3 {
+    height: 9rem;
+}
+
 .c-form__input--larger {
     min-width: 480px;
 }

--- a/resources/lang/en/documents.php
+++ b/resources/lang/en/documents.php
@@ -147,6 +147,7 @@ return [
 
         'abstract_label' => 'Abstract',
         'abstract_placeholder' => 'Document abstract',
+        'abstract_help' => '<a href="https://daringfireball.net/projects/markdown/syntax" target="_blank" rel="noopener">Markdown</a> format supported',
 
         'authors_label' => 'Authors',
         'authors_help' => 'Authors must be specified like <code>name surname &lt;mail@something.com&gt;</code>',

--- a/resources/views/documents/edit.blade.php
+++ b/resources/views/documents/edit.blade.php
@@ -121,9 +121,9 @@
 			@if( isset($errors) && $errors->has('abstract') )
 	            <span class="field-error">{{ implode(",", $errors->get('abstract'))  }}</span>
 	        @endif
-  			<textarea class="c-form__input c-form__input--larger" placeholder="{{trans('documents.edit.abstract_placeholder')}}" id="abstract" name="abstract" @if(!$document->isMine() || !$can_edit_document) disabled @endif>
+  			<textarea class="c-form__input c-form__input--width-2/3 c-form__input--height-3" placeholder="{{trans('documents.edit.abstract_placeholder')}}" id="abstract" name="abstract" @if(!$document->isMine() || !$can_edit_document) disabled @endif>
 {{old('abstract', isset($document) ? $document->abstract : '')}}</textarea>
-
+			<span class="description">{!! trans('documents.edit.abstract_help') !!}</span>
 		</div>
 		<div class="c-form__field">
   			<label for="authors">{{trans('documents.edit.authors_label')}}</label>

--- a/resources/views/documents/partials/preview_properties.blade.php
+++ b/resources/views/documents/partials/preview_properties.blade.php
@@ -39,6 +39,15 @@
 				])
 		</div>
 	@endauth
+
+	@if(!empty($document->abstract))
+
+		<div class="meta abstract">
+			<h4 class="c-panel__section">{{trans('panels.abstract_section_title')}}</h4>
+			{!! $document->abstract_html !!}
+		</div>
+
+	@endif
 	
 	@include('documents.partials.properties')
 	

--- a/resources/views/panels/document.blade.php
+++ b/resources/views/panels/document.blade.php
@@ -130,7 +130,7 @@
 
 <div class="meta abstract">
 	<h4 class="c-panel__section">{{trans('panels.abstract_section_title')}}</h4>
-	{{$item->abstract}}
+	{!! $item->abstract_html !!}
 </div>
 
 @endif


### PR DESCRIPTION
## What does this PR do?

Add document abstract rendering with Markdown. This will make sure new lines are respected and lists, bold, and various formatting options can be used. In addition the abstract field is bigger and the abstract is also presented on the preview page, inside the details

![image](https://user-images.githubusercontent.com/5672748/54841582-e1b22300-4ccf-11e9-9668-db574baf546a.png)

![image](https://user-images.githubusercontent.com/5672748/54841593-ec6cb800-4ccf-11e9-9cb5-18eedaab14d5.png)


### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)