### PR TITLE
Prevent share with link option to appear for collections

### DIFF
--- a/resources/views/share/dialog.blade.php
+++ b/resources/views/share/dialog.blade.php
@@ -52,7 +52,9 @@
 						<select name="linktype" id="linktype" class="js-link-type c-form__input c-form__input--full-width">
 
 							<option value="internal" @unless($public_link) selected @endif>{{ trans('share.dialog.linkshare_members_only') }}</option>
-							<option value="public" @if($public_link) selected @endif>{{ trans('share.dialog.linkshare_public') }}</option>
+							@unless($has_groups)
+								<option value="public" @if($public_link) selected @endif>{{ trans('share.dialog.linkshare_public') }}</option>
+							@endunless
 						
 						</select>
 

--- a/tests/SharingControllerTest.php
+++ b/tests/SharingControllerTest.php
@@ -207,7 +207,7 @@ class SharingControllerTest extends BrowserKitTestCase
         $this->visit(route('shares.create', [
             'collections' => [],
             'documents' => [$document->id]
-        ]));
+        ]))->see(trans('share.dialog.linkshare_public'));
 
         $this->assertViewHas('is_network_enabled', false);
         $this->assertViewHas('can_make_public', false);
@@ -278,7 +278,7 @@ class SharingControllerTest extends BrowserKitTestCase
         $this->visit(route('shares.create', [
             'collections' => [$collection->id],
             'documents' => [],
-        ]));
+        ]))->dontSee(trans('share.dialog.linkshare_public'));
 
         $this->assertViewHas('is_network_enabled', false);
         $this->assertViewHas('can_make_public', false);


### PR DESCRIPTION
## What does this PR do?

Exclude the "share with link" option when sharing a collection. The feature is not implemented and this bug lead users think a behavior was erroneously available

### Review checklist

* [x] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)