### PR TITLE
Open mailto link in another window

### DIFF
--- a/resources/views/share/dialog.blade.php
+++ b/resources/views/share/dialog.blade.php
@@ -28,7 +28,7 @@
 						<span class="button__content button__success">{{ trans('actions.clipboard.copied_title') }}</span>
 						<span class="button__content button__error">{{ trans('actions.clipboard.not_copied_title') }}</span>
 					</button>
-					<a class="button" title="{{ trans($elements_count == 1 ? 'share.send_link' : 'share.send_link_multiple') }}" href="mailto:?body={{ urlencode($sharing_links) }}">
+					<a class="button" title="{{ trans($elements_count == 1 ? 'share.send_link' : 'share.send_link_multiple') }}" target="_blank" rel="noopener noreferrer" href="mailto:?body={{ urlencode($sharing_links) }}">
 						@materialicon('content', 'mail', 'button__icon')
 					</a>
 


### PR DESCRIPTION
## What does this PR do?

Make the email link on the sharing dialog open in another window by default. In this way you can have GMail as `mailto` handler

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)