### PR TITLE
Add readonly mode

### DIFF
--- a/app/Console/Commands/ActivateReadonlyModeCommand.php
+++ b/app/Console/Commands/ActivateReadonlyModeCommand.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace KBox\Console\Commands;
+
+use KBox\Services\ReadonlyMode;
+use Illuminate\Console\Command;
+use Illuminate\Support\InteractsWithTime;
+
+class ActivateReadonlyModeCommand extends Command
+{
+    use InteractsWithTime;
+    
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'readonly:up {--message= : The message for the readonly mode}
+                                        {--retry= : The number of seconds after which the request may be retried}
+                                        {--allow=* : IP or networks allowed to access the application while in readonly mode}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Put the application into readonly mode';
+
+    /**
+     * @var \KBox\Services\ReadonlyMode
+     */
+    private $readonly = null;
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct(ReadonlyMode $service)
+    {
+        parent::__construct();
+
+        $this->readonly = $service;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->readonly->activate($this->getReadonlyConfiguration());
+
+        $this->comment('Application is now in readonly mode.');
+    }
+
+    /**
+     * Get the readonly mode configuration.
+     *
+     * @return array
+     */
+    protected function getReadonlyConfiguration()
+    {
+        return [
+            'time' => $this->currentTime(),
+            'message' => $this->option('message'),
+            'retry' => $this->getRetryTime(),
+            'allowed' => $this->option('allow'),
+        ];
+    }
+
+    /**
+     * Get the number of seconds the client should wait before retrying their request.
+     *
+     * @return int|null
+     */
+    protected function getRetryTime()
+    {
+        $retry = $this->option('retry');
+
+        return is_numeric($retry) && $retry > 0 ? (int) $retry : null;
+    }
+}

--- a/app/Console/Commands/DeactivateReadonlyModeCommand.php
+++ b/app/Console/Commands/DeactivateReadonlyModeCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace KBox\Console\Commands;
+
+use KBox\Services\ReadonlyMode;
+use Illuminate\Console\Command;
+
+class DeactivateReadonlyModeCommand extends Command
+{
+    
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'readonly:down';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Disable the readonly mode and make the application accepting changes';
+
+    /**
+     * @var \KBox\Services\ReadonlyMode
+     */
+    private $readonly = null;
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct(ReadonlyMode $service)
+    {
+        parent::__construct();
+
+        $this->readonly = $service;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->readonly->deactivate();
+
+        $this->comment('Application is now live.');
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -39,6 +39,8 @@ class Kernel extends ConsoleKernel
         \KBox\Console\Commands\StatisticsCommand::class,
         \KBox\Console\Commands\PrivacyLoadCommand::class,
         \KBox\Console\Commands\TermsLoadCommand::class,
+        \KBox\Console\Commands\ActivateReadonlyModeCommand::class,
+        \KBox\Console\Commands\DeactivateReadonlyModeCommand::class,
     ];
 
     /**

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -5,7 +5,6 @@ namespace KBox\Exceptions;
 use Exception;
 use ErrorException;
 use Illuminate\Http\JsonResponse;
-use KBox\Exceptions\ReadonlyModeException;
 use GuzzleHttp\Exception\TransferException;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Session\TokenMismatchException;
@@ -125,7 +124,7 @@ class Handler extends ExceptionHandler
                     ], $e->getStatusCode());
             }
             
-            return response()->make(view('errors.503-readonly', ['reason' => 'ReadonlyModeException ' . $e->getMessage()]), $e->getStatusCode());
+            return response()->make(view('errors.503-readonly', ['reason' => 'ReadonlyModeException '.$e->getMessage()]), $e->getStatusCode());
         }
 
         // if($e instanceof HttpResponseException)

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -5,6 +5,7 @@ namespace KBox\Exceptions;
 use Exception;
 use ErrorException;
 use Illuminate\Http\JsonResponse;
+use KBox\Exceptions\ReadonlyModeException;
 use GuzzleHttp\Exception\TransferException;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Session\TokenMismatchException;
@@ -112,6 +113,19 @@ class Handler extends ExceptionHandler
             }
 
             return trans('errors.413_text');
+        }
+        
+        if ($e instanceof ReadonlyModeException) {
+            if ($request->expectsJson()) {
+                return response()->json([
+                        'error' => $e->getMessage() ?? trans('errors.503-readonly_text'),
+                        'wentDownAt' => $e->wentDownAt,
+                        'retryAfter' => $e->retryAfter,
+                        'willBeAvailableAt' => $e->willBeAvailableAt,
+                    ], $e->getStatusCode());
+            }
+            
+            return response()->make(view('errors.503-readonly', ['reason' => 'ReadonlyModeException ' . $e->getMessage()]), $e->getStatusCode());
         }
 
         // if($e instanceof HttpResponseException)

--- a/app/Exceptions/ReadonlyModeException.php
+++ b/app/Exceptions/ReadonlyModeException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace KBox\Exceptions;
+
+use Exception;
+use Illuminate\Foundation\Http\Exceptions\MaintenanceModeException;
+
+class ReadonlyModeException extends MaintenanceModeException
+{
+    /**
+     * Create a new exception instance.
+     *
+     * @param  int  $time
+     * @param  int  $retryAfter
+     * @param  string  $message
+     * @param  \Exception  $previous
+     * @param  int  $code
+     * @return void
+     */
+    public function __construct($time, $retryAfter = null, $message = null, Exception $previous = null, $code = 0)
+    {
+        parent::__construct($time, $retryAfter, $message ?? trans('errors.503-readonly_text'), $previous, $code);
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -14,6 +14,7 @@ class Kernel extends HttpKernel
      */
     protected $middleware = [
         \KBox\Http\Middleware\CheckForMaintenanceMode::class,
+        \KBox\Http\Middleware\CheckForReadonlyMode::class,
         \KBox\Http\Middleware\TrustedProxyMiddleware::class,
         \KBox\Http\Middleware\PortRedirectMiddleware::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,

--- a/app/Http/Middleware/CheckForReadonlyMode.php
+++ b/app/Http/Middleware/CheckForReadonlyMode.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace KBox\Http\Middleware;
+
+use Closure;
+use KBox\Services\ReadonlyMode;
+use Symfony\Component\HttpFoundation\IpUtils;
+use Illuminate\Foundation\Http\Exceptions\MaintenanceModeException;
+
+class CheckForReadonlyMode
+{
+    /**
+     * The application implementation.
+     *
+     * @var \KBox\Services\ReadonlyMode
+     */
+    protected $readonlyModeService;
+
+    /**
+     * The URIs that should be accessible while readonly mode is enabled.
+     *
+     * Default URIs include: login, logout, password reset
+     * and administration
+     *
+     * @var array
+     */
+    protected $except = [
+        'login',
+        'logout',
+        'administration/*',
+        'password/*',
+    ];
+
+    protected $blockedMethods = [
+        'POST',
+        'PUT',
+        'DELETE',
+    ];
+
+    /**
+     * Create a new middleware instance.
+     *
+     * @param  \KBox\Services\ReadonlyMode  $readonlyModeService
+     * @return void
+     */
+    public function __construct(ReadonlyMode $readonlyModeService)
+    {
+        $this->readonlyModeService = $readonlyModeService;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+     */
+    public function handle($request, Closure $next)
+    {
+        if ($this->readonlyModeService->isReadonlyActive()) {
+            if (! in_array($request->method(), $this->blockedMethods)) {
+                return $next($request);
+            }
+
+            $data = $this->readonlyModeService->getReadonlyConfiguration();
+
+            if (isset($data['allowed']) && IpUtils::checkIp($request->ip(), (array) $data['allowed'])) {
+                return $next($request);
+            }
+
+            if ($this->inExceptArray($request)) {
+                return $next($request);
+            }
+
+            throw new MaintenanceModeException($data['time'], $data['retry'], $data['message']);
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * Determine if the request has a URI that should be accessible in maintenance mode.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    protected function inExceptArray($request)
+    {
+        foreach ($this->except as $except) {
+            if ($except !== '/') {
+                $except = trim($except, '/');
+            }
+
+            if ($request->fullUrlIs($except) || $request->is($except)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/app/Http/Middleware/CheckForReadonlyMode.php
+++ b/app/Http/Middleware/CheckForReadonlyMode.php
@@ -5,7 +5,7 @@ namespace KBox\Http\Middleware;
 use Closure;
 use KBox\Services\ReadonlyMode;
 use Symfony\Component\HttpFoundation\IpUtils;
-use Illuminate\Foundation\Http\Exceptions\MaintenanceModeException;
+use KBox\Exceptions\ReadonlyModeException;
 
 class CheckForReadonlyMode
 {
@@ -29,6 +29,7 @@ class CheckForReadonlyMode
         'logout',
         'administration/*',
         'password/*',
+        'consent/*',
     ];
 
     protected $blockedMethods = [
@@ -74,7 +75,7 @@ class CheckForReadonlyMode
                 return $next($request);
             }
 
-            throw new MaintenanceModeException($data['time'], $data['retry'], $data['message']);
+            throw new ReadonlyModeException($data['time'], $data['retry'], $data['message']);
         }
 
         return $next($request);

--- a/app/Services/ReadonlyMode.php
+++ b/app/Services/ReadonlyMode.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace KBox\Services;
+
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\InteractsWithTime;
+
+class ReadonlyMode
+{
+    use InteractsWithTime;
+
+    /**
+     * Get the path of the local storage
+     *
+     * @return string
+     */
+    protected function storagePath()
+    {
+        return storage_path('');
+    }
+    
+    /**
+     * Get the path of the readonly file that
+     * contains the configuration for
+     * activating the readonly mode
+     *
+     * @return string
+     */
+    public function readonlyPath()
+    {
+        return $this->storagePath().'/framework/readonly';
+    }
+
+    /**
+     * Check if the readonly mode is active
+     *
+     * @return boolean
+     */
+    public function isReadonlyActive()
+    {
+        return file_exists($this->readonlyPath());
+    }
+       
+    /**
+     * Activate the readonly mode
+     *
+     * @return ReadonlyMode
+     */
+    public function activate($config = [])
+    {
+        $data = array_merge([
+            'time' => $this->currentTime(),
+            'retry' => 86400,
+            'message' => 'This application is in readonly mode.',
+        ], $config);
+    
+        file_put_contents($this->readonlyPath(), json_encode($data, JSON_PRETTY_PRINT));
+    
+        return $this;
+    }
+
+    /**
+     * Deactivate the readonly mode
+     *
+     * @return ReadonlyMode
+     */
+    public function deactivate()
+    {
+        if ($this->isReadonlyActive()) {
+            unlink($this->readonlyPath());
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get the readonly mode configuration
+     *
+     * @return array
+     */
+    public function getReadonlyConfiguration()
+    {
+        return json_decode(file_get_contents($this->readonlyPath()), true);
+    }
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,6 +1,7 @@
 <?php
 
 use KBox\Plugins\PluginManager;
+use KBox\Services\ReadonlyMode;
 
 if (! function_exists('css_asset')) {
     /**
@@ -281,5 +282,17 @@ if (! function_exists('plugins')) {
         }
 
         return app(PluginManager::class)->isEnabled($plugin);
+    }
+}
+
+if (! function_exists('is_readonly')) {
+    /**
+     * Check if application is in readonly mode.
+     *
+     * @return bool
+     */
+    function is_readonly()
+    {
+        return app(ReadonlyMode::class)->isReadonlyActive();
     }
 }

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -68,6 +68,9 @@ return [
 
     '503_title' => 'K-Box Maintenance',
     '503_text' => 'The <strong>K-Box</strong> is currently in<br/><strong>maintenance.</strong><br/><small> Will be back shortly :)</small>',
+    
+    '503-readonly_title' => 'K-Box is Readonly',
+    '503-readonly_text' => 'The <strong>K-Box</strong> is currently in <strong>readonly mode.</strong><br/><small> For maintenance reasons you cannot change or update content.</small>',
 
     '500_title' => 'Error - K-Box',
     '500_text' => 'Something <strong>bad</strong><br/>and unexpected <strong>has happened</strong>. <br/>We are deeply sorry.',

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -70,7 +70,7 @@ return [
     '503_text' => 'The <strong>K-Box</strong> is currently in<br/><strong>maintenance.</strong><br/><small> Will be back shortly :)</small>',
     
     '503-readonly_title' => 'K-Box is Readonly',
-    '503-readonly_text' => 'The <strong>K-Box</strong> is currently in <strong>readonly mode.</strong><br/><small> For maintenance reasons you cannot change or update content.</small>',
+    '503-readonly_text' => 'The <strong>K-Box</strong> is currently in <strong>readonly mode.</strong><br/><small> For maintenance reasons you cannot change or upload content.</small>',
 
     '500_title' => 'Error - K-Box',
     '500_text' => 'Something <strong>bad</strong><br/>and unexpected <strong>has happened</strong>. <br/>We are deeply sorry.',

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -70,7 +70,8 @@ return [
     '503_text' => 'The <strong>K-Box</strong> is currently in<br/><strong>maintenance.</strong><br/><small> Will be back shortly :)</small>',
     
     '503-readonly_title' => 'K-Box is Readonly',
-    '503-readonly_text' => 'The <strong>K-Box</strong> is currently in <strong>readonly mode.</strong><br/><small> For maintenance reasons you cannot change or upload content.</small>',
+    '503-readonly_text_styled' => 'The <strong>K-Box</strong> is currently in <strong>readonly mode.</strong><br/><small> For maintenance reasons you cannot change or upload content.</small>',
+    '503-readonly_text' => 'The K-Box is currently in readonly mode. For maintenance reasons you cannot change or upload content.',
 
     '500_title' => 'Error - K-Box',
     '500_text' => 'Something <strong>bad</strong><br/>and unexpected <strong>has happened</strong>. <br/>We are deeply sorry.',

--- a/resources/views/errors/503-readonly.blade.php
+++ b/resources/views/errors/503-readonly.blade.php
@@ -1,0 +1,14 @@
+@extends('errors.http-error')
+
+@section('title')
+
+	{{trans('errors.503-readonly_title')}}
+
+@stop
+
+
+@section('content')
+
+	{!!trans('errors.503-readonly_text')!!}
+    
+@stop

--- a/resources/views/errors/503-readonly.blade.php
+++ b/resources/views/errors/503-readonly.blade.php
@@ -9,6 +9,6 @@
 
 @section('content')
 
-	{!!trans('errors.503-readonly_text')!!}
+	{!!trans('errors.503-readonly_text_styled')!!}
     
 @stop

--- a/resources/views/headers/header.blade.php
+++ b/resources/views/headers/header.blade.php
@@ -15,6 +15,12 @@
 
 		</div>
 
+		@if(is_readonly())
+			<div class="c-message c-message--warning" style="flex-grow:0;padding:0 4px;margin:0;">
+				{!!trans('errors.503-readonly_text')!!}
+			</div>
+		@endif
+
 		@if( auth()->check() )
 
 			<div class="header__navigation">

--- a/resources/views/headers/header.blade.php
+++ b/resources/views/headers/header.blade.php
@@ -17,7 +17,7 @@
 
 		@if(is_readonly())
 			<div class="c-message c-message--warning" style="flex-grow:0;padding:0 4px;margin:0;">
-				{!!trans('errors.503-readonly_text')!!}
+				{!!trans('errors.503-readonly_text_styled')!!}
 			</div>
 		@endif
 

--- a/tests/Unit/ActivateReadonlyModeCommandTest.php
+++ b/tests/Unit/ActivateReadonlyModeCommandTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Tests\Unit;
+
+use Mockery as m;
+use Tests\TestCase;
+use KBox\Services\ReadonlyMode;
+use Illuminate\Filesystem\Filesystem;
+
+class ActivateReadonlyModeCommandTest extends TestCase
+{
+
+    /**
+     * @var string
+     */
+    protected $storagePath;
+
+    /**
+     * @var string
+     */
+    protected $readonlyFilePath;
+
+    /**
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $files;
+    
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (is_null($this->files)) {
+            $this->files = new Filesystem;
+        }
+
+        $this->storagePath = __DIR__.'/tmp';
+
+        $this->readonlyFilePath = $this->storagePath.'/framework/readonly';
+        $this->files->makeDirectory($this->storagePath.'/framework', 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->files->deleteDirectory($this->storagePath);
+
+        m::close();
+    }
+
+    public function test_activate_readonly_mode()
+    {
+        $service = $this->createReadonlyModeService();
+
+        $this->artisan("readonly:up")
+            ->expectsOutput('Application is now in readonly mode.')
+            ->assertExitCode(0);
+
+        $this->assertFileExists($this->readonlyFilePath);
+        $this->assertTrue($service->isReadonlyActive());
+        $config = $service->getReadonlyConfiguration();
+        $this->assertArrayHasKey('time', $config);
+        $this->assertArrayHasKey('message', $config);
+        $this->assertArrayHasKey('retry', $config);
+        $this->assertArrayHasKey('allowed', $config);
+    }
+
+    public function test_activate_readonly_mode_with_custom_message()
+    {
+        $service = $this->createReadonlyModeService();
+
+        $this->artisan("readonly:up", [
+                '--message' => 'A new message'
+            ])
+            ->expectsOutput('Application is now in readonly mode.')
+            ->assertExitCode(0);
+        
+        $config = $service->getReadonlyConfiguration();
+        $this->assertEquals('A new message', $config['message']);
+    }
+
+    public function test_activate_readonly_mode_with_custom_retry()
+    {
+        $service = $this->createReadonlyModeService();
+
+        $this->artisan("readonly:up", [
+                '--retry' => 600
+            ])
+            ->expectsOutput('Application is now in readonly mode.')
+            ->assertExitCode(0);
+        
+        $config = $service->getReadonlyConfiguration();
+        $this->assertEquals(600, $config['retry']);
+    }
+
+    public function test_activate_readonly_mode_with_custom_allow()
+    {
+        $service = $this->createReadonlyModeService();
+
+        $this->artisan("readonly:up", [
+                '--allow' => "127.0.0.1"
+            ])
+            ->expectsOutput('Application is now in readonly mode.')
+            ->assertExitCode(0);
+        
+        $config = $service->getReadonlyConfiguration();
+        $this->assertEquals("127.0.0.1", $config['allowed']);
+    }
+    
+    protected function createReadonlyModeService()
+    {
+        $fake = m::mock(ReadonlyMode::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        
+        $fake->shouldReceive('storagePath')->andReturn($this->storagePath);
+
+        $this->swap(ReadonlyMode::class, $fake);
+
+        return $fake;
+    }
+
+    /**
+     * Make a readonly file with the given allowed ips.
+     *
+     * @param  string|array  $ips
+     * @return array
+     */
+    protected function makeReadonlyFile($ips = null)
+    {
+        $data = [
+            'time' => time(),
+            'retry' => 86400,
+            'message' => 'This application is in readonly mode.',
+        ];
+
+        if ($ips !== null) {
+            $data['allowed'] = $ips;
+        }
+
+        $this->files->put($this->readonlyFilePath, json_encode($data, JSON_PRETTY_PRINT));
+
+        return $data;
+    }
+}

--- a/tests/Unit/DeactivateReadonlyModeCommandTest.php
+++ b/tests/Unit/DeactivateReadonlyModeCommandTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Unit;
+
+use Mockery as m;
+use Tests\TestCase;
+use KBox\Services\ReadonlyMode;
+use Illuminate\Filesystem\Filesystem;
+
+class DeactivateReadonlyModeCommandTest extends TestCase
+{
+
+    /**
+     * @var string
+     */
+    protected $storagePath;
+
+    /**
+     * @var string
+     */
+    protected $readonlyFilePath;
+
+    /**
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $files;
+    
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (is_null($this->files)) {
+            $this->files = new Filesystem;
+        }
+
+        $this->storagePath = __DIR__.'/tmp';
+
+        $this->readonlyFilePath = $this->storagePath.'/framework/readonly';
+        $this->files->makeDirectory($this->storagePath.'/framework', 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->files->deleteDirectory($this->storagePath);
+
+        m::close();
+    }
+
+    public function test_deactivate_readonly_mode()
+    {
+        $service = $this->createReadonlyModeService();
+
+        $this->artisan("readonly:down")
+            ->expectsOutput('Application is now live.')
+            ->assertExitCode(0);
+
+        $this->assertFileNotExists($this->readonlyFilePath);
+        $this->assertFalse($service->isReadonlyActive());
+    }
+
+    protected function createReadonlyModeService()
+    {
+        $this->makeReadonlyFile();
+
+        $fake = m::mock(ReadonlyMode::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        
+        $fake->shouldReceive('storagePath')->andReturn($this->storagePath);
+
+        $this->swap(ReadonlyMode::class, $fake);
+
+        return $fake;
+    }
+
+    /**
+     * Make a readonly file with the given allowed ips.
+     *
+     * @param  string|array  $ips
+     * @return array
+     */
+    protected function makeReadonlyFile($ips = null)
+    {
+        $data = [
+            'time' => time(),
+            'retry' => 86400,
+            'message' => 'This application is in readonly mode.',
+        ];
+
+        if ($ips !== null) {
+            $data['allowed'] = $ips;
+        }
+
+        $this->files->put($this->readonlyFilePath, json_encode($data, JSON_PRETTY_PRINT));
+
+        return $data;
+    }
+}

--- a/tests/Unit/ReadonlyModeMiddlewareTest.php
+++ b/tests/Unit/ReadonlyModeMiddlewareTest.php
@@ -7,8 +7,8 @@ use Tests\TestCase;
 use Illuminate\Http\Request;
 use KBox\Services\ReadonlyMode;
 use Illuminate\Filesystem\Filesystem;
+use KBox\Exceptions\ReadonlyModeException;
 use KBox\Http\Middleware\CheckForReadonlyMode;
-use Illuminate\Foundation\Http\Exceptions\MaintenanceModeException;
 
 class ReadonlyModeMiddlewareTest extends TestCase
 {
@@ -66,7 +66,7 @@ class ReadonlyModeMiddlewareTest extends TestCase
     {
         $service = $this->createReadonlyModeService();
 
-        $this->expectException(MaintenanceModeException::class);
+        $this->expectException(ReadonlyModeException::class);
         $this->expectExceptionMessage('This application is in readonly mode.');
 
         $middleware = new CheckForReadonlyMode($service);
@@ -79,7 +79,7 @@ class ReadonlyModeMiddlewareTest extends TestCase
     {
         $service = $this->createReadonlyModeService();
 
-        $this->expectException(MaintenanceModeException::class);
+        $this->expectException(ReadonlyModeException::class);
         $this->expectExceptionMessage('This application is in readonly mode.');
 
         $middleware = new CheckForReadonlyMode($service);
@@ -92,7 +92,7 @@ class ReadonlyModeMiddlewareTest extends TestCase
     {
         $service = $this->createReadonlyModeService();
 
-        $this->expectException(MaintenanceModeException::class);
+        $this->expectException(ReadonlyModeException::class);
         $this->expectExceptionMessage('This application is in readonly mode.');
 
         $middleware = new CheckForReadonlyMode($service);

--- a/tests/Unit/ReadonlyModeMiddlewareTest.php
+++ b/tests/Unit/ReadonlyModeMiddlewareTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Tests\Unit;
+
+use Mockery as m;
+use Tests\TestCase;
+use Illuminate\Http\Request;
+use KBox\Services\ReadonlyMode;
+use Illuminate\Filesystem\Filesystem;
+use KBox\Http\Middleware\CheckForReadonlyMode;
+use Illuminate\Foundation\Http\Exceptions\MaintenanceModeException;
+
+class ReadonlyModeMiddlewareTest extends TestCase
+{
+
+    /**
+     * @var string
+     */
+    protected $storagePath;
+
+    /**
+     * @var string
+     */
+    protected $readonlyFilePath;
+
+    /**
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $files;
+    
+    protected function setUp(): void
+    {
+        if (is_null($this->files)) {
+            $this->files = new Filesystem;
+        }
+
+        $this->storagePath = __DIR__.'/tmp';
+
+        $this->readonlyFilePath = $this->storagePath.'/framework/readonly';
+        $this->files->makeDirectory($this->storagePath.'/framework', 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->files->deleteDirectory($this->storagePath);
+
+        m::close();
+    }
+
+    public function test_application_is_running_normally()
+    {
+        $service = m::mock(ReadonlyMode::class);
+
+        $service->shouldReceive('isReadonlyActive')->once()->andReturn(false);
+
+        $middleware = new CheckForReadonlyMode($service);
+
+        $result = $middleware->handle(Request::create('/', 'POST'), function ($request) {
+            return 'Running normally.';
+        });
+
+        $this->assertSame('Running normally.', $result);
+    }
+
+    public function test_post_requests_are_blocked_in_readonly_mode()
+    {
+        $service = $this->createReadonlyModeService();
+
+        $this->expectException(MaintenanceModeException::class);
+        $this->expectExceptionMessage('This application is in readonly mode.');
+
+        $middleware = new CheckForReadonlyMode($service);
+
+        $result = $middleware->handle(Request::create('/', 'POST'), function ($request) {
+        });
+    }
+    
+    public function test_put_requests_are_blocked_in_readonly_mode()
+    {
+        $service = $this->createReadonlyModeService();
+
+        $this->expectException(MaintenanceModeException::class);
+        $this->expectExceptionMessage('This application is in readonly mode.');
+
+        $middleware = new CheckForReadonlyMode($service);
+
+        $result = $middleware->handle(Request::create('/', 'PUT'), function ($request) {
+        });
+    }
+    
+    public function test_delete_requests_are_blocked_in_readonly_mode()
+    {
+        $service = $this->createReadonlyModeService();
+
+        $this->expectException(MaintenanceModeException::class);
+        $this->expectExceptionMessage('This application is in readonly mode.');
+
+        $middleware = new CheckForReadonlyMode($service);
+
+        $result = $middleware->handle(Request::create('/', 'DELETE'), function ($request) {
+        });
+    }
+    
+    public function test_get_requests_are_not_blocked_in_readonly_mode()
+    {
+        $service = $this->createReadonlyModeService();
+
+        $middleware = new CheckForReadonlyMode($service);
+
+        $result = $middleware->handle(Request::create('/'), function ($request) {
+            return 'Running normally.';
+        });
+
+        $this->assertSame('Running normally.', $result);
+    }
+
+    public function test_application_allows_some_URIs()
+    {
+        $service = $this->createReadonlyModeService();
+
+        $middleware = new class($service) extends CheckForReadonlyMode {
+            public function __construct($service)
+            {
+                parent::__construct($service);
+                $this->except = ['foo/*'];
+            }
+        };
+
+        $result = $middleware->handle(Request::create('/foo/bar', 'POST'), function ($request) {
+            return 'Excepting /foo/bar';
+        });
+
+        $this->assertSame('Excepting /foo/bar', $result);
+    }
+
+    protected function createReadonlyModeService($ips = null)
+    {
+        $this->makeReadonlyFile($ips);
+
+        $readonlyModeService = m::mock(ReadonlyMode::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        
+        $readonlyModeService->shouldReceive('storagePath')->andReturn($this->storagePath);
+
+        return $readonlyModeService;
+    }
+
+    /**
+     * Make a readonly file with the given allowed ips.
+     *
+     * @param  string|array  $ips
+     * @return array
+     */
+    protected function makeReadonlyFile($ips = null)
+    {
+        $data = [
+            'time' => time(),
+            'retry' => 86400,
+            'message' => 'This application is in readonly mode.',
+        ];
+
+        if ($ips !== null) {
+            $data['allowed'] = $ips;
+        }
+
+        $this->files->put($this->readonlyFilePath, json_encode($data, JSON_PRETTY_PRINT));
+
+        return $data;
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Add a new maintenance mode, called "readonly" mode, in which edit, delete and upload actions are denied. This is useful in case re-index of documents should occur, but viewing the documents should not be affected.

### Review checklist

* [x] Are unit tests required?
* [x] Are Documentation changes needed?

**Before merging**

* [x] Is history cleaned up? (or can be squashed on merge?)