### PR TITLE
Perform opcache_reset when enabling/disabling plugins

### DIFF
--- a/app/Plugins/PluginManager.php
+++ b/app/Plugins/PluginManager.php
@@ -123,6 +123,8 @@ final class PluginManager
         if (! app()->runningUnitTests()) {
             Artisan::call('route:cache');
         }
+
+        $this->opcache_clear();
     }
     
     /**
@@ -148,6 +150,8 @@ final class PluginManager
         if (! app()->runningUnitTests()) {
             Artisan::call('route:cache');
         }
+
+        $this->opcache_clear();
     }
     
     /**
@@ -300,5 +304,20 @@ final class PluginManager
             $this->manifestPath,
             '<?php return '.var_export($manifest, true).';'
         );
+    }
+
+    private function opcache_clear()
+    {
+        if (! function_exists('opcache_get_status')) {
+            return false;
+        }
+
+        $opcache_status = opcache_get_status();
+        
+        if (isset($opcache_status["opcache_enabled"]) && ! $opcache_status["opcache_enabled"]) {
+            return false;
+        }
+
+        return opcache_reset();
     }
 }


### PR DESCRIPTION
## What does this PR do?

In the production Docker image we use the PHP opcode cache (OPcache) to speed-up the execution. This have an impact on dynamic plugin configuration, specifically when enabling and disabling them.

This pull request introduce the opcache reset as part of the http request that enable/disable each plugin.

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)