### PR TITLE
Remove klink.asia as default contact information

### DIFF
--- a/resources/views/static/contact.blade.php
+++ b/resources/views/static/contact.blade.php
@@ -50,21 +50,6 @@
 
             </div>
 
-        @else 
-            <div class="contact__image" style="background-image:url('https://build.klink.asia/klink_logo_slide_alternate.png')"></div>
-
-            <div class="contact__card">
-                <h3>K-Link</h3>
-
-                <div class="mail">
-                    <span class="icon-content-black icon-content-black-ic_mail_black_24dp"></span> <span itemprop="email">info@klink.asia</span>
-                </div>
-
-                <div class="website">
-                    <span class="icon-action-black icon-action-black-ic_language_black_24dp"></span> <a href="https://klink.asia">https://klink.asia</a>
-                </div>
-            </div>
-
         @endif
 
   </div>

--- a/tests/Feature/ContactPageControllerTest.php
+++ b/tests/Feature/ContactPageControllerTest.php
@@ -19,9 +19,8 @@ class ContactPageControllerTest extends TestCase
 
         $response->assertViewIs('static.contact');
 
-        $response->assertSee('K-Link');
-        $response->assertSee('info@klink.asia');
-        $response->assertSee('https://klink.asia');
+        $response->assertDontSee('info@klink.asia');
+        $response->assertDontSee('https://klink.asia');
     }
     
     public function testContactPageShowsSavedContactInfo()


### PR DESCRIPTION
## What does this PR do?

Removes the default hard-coded contact information from the contacts page if nothing is configured

### Related issues

Fixes ...

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)