### PR TITLE
Handle disabled users on sharing dialog

### DIFF
--- a/resources/lang/en/notices.php
+++ b/resources/lang/en/notices.php
@@ -33,4 +33,6 @@ return [
     
     // upload blocked message for administrators
     'uploads_blocked_admin' => 'Read-only mode is active. File uploads are blocked. Please review the configuration.',
+
+    'disabled_user' => '[disabled user]',
 ];

--- a/resources/views/share/partials/shared-list-item.blade.php
+++ b/resources/views/share/partials/shared-list-item.blade.php
@@ -5,11 +5,11 @@
     <div class="shared-list__user-container">
         @unless($item->isPublicLink())
             @component('avatar.full', [
-                'image' => $item->sharedwith->avatar, 
-                'name' => $item->sharedwith->name])
+                'image' => optional($item->sharedwith)->avatar ?? null, 
+                'name' => optional($item->sharedwith)->name ?? trans('notices.disabled_user')])
 
-                {{$item->sharedwith->name}}
-                <span class="shared-list__mail">{{$item->sharedwith->email}}</span>
+                {{optional($item->sharedwith)->name}}
+                <span class="shared-list__mail">{{optional($item->sharedwith)->email ?? trans('notices.disabled_user')}}</span>
 
             @endcomponent
 


### PR DESCRIPTION
## What does this PR do?

Ensure that the sharing dialog can be opened if the document/collection was shared to a user that has been disabled.

For a disabled user we cannot get name and email, therefore we decided to show the label `[disabled user]`

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)