### PR TITLE
Fix available users list to add as members

### DIFF
--- a/app/Http/Controllers/Projects/ProjectsController.php
+++ b/app/Http/Controllers/Projects/ProjectsController.php
@@ -92,15 +92,14 @@ class ProjectsController extends Controller
 
         $current_members = $prj->users()->orderBy('name', 'ASC')->get();
 
-        $skip = $current_members->merge([$user]);
+        $skip = $current_members->merge([$prj->manager]);
 
         $available_users = $this->getAvailableUsers($skip);
 
         return view('projects.edit', [
             'pagetitle' => trans('projects.edit_page_title', ['name' => $prj->name]),
             'available_users' => $available_users,
-            'manager_id' => $user->id,
-            // 'available_users_encoded' => json_encode($available_users),
+            'manager_id' => optional($prj->manager)->id,
             'project' => $prj,
             'project_users' => $current_members,
         ]);
@@ -116,7 +115,6 @@ class ProjectsController extends Controller
             'pagetitle' => trans('projects.create_page_title'),
             'available_users' => $available_users,
             'manager_id' => $user->id,
-            // 'available_users_encoded' => json_encode($available_users)
         ]);
     }
     

--- a/config/route-permissions.php
+++ b/config/route-permissions.php
@@ -117,9 +117,9 @@ return [
         'create' => [KBox\Capability::CREATE_PROJECTS],
         'store' => [KBox\Capability::CREATE_PROJECTS],
         'show' => ['all' => KBox\Capability::$PROJECT_MANAGER_LIMITED],
-        'edit' => ['all' => KBox\Capability::$PROJECT_MANAGER_LIMITED],
-        'update' => ['all' => KBox\Capability::$PROJECT_MANAGER_LIMITED],
-        'destroy' => ['all' => KBox\Capability::$PROJECT_MANAGER_LIMITED],
+        'edit' => [KBox\Capability::CREATE_PROJECTS],
+        'update' => [KBox\Capability::CREATE_PROJECTS],
+        'destroy' => [KBox\Capability::CREATE_PROJECTS],
 
         'avatar' => [
             'index' => KBox\Capability::RECEIVE_AND_SEE_SHARE,

--- a/tests/Feature/ProjectsTest.php
+++ b/tests/Feature/ProjectsTest.php
@@ -186,6 +186,31 @@ class ProjectsTest extends TestCase
 
         $this->assertEquals($expected_available_users->pluck('id')->toArray(), $available_users->pluck('id')->toArray());
     }
+    
+    public function test_admin_should_bet_able_to_add_itself_as_project_member()
+    {
+        $project = factory(Project::class)->create();
+        
+        $user = $project->manager()->first();
+
+        $admin = $this->createUser(Capability::$ADMIN);
+
+        $expected_available_users = collect([$this->createUser(Capability::$PARTNER), $admin])->sortBy('name');
+
+        $response = $this->actingAs($admin)->get(route('projects.edit', ['id' => $project->id]));
+
+        $response->assertStatus(200);
+
+        $response->assertViewIs('projects.edit');
+
+        $response->assertViewHas('manager_id', $user->id);
+
+        $response->assertViewHas('available_users');
+
+        $available_users = $response->data('available_users');
+
+        $this->assertEquals($expected_available_users->pluck('id')->toArray(), $available_users->pluck('id')->toArray());
+    }
 
     public function test_project_is_accessible_by_user()
     {

--- a/tests/Feature/ProjectsTest.php
+++ b/tests/Feature/ProjectsTest.php
@@ -37,7 +37,7 @@ class ProjectsTest extends TestCase
             [ Capability::$PROJECT_MANAGER_LIMITED, 'projects.index', 200 ],
             [ Capability::$PROJECT_MANAGER_LIMITED, 'projects.show', 200 ],
             [ Capability::$PROJECT_MANAGER_LIMITED, 'projects.create', 403 ],
-            [ Capability::$PROJECT_MANAGER_LIMITED, 'projects.edit', 200 ],
+            [ Capability::$PROJECT_MANAGER_LIMITED, 'projects.edit', 403 ],
             [ Capability::$PROJECT_MANAGER, 'projects.index', 200 ],
             [ Capability::$PROJECT_MANAGER, 'projects.show', 200 ],
             [ Capability::$PROJECT_MANAGER, 'projects.create', 200 ],
@@ -187,7 +187,7 @@ class ProjectsTest extends TestCase
         $this->assertEquals($expected_available_users->pluck('id')->toArray(), $available_users->pluck('id')->toArray());
     }
     
-    public function test_admin_should_bet_able_to_add_itself_as_project_member()
+    public function test_admin_should_be_able_to_add_itself_as_project_member()
     {
         $project = factory(Project::class)->create();
         
@@ -210,6 +210,19 @@ class ProjectsTest extends TestCase
         $available_users = $response->data('available_users');
 
         $this->assertEquals($expected_available_users->pluck('id')->toArray(), $available_users->pluck('id')->toArray());
+    }
+    
+    public function test_other_project_manager_should_not_be_able_to_add_itself_as_project_member()
+    {
+        $project = factory(Project::class)->create();
+        
+        $user = $project->manager()->first();
+
+        $prjmanager = $this->createUser(Capability::$PROJECT_MANAGER);
+
+        $response = $this->actingAs($prjmanager)->get(route('projects.edit', ['id' => $project->id]));
+
+        $response->assertStatus(403);
     }
 
     public function test_project_is_accessible_by_user()


### PR DESCRIPTION
## What does this PR do?

Changes how the available users list for project members is populated. The current project manager is now excluded instead of the current logged in user, so an admin can add itself as a project member.

### Related issues

Fixes #211 

### Review checklist

* [x] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)