### PR TITLE
Workaround for node12 and gulp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 FROM docker.klink.asia/images/video-processing-cli:0.5.3 AS videocli
 ## .. we just need this image so we can copy from it
 
-FROM edbizarro/gitlab-ci-pipeline-php:7.1 AS builder
+FROM docker.klink.asia/main/docker-php:7.1 AS builder
 ## Installing the dependencies to be used in a later step.
 ## Will generate three directories:
 ## * /var/www/dms/bin/


### PR DESCRIPTION
## What does this PR do?

Gulp 3.9.x cannot be executed on Node 12, therefore the build step of the Docker image fails. This workaround make use of an internal build that has still NodeJS 11

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)