### PR TITLE
Improve support configuration

### DIFF
--- a/app/Http/Controllers/Administration/SettingsAdministrationController.php
+++ b/app/Http/Controllers/Administration/SettingsAdministrationController.php
@@ -48,7 +48,6 @@ class SettingsAdministrationController extends Controller
         Option::PUBLIC_CORE_NETWORK_NAME_EN => Option::option(Option::PUBLIC_CORE_NETWORK_NAME_EN, ''),
         Option::PUBLIC_CORE_NETWORK_NAME_RU => Option::option(Option::PUBLIC_CORE_NETWORK_NAME_RU, ''),
         Option::STREAMING_SERVICE_URL => Option::option(Option::STREAMING_SERVICE_URL, ''),
-        Option::SUPPORT_TOKEN => support_token(),
         ];
 
         return view('administration.settings.index', $data);
@@ -57,14 +56,6 @@ class SettingsAdministrationController extends Controller
     public function store(AuthGuard $auth, SettingsSaveRequest $request)
     {
         try {
-            if ($request->input('support-settings-save-btn', false) !== false) {
-                if ($request->has(Option::SUPPORT_TOKEN) && ! empty($request->input(Option::SUPPORT_TOKEN, null))) {
-                    Option::put(Option::SUPPORT_TOKEN, $request->input(Option::SUPPORT_TOKEN, null));
-                } else {
-                    // disable it
-                    Option::put(Option::SUPPORT_TOKEN, '');
-                }
-            }
 
             if ($request->input('public-settings-save-btn', false) !== false) {
                 if ($request->has(Option::PUBLIC_CORE_URL) &&

--- a/app/Http/Controllers/Administration/SettingsAdministrationController.php
+++ b/app/Http/Controllers/Administration/SettingsAdministrationController.php
@@ -56,7 +56,6 @@ class SettingsAdministrationController extends Controller
     public function store(AuthGuard $auth, SettingsSaveRequest $request)
     {
         try {
-
             if ($request->input('public-settings-save-btn', false) !== false) {
                 if ($request->has(Option::PUBLIC_CORE_URL) &&
                     $request->input(Option::PUBLIC_CORE_PASSWORD)) {

--- a/app/Http/Controllers/Administration/SupportController.php
+++ b/app/Http/Controllers/Administration/SupportController.php
@@ -5,7 +5,6 @@ namespace KBox\Http\Controllers\Administration;
 use Log;
 use Exception;
 use KBox\Option;
-use Illuminate\Support\Str;
 use KBox\Support\SupportService;
 use KBox\Http\Controllers\Controller;
 use KBox\Http\Requests\AnalyticsSaveRequest;
@@ -39,7 +38,6 @@ class SupportController extends Controller
     public function update(AuthGuard $auth, AnalyticsSaveRequest $request)
     {
         try {
-
             $validatedData = $request->validate([
                 SupportService::SUPPORT_TOKEN => 'nullable|sometimes|string',
             ]);

--- a/app/Http/Controllers/Administration/SupportController.php
+++ b/app/Http/Controllers/Administration/SupportController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace KBox\Http\Controllers\Administration;
+
+use Log;
+use Exception;
+use KBox\Option;
+use Illuminate\Support\Str;
+use KBox\Support\SupportService;
+use KBox\Http\Controllers\Controller;
+use KBox\Http\Requests\AnalyticsSaveRequest;
+use Illuminate\Contracts\Auth\Guard as AuthGuard;
+
+class SupportController extends Controller
+{
+
+    /**
+     * Create a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->middleware('auth');
+
+        $this->middleware('capabilities');
+    }
+  
+    public function index(AuthGuard $auth)
+    {
+        $data = [
+            'pagetitle' => trans('administration.menu.support'),
+            SupportService::SUPPORT_TOKEN => SupportService::token(),
+        ];
+
+        return view('administration.support.index', $data);
+    }
+  
+    public function update(AuthGuard $auth, AnalyticsSaveRequest $request)
+    {
+        try {
+
+            $validatedData = $request->validate([
+                SupportService::SUPPORT_TOKEN => 'nullable|sometimes|string',
+            ]);
+
+            if ($request->has(SupportService::SUPPORT_TOKEN) && ! empty($request->input(SupportService::SUPPORT_TOKEN, null))) {
+                Option::put(SupportService::SUPPORT_TOKEN, e($request->input(SupportService::SUPPORT_TOKEN, null)));
+                Option::put(SupportService::SUPPORT_SERVICE, 'uservoice');
+            } else {
+                // disable it
+                Option::remove(SupportService::SUPPORT_TOKEN);
+                Option::remove(SupportService::SUPPORT_SERVICE);
+            }
+            
+            return redirect()->route('administration.support.index')->with([
+              'flash_message' => trans('administration.support.saved')
+            ]);
+        } catch (Exception $ex) {
+            Log::error('Support settings save error', ['error' => $ex, 'request' => $request->all()]);
+        
+            return redirect()->back()->withInput()->withErrors([
+              'error' => trans('administration.support.save_error', ['error' => $ex->getMessage()])
+            ]);
+        }
+    }
+}

--- a/app/Http/Requests/SettingsSaveRequest.php
+++ b/app/Http/Requests/SettingsSaveRequest.php
@@ -30,7 +30,6 @@ class SettingsSaveRequest extends Request
             'public_core_password' => 'nullable|sometimes|required_with:public_core_url|string',
             'public_core_network_name_en' => 'nullable|sometimes|string',
             'public_core_network_name_ru' => 'nullable|sometimes|string',
-            'support_token' => 'nullable|sometimes|string',
             'streaming_service_url' => 'nullable|sometimes|string|url',
         ];
     }

--- a/app/Option.php
+++ b/app/Option.php
@@ -45,11 +45,6 @@ class Option extends Model
     const STREAMING_SERVICE_URL = 'streaming_service_url';
     
     /**
-     * The option that stores the key for the UserVoice support service
-     */
-    const SUPPORT_TOKEN = 'support_token';
-    
-    /**
      * The option that stores the default copyright usage license
      */
     const COPYRIGHT_DEFAULT_LICENSE = 'copyright_default_license';
@@ -196,25 +191,7 @@ class Option extends Model
     
     // convenience methods for known options
     
-    /**
-     * Get the support service access token.
-     *
-     * First the static configuration is checked, then the stored options will be checked
-     *
-     * @return string|boolean the support ticket integration token if configured, false if not configured
-     */
-    public static function support_token()
-    {
-        $conf = config("dms.support_token");
-        
-        if (is_null($conf)) {
-            $opt = static::option(static::SUPPORT_TOKEN, false);
-            
-            return empty($opt) ? false : $opt;
-        }
-        
-        return $conf;
-    }
+    
 
     /**
      *

--- a/app/Option.php
+++ b/app/Option.php
@@ -191,8 +191,6 @@ class Option extends Model
     
     // convenience methods for known options
     
-    
-
     /**
      *
      * @return bool true if mail service is usable, false otherwise

--- a/app/Support/SupportService.php
+++ b/app/Support/SupportService.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace KBox\Support;
+
+use KBox\User;
+use KBox\Option;
+
+class SupportService
+{
+    /**
+     * The option that stores the key for the UserVoice support service
+     */
+    const SUPPORT_TOKEN = 'support_token';
+    
+    /**
+     * The option that stores the current analytics service
+     */
+    const SUPPORT_SERVICE = 'support_service';
+    
+    /**
+     * Get the support service access token.
+     *
+     * First the stored option is checked, then the static deploy configuration
+     *
+     * @return string|null the support ticket integration token if configured, null otherwise
+     */
+    public static function token()
+    {
+        $conf = static::service();
+
+        return Option::option(static::SUPPORT_TOKEN, null) ?? $conf['token'] ?? null;
+    }
+    
+    /**
+     * Retrieve the current analytics service settings
+     *
+     * @return array
+     */
+    protected static function service()
+    {
+        $activeService = self::serviceName();
+
+        return config('support.providers.'.$activeService) ?? [];
+    }
+    
+    /**
+     * Retrieve the current analytics service settings
+     *
+     * @return array
+     */
+    public static function serviceName()
+    {
+        return Option::option(static::SUPPORT_SERVICE, null) ?? config('support.service');
+    }
+
+    /**
+     * Check if support service is enabled
+     *
+     * @param string $service The service to verify. Default uservoice
+     * @return boolean
+     */
+    public static function active($service = 'uservoice')
+    {
+        return static::serviceName() === $service && static::token() !== null;
+    }
+
+}

--- a/app/Support/SupportService.php
+++ b/app/Support/SupportService.php
@@ -2,7 +2,6 @@
 
 namespace KBox\Support;
 
-use KBox\User;
 use KBox\Option;
 
 class SupportService
@@ -63,5 +62,4 @@ class SupportService
     {
         return static::serviceName() === $service && static::token() !== null;
     }
-
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -56,13 +56,27 @@ if (! function_exists('support_token')) {
     /**
      * Get the Support service authentication token
      *
-     * @uses \KBox\Option::support_token()
+     * @uses \KBox\Support\SupportService::token()
      *
-     * @return string|boolean the support ticket integration token if configured, false if not configured
+     * @return string|null the support ticket integration token if configured, null if not configured
      */
     function support_token()
     {
-        return \KBox\Option::support_token();
+        return \KBox\Support\SupportService::token();
+    }
+}
+
+if (! function_exists('support_active')) {
+    /**
+     * Check if the specified support service is active
+     *
+     * @uses \KBox\Support\SupportService::active()
+     *
+     * @return boolean true if the support service is active, false otherwise
+     */
+    function support_active($service = 'uservoice')
+    {
+        return \KBox\Support\SupportService::active($service);
     }
 }
 

--- a/config/dms.php
+++ b/config/dms.php
@@ -155,20 +155,6 @@ return [
     
     /*
     |--------------------------------------------------------------------------
-    | Support Widget Token
-    |--------------------------------------------------------------------------
-    |
-    | The UserVoice support key
-    |
-    | default: null, support is not configured and not enabled
-    |
-    | @var string
-    */
-    
-    'support_token' => env('KBOX_SUPPORT_TOKEN', env('SUPPORT_TOKEN', null)),
-    
-    /*
-    |--------------------------------------------------------------------------
     | Language whitelist
     |--------------------------------------------------------------------------
     |

--- a/config/route-permissions.php
+++ b/config/route-permissions.php
@@ -213,6 +213,11 @@ return [
             'update' => KBox\Capability::MANAGE_KBOX,
         ],
 
+        'support' => [
+            'index' => KBox\Capability::MANAGE_KBOX,
+            'update' => KBox\Capability::MANAGE_KBOX,
+        ],
+
         'licenses' => [
             'index' => KBox\Capability::MANAGE_KBOX,
             'default' => ['update' => KBox\Capability::MANAGE_KBOX],

--- a/config/support.php
+++ b/config/support.php
@@ -1,0 +1,31 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Support service
+    |--------------------------------------------------------------------------
+    |
+    | The support service to use. The supported values comes from the 
+    | providers list, for example "uservoice".
+    | Set this configuration to null will disable any support service
+    |
+    */
+    'service' => env('KBOX_SUPPORT_SERVICE', env('SUPPORT_SERVICE', null)),
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Support service providers
+    |--------------------------------------------------------------------------
+    |
+    | The providers that can be use for serving support requests.
+    |
+    */
+    'providers' => [
+        'uservoice' => [
+            'token' => env('KBOX_SUPPORT_USERVOICE_TOKEN', env('SUPPORT_USERVOICE_TOKEN', env('KBOX_SUPPORT_TOKEN', env('SUPPORT_TOKEN', null)))),
+        ],
+    ],
+    
+];

--- a/config/support.php
+++ b/config/support.php
@@ -7,7 +7,7 @@ return [
     | Support service
     |--------------------------------------------------------------------------
     |
-    | The support service to use. The supported values comes from the 
+    | The support service to use. The supported values comes from the
     | providers list, for example "uservoice".
     | Set this configuration to null will disable any support service
     |

--- a/docs/administration/support.md
+++ b/docs/administration/support.md
@@ -1,0 +1,54 @@
+---
+Title: Support
+Description: How to configure support services
+---
+# Support
+
+The K-Box can be configured to show links or use external services for providing support to users.
+
+Currently the K-Box offers out-of-the-box support for [UserVoice](https://www.uservoice.com/).
+
+
+## Uservoice
+
+The Uservoice service will display an interactive widget on each page that allow the user to send immediate requests.
+
+The K-Box will share the following data with UserVoice:
+
+- K-Box application name
+- K-Box version
+- Route of page path
+- Collection being browsed
+- Search parameters
+
+For logged-in users we will share also
+
+- Email address (to receive responses and continue the inquiry)
+- Username
+
+> **When activating the UserVoice support service you should include the information of the service and the collected data inside the Privacy Policy**.
+
+
+## Configuration via User Interface
+
+The uservoice token and service can be configured from the _Administration > Support_ page.
+
+> Removing the token from the UI will not disable the service if the environment configuration expose the support configuration
+
+
+## Configuration via deployment environment file
+
+The support service configuration is done via environment variables at deploy time.
+
+The general configuration variables are:
+
+- `KBOX_SUPPORT_SERVICE`: The support service provider. Possible values are: `null` (to disable the support), `uservoice`
+
+Based on the selected service, more configuration options might be available.
+
+
+**uservoice**
+
+The UserVoice service require the following additional parameters:
+
+- `KBOX_SUPPORT_USERVOICE_TOKEN`: the UserVoice token for the widget

--- a/docs/developer/configuration.md
+++ b/docs/developer/configuration.md
@@ -42,11 +42,12 @@ The next table shows the K-Box specific configuration parameters:
 | `KBOX_MAIL_FROM_NAME`                 |           | string  |               | The name to show when sending emails|
 | `KBOX_MAIL_USERNAME`                  |           | string  |               | The E-Mail server authentication |
 | `KBOX_MAIL_PASSWORD`                  |           | string  |               | The E-Mail server authentication |
-| `KBOX_SUPPORT_TOKEN` (`SUPPORT_TOKEN`)|           | string  |               | The Authentication token for the support service (can be configured from the UI) |
+| `KBOX_SUPPORT_TOKEN` (`SUPPORT_TOKEN`)|           | string  |               | The Authentication token for the support service (can be configured from the UI). Deprecated, [use `KBOX_SUPPORT_USERVOICE_TOKEN`](../administration/support.md) |
 | `KBOX_PAGE_LIMIT`                     |           | number  | 12            | The default number of items per page to show |
 | `KBOX_USER_REGISTRATION`              |           | boolean  | false        | Enable or disable self user registration |
 | `KBOX_ANALYTICS_SERVICE`              |           | string  | matomo        | The analytics tracking provider. Available: matomo, google-analytics |
 | `KBOX_ANALYTICS_TOKEN`                |           | string  |               | The analytics token to use for the specific analytics tracking provider |
+| `KBOX_SUPPORT_SERVICE`                |           | string  | null          | The support service to use. See [Configuring Support service](../administration/support.md) |
 
 > `KBOX_MAIL_*` parameters can be configured from the User Interface, see [Configuring E-Mail](../administration/mail.md).
 

--- a/resources/lang/en/administration.php
+++ b/resources/lang/en/administration.php
@@ -27,6 +27,7 @@ return [
         'identity' => 'Identity',
         'licenses' => 'Document Licenses',
         'analytics' => 'Analytics',
+        'support' => 'Support',
 
     ],
 
@@ -251,11 +252,6 @@ return [
         
         'map_visualization_chk' => 'Enable the map visualization',
         
-        'support_section' => 'Support',
-        'support_section_help' => 'If you have a support subscription please insert here the authentication token to enable your users to submit support requests and receive help from the K-Link Dev team.',
-        'support_token_field' => 'Support Token',
-        'support_save_btn' => 'Save Support Settings',
-
         'analytics_section' => 'Analytics',
         'analytics_section_help' => 'Analytics support the process of understanding how often and for what purposes the system is being used. In this section you can opt-in for the K-Link Analytics.',
         'analytics_token_field' => 'Analytics token',
@@ -272,6 +268,15 @@ return [
         'token_field' => 'Analytics token',
         'service_field' => 'Analytics service',
         'domain_field' => 'Analytics service URL',
+    ],
+    
+    'support' => [
+        'section' => 'Support',
+        'section_help' => 'If you have a UserVoice support subscription please insert here the authentication token to enable your users to submit support requests.',
+        'token_field' => 'Support Token',
+        'save_btn' => 'Save Support Settings',
+        'saved' => 'Support settings updated.',
+        'save_error' => 'Support settings cannot be updated. :error',
     ],
 
     'identity' => [

--- a/resources/views/administration/administration.blade.php
+++ b/resources/views/administration/administration.blade.php
@@ -86,6 +86,14 @@
 					{{trans('administration.menu.analytics')}}
 				</a>
 			</li>
+			
+			<li class="navigation-admin__item"><a href="{{ route('administration.support.index') }}" class="navigation-admin__link @if(\Request::is('*support')) navigation--current @endif">
+					
+					@materialicon('communication', 'live_help', 'navigation-admin__item__icon')
+					
+					{{trans('administration.menu.support')}}
+				</a>
+			</li>
 
 			@flag(\KBox\Flags::PLUGINS)
 				<li class="navigation-admin__item"><a href="{{ route('administration.plugins.index') }}" class="navigation-admin__link @if(\Request::is('*plugins')) navigation--current @endif">	

--- a/resources/views/administration/adminmenu.blade.php
+++ b/resources/views/administration/adminmenu.blade.php
@@ -59,6 +59,13 @@
 		{{trans('administration.menu.analytics')}}
 	</a>
 
+	<a href="{{ route('administration.support.index') }}" class="navigation__item navigation__item--link @if(\Request::is('*support')) navigation__item--current @endif">
+			
+		@materialicon('communication', 'live_help', 'navigation__item__icon')
+		
+		{{trans('administration.menu.support')}}
+	</a>
+
 	@flag(\KBox\Flags::PLUGINS)
 	<a href="{{ route('administration.plugins.index') }}" class="navigation__item navigation__item--link @if(\Request::is('*plugins')) navigation__item--current @endif">
 			

--- a/resources/views/administration/settings/index.blade.php
+++ b/resources/views/administration/settings/index.blade.php
@@ -16,39 +16,6 @@
 @section('page')
         
         @include('errors.list')
-        
-        
-
-            <form  method="post" class="c-form" action="{{route('administration.settings.store')}}">
-    
-                {{ csrf_field() }}
-
-                <div class="c-section c-section--separated">
-                    <h4 class="c-section__title">{{trans('administration.settings.support_section')}}</h4>
-                    <p class="c-section__description">{{trans('administration.settings.support_section_help')}}</p>
-            
-                    <div class="c-form__field">
-                        <label for="support_token">{{trans('administration.settings.support_token_field')}}</label>
-                        @if( isset($errors) && $errors->has('support_token') )
-                            <span class="field-error">{{ implode(",", $errors->get('support_token'))  }}</span>
-                        @endif
-                        <input class="c-form__input c-form__input--larger" type="text" name="support_token" id="support_token" value="{{old('support_token', isset($support_token) ? $support_token : '')}}">
-                    </div>
-                    
-
-                    <div class="c-form__buttons">
-
-                        <button type="submit" class="button" id="support-settings-save-btn" name="support-settings-save-btn">
-                            {{trans('administration.settings.support_save_btn')}}
-                        </button>
-                    </div>
-
-                </div>
-            
-            </form>
-        
-        
-        
 
             <form  method="post" class="c-form" action="{{route('administration.settings.store')}}">
     

--- a/resources/views/administration/support/index.blade.php
+++ b/resources/views/administration/support/index.blade.php
@@ -1,0 +1,49 @@
+@extends('administration.layout')
+
+@section('breadcrumbs')
+        
+    <a href="{{route('administration.index')}}"  class="breadcrumb__item">{{trans('administration.page_title')}}</a> <span class="breadcrumb__item--current">{{$pagetitle}}</span>
+
+@stop
+
+@section('action-menu')
+
+
+
+
+@stop
+
+@section('page')
+        
+    @include('errors.list')
+    
+
+    <form  method="post" class="c-form" action="{{route('administration.support.update')}}">
+
+        {{ csrf_field() }}
+        
+        @method('PUT')
+
+        <div class="c-section">
+            <h4 class="c-section__title">{{trans('administration.support.section')}}</h4>
+            <p class="c-section__description">{{trans('administration.support.section_help')}}</p> 
+
+            <div class="c-form__field">
+                <label for="support_token">{{trans('administration.support.token_field')}}</label>
+                @if( isset($errors) && $errors->has('support_token') )
+                    <span class="field-error">{{ implode(",", $errors->get('support_token'))  }}</span>
+                @endif
+                <input class="c-form__input" type="text" name="support_token" id="support_token" value="{{old('support_token', isset($support_token) ? $support_token : '')}}">
+            </div>
+    
+        
+            <div class="c-form__buttons">
+                <button type="submit" class="button" id="support-settings-save-btn" name="support-settings-save-btn">
+                    {{trans('administration.support.save_btn')}}
+                </button>
+            </div>
+    
+        </div>
+    </form>
+    
+@stop

--- a/resources/views/global.blade.php
+++ b/resources/views/global.blade.php
@@ -101,51 +101,18 @@
 	</script>
 <![endif]-->
 	
-    @if(support_token() !== false)
-	
-	<script>
-		
-		<?php 
-        
-        $support_context = json_encode([
-            'product' => config('app.name'),
-            'version' => \Config::get("dms.version"),
-            'route' => ! is_null(\Route::getCurrentRoute()->getName()) ? \Route::getCurrentRoute()->getName() : \Route::getCurrentRoute()->getPath(),
-            'context' => isset($context) ? $context : null,
-            'group' => isset($context_group) ? $context_group : null,
-            'visibility' => isset($current_visibility) ? $current_visibility : null,
-            'search_terms' => isset($search_terms) ? e($search_terms) : null,
-        ]);
-        
-        ?>
-		
-		UserVoice=window.UserVoice||[];(function(){var uv=document.createElement('script');uv.type='text/javascript';uv.async=true;uv.src='//widget.uservoice.com/{{ support_token() }}.js';var s=document.getElementsByTagName('script')[0];s.parentNode.insertBefore(uv,s)})();
-
-		UserVoice.push(['set', {
-		  accent_color: '#448dd6',
-		  trigger_color: 'white',
-          locale: '{{ \App::getLocale() }}',
-		  trigger_background_color: '#448dd6',
-		  ticket_custom_fields: {
-			
-			'context': '{!!$support_context!!}'
-			
-		  },
-		}]);
-		
-		@if(isset($feedback_loggedin) && $feedback_loggedin)
-		UserVoice.push(['identify', {
-		  email:      '{{$feedback_user_mail}}',
-		  name:       '{{$feedback_user_name}}',
-		}]);
-		
-		@endif
-		
-		UserVoice.push(['addTrigger', { mode: 'contact', trigger_position: 'bottom-right' }]);
-		UserVoice.push(['autoprompt', {}]);
-	</script>
-    
-    @endif
+		@includeWhen(support_active(), 'support.uservoice', [
+			'feedback_loggedin' => $feedback_loggedin ?? false,
+			'feedback_user_mail' => $feedback_user_mail ?? null,
+			'feedback_user_name' => $feedback_user_name ?? null,
+			'product' => config('app.name'),
+			'version' => config("dms.version"),
+			'route' => ! is_null(\Route::getCurrentRoute()->getName()) ? \Route::getCurrentRoute()->getName() : \Route::getCurrentRoute()->getPath(),
+			'context' => isset($context) ? e($context) : null,
+			'group' => isset($context_group) ? e($context_group) : null,
+			'visibility' => isset($current_visibility) ? e($current_visibility) : null,
+			'search_terms' => isset($search_terms) ? e($search_terms) : null,
+		])
 
 	</body>
 	

--- a/resources/views/support/uservoice.blade.php
+++ b/resources/views/support/uservoice.blade.php
@@ -1,0 +1,28 @@
+@if(support_token() !== null)
+	
+	<script>
+
+		UserVoice=window.UserVoice||[];(function(){var uv=document.createElement('script');uv.type='text/javascript';uv.async=true;uv.src='//widget.uservoice.com/{{ support_token() }}.js';var s=document.getElementsByTagName('script')[0];s.parentNode.insertBefore(uv,s)})();
+
+		UserVoice.push(['set', {
+		  accent_color: '#448dd6',
+		  trigger_color: 'white',
+          locale: '{{ \App::getLocale() }}',
+		  trigger_background_color: '#448dd6',
+		  ticket_custom_fields: {			
+			'context': '{"product": "{{$product}}","version": "{{$version}}","route": "{{$route}}","context": "{{$context}}","group": "{{$group}}","visibility": "{{$visibility}}","search_terms" => "{{$search_terms}}"}'
+		  },
+		}]);
+		
+		@if(isset($feedback_loggedin) && $feedback_loggedin)
+            UserVoice.push(['identify', {
+                email: '{{$feedback_user_mail}}',
+                name: '{{$feedback_user_name}}',
+            }]);
+		@endif
+		
+		UserVoice.push(['addTrigger', { mode: 'contact', trigger_position: 'bottom-right' }]);
+		UserVoice.push(['autoprompt', {}]);
+	</script>
+    
+@endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -91,6 +91,9 @@ Route::group(['as' => 'administration.', 'prefix' => 'administration'], function
 
     Route::get('/analytics', 'Administration\AnalyticsController@index')->name('analytics.index');
     Route::put('/analytics', 'Administration\AnalyticsController@update')->name('analytics.update');
+    
+    Route::get('/support', 'Administration\SupportController@index')->name('support.index');
+    Route::put('/support', 'Administration\SupportController@update')->name('support.update');
 });
 /*
 |--------------------------------------------------------------------------

--- a/tests/Feature/SettingsControllerTest.php
+++ b/tests/Feature/SettingsControllerTest.php
@@ -31,47 +31,7 @@ class SettingsControllerTest extends TestCase
         $response->assertViewHas(Option::PUBLIC_CORE_PASSWORD);
         $response->assertViewHas(Option::PUBLIC_CORE_NETWORK_NAME_EN);
         $response->assertViewHas(Option::PUBLIC_CORE_NETWORK_NAME_RU);
-        $response->assertViewHas(Option::SUPPORT_TOKEN);
         $response->assertViewHas(Option::STREAMING_SERVICE_URL);
-    }
-    
-    public function testUservoiceSettingStore()
-    {
-        $user = tap(factory(User::class)->create(), function ($u) {
-            $u->addCapabilities(Capability::$ADMIN);
-        });
-        
-        $response = $this->actingAs($user)
-                         ->from(route('administration.settings.index'))
-                         ->post(route('administration.settings.store'), [
-                            'support_token' => 'Support-token-value',
-                            'support-settings-save-btn' => true, // simulating pressing save on the form
-                         ]);
-        
-        $response->assertRedirect(route('administration.settings.index'));
-        $response->assertSessionHas('flash_message', trans('administration.settings.saved'));
-
-        $this->assertEquals('Support-token-value', Option::support_token());
-
-        $saved_get_response = $this->actingAs($user)
-                         ->get(route('administration.settings.index'));
-        $saved_get_response->assertViewHas(Option::SUPPORT_TOKEN, 'Support-token-value');
-        
-        $remove_response = $this->actingAs($user)
-                         ->from(route('administration.settings.index'))
-                         ->post(route('administration.settings.store'), [
-                            'support_token' => '',
-                            'support-settings-save-btn' => true, // simulating pressing save on the form
-                         ]);
-        
-        $remove_response->assertRedirect(route('administration.settings.index'));
-        $remove_response->assertSessionHas('flash_message', trans('administration.settings.saved'));
-
-        $this->assertEquals('', Option::support_token());
-        
-        $updated_get_response = $this->actingAs($user)
-                         ->get(route('administration.settings.index'));
-        $updated_get_response->assertViewHas(Option::SUPPORT_TOKEN, '');
     }
 
     public function test_network_settings_are_stored()

--- a/tests/Feature/SupportTest.php
+++ b/tests/Feature/SupportTest.php
@@ -5,10 +5,7 @@ namespace Tests\Feature;
 use KBox\User;
 use Tests\TestCase;
 use KBox\Capability;
-use KBox\Consent;
 use KBox\Option;
-use KBox\Consents;
-use KBox\Support\Analytics\Analytics;
 use KBox\Support\SupportService;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
@@ -24,7 +21,6 @@ class SupportTest extends TestCase
         $response->assertDontSee('UserVoice');
     }
     
-    
     public function test_support_not_active_if_partially_configured()
     {
         config([
@@ -37,7 +33,6 @@ class SupportTest extends TestCase
         $response->assertDontSee('UserVoice');
     }
     
-
     public function test_uservoice_included_from_environment()
     {
         config([
@@ -88,7 +83,6 @@ class SupportTest extends TestCase
         $response->assertSee("email: '$user->email'");
         $response->assertSee("name: '$user->name'");
     }
-
 
     public function test_support_settings_page_loads_env_variables()
     {
@@ -160,5 +154,4 @@ class SupportTest extends TestCase
         $this->assertEquals(null, SupportService::serviceName());
         $this->assertFalse(support_active());
     }
-  
 }

--- a/tests/Feature/SupportTest.php
+++ b/tests/Feature/SupportTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Tests\Feature;
+
+use KBox\User;
+use Tests\TestCase;
+use KBox\Capability;
+use KBox\Consent;
+use KBox\Option;
+use KBox\Consents;
+use KBox\Support\Analytics\Analytics;
+use KBox\Support\SupportService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class SupportTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_support_not_active()
+    {
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+        $response->assertDontSee('UserVoice');
+    }
+    
+    
+    public function test_support_not_active_if_partially_configured()
+    {
+        config([
+            'support.service' => 'uservoice',
+        ]);
+
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+        $response->assertDontSee('UserVoice');
+    }
+    
+
+    public function test_uservoice_included_from_environment()
+    {
+        config([
+            'support.service' => 'uservoice',
+            'support.providers.uservoice.token' => 'AAAAA',
+        ]);
+
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+        $response->assertSee('UserVoice');
+        $response->assertSee('AAAAA.js');
+    }
+
+    public function test_uservoice_included_using_dynamic_configuration()
+    {
+        config([
+            'support.service' => null,
+            'support.providers.uservoice.token' => null,
+        ]);
+
+        Option::put(SupportService::SUPPORT_TOKEN, 'AAAAA');
+        Option::put(SupportService::SUPPORT_SERVICE, 'uservoice');
+
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+        $response->assertSee('UserVoice');
+        $response->assertSee('AAAAA.js');
+    }
+
+    public function test_user_is_passed_to_uservoice_widget()
+    {
+        config([
+            'support.service' => 'uservoice',
+            'support.providers.uservoice.token' => 'AAAAA',
+        ]);
+
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $response = $this->actingAs($user)->get(route('contact'));
+
+        $response->assertStatus(200);
+        
+        $response->assertSee("UserVoice.push(['identify'");
+        $response->assertSee("email: '$user->email'");
+        $response->assertSee("name: '$user->name'");
+    }
+
+
+    public function test_support_settings_page_loads_env_variables()
+    {
+        config([
+            'support.service' => 'uservoice',
+            'support.providers.uservoice.token' => 'AAAAA',
+        ]);
+
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$ADMIN);
+        });
+        
+        $response = $this->actingAs($user)
+                         ->get(route('administration.support.index'));
+        
+        $response->assertViewIs('administration.support.index');
+        $response->assertViewHas(SupportService::SUPPORT_TOKEN, 'AAAAA');
+        $this->assertTrue(SupportService::active());
+    }
+
+    public function test_support_settings_page_loads_dynamic_settings()
+    {
+        config([
+            'support.service' => 'uservoice',
+        ]);
+
+        Option::put(SupportService::SUPPORT_TOKEN, 'AAAAA');
+
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$ADMIN);
+        });
+        
+        $response = $this->actingAs($user)
+                         ->get(route('administration.support.index'));
+        
+        $response->assertViewIs('administration.support.index');
+        $response->assertViewHas(SupportService::SUPPORT_TOKEN, 'AAAAA');
+    }
+
+    public function test_support_setting_are_saved()
+    {
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$ADMIN);
+        });
+        
+        $response = $this->actingAs($user)
+                         ->from(route('administration.support.index'))
+                         ->put(route('administration.support.update'), [
+                            'support_token' => 'support-token-value',
+                         ]);
+        
+        $response->assertRedirect(route('administration.support.index'));
+        $response->assertSessionHas('flash_message', trans('administration.support.saved'));
+
+        $this->assertEquals('support-token-value', support_token());
+        $this->assertEquals('uservoice', SupportService::serviceName());
+        $this->assertTrue(support_active());
+        
+        $response = $this->actingAs($user)
+                         ->from(route('administration.support.index'))
+                         ->put(route('administration.support.update'), [
+                            'support_token' => '',
+                         ]);
+        
+        $response->assertRedirect(route('administration.support.index'));
+        $response->assertSessionHas('flash_message', trans('administration.support.saved'));
+
+        $this->assertEquals(null, support_token());
+        $this->assertEquals(null, SupportService::serviceName());
+        $this->assertFalse(support_active());
+    }
+  
+}


### PR DESCRIPTION
## What does this PR do?

- Separate support settings from general K-Box settings
- Prepare for eventual additional support service
- Define `KBOX_SUPPORT_SERVICE` and `KBOX_SUPPORT_USERVOICE_TOKEN` environment variables
- Deprecate `KBOX_SUPPORT_TOKEN` environment variable
- Documented what information are shared with UserVoice

When this will be merged, the instances with a configured support service must be reconfigured. It is enough to enter the new Support settings area and press "Save". The change can also be done via environment configuration by setting `KBOX_SUPPORT_SERVICE: true`

### Review checklist

* [x] Are unit tests required?
* [x] Are Documentation changes needed?

**Before merging**

* [x] Is history cleaned up? (or can be squashed on merge?)