### PR TITLE
Fix duplicate resolution in collection causing multiple entries

### DIFF
--- a/app/Http/Controllers/Document/DuplicateDocumentsController.php
+++ b/app/Http/Controllers/Document/DuplicateDocumentsController.php
@@ -69,7 +69,9 @@ class DuplicateDocumentsController extends Controller
             if (! $collections->isEmpty()) {
                 DB::transaction(function () use ($collections, $user, $duplicate) {
                     $collections->each(function ($c) use ($user, $duplicate) {
-                        $this->service->addDocumentToGroup($user, $duplicate->duplicateOf, $c, false);
+                        if ($duplicate->duplicateOf->groups()->where('group_id', $c->id)->count() === 0) {
+                            $this->service->addDocumentToGroup($user, $duplicate->duplicateOf, $c, false);
+                        }
                     });
                     try {
                         $this->service->triggerReindex($duplicate->duplicateOf);

--- a/tests/Feature/DuplicateDocumentsControllerTest.php
+++ b/tests/Feature/DuplicateDocumentsControllerTest.php
@@ -254,8 +254,8 @@ class DuplicateDocumentsControllerTest extends TestCase
         $this->assertTrue($duplicate->fresh()->resolved, "Duplicate not marked as resolved");
 
         $this->assertEquals(
-            [$collection_for_existing->id, $collection_for_duplicate->id],
-            $existing_document->fresh()->groups()->pluck('group_id')->toArray()
+            collect([$collection_for_existing->id, $collection_for_duplicate->id])->sort()->toArray(),
+            $existing_document->fresh()->groups()->pluck('group_id')->sort()->toArray()
         );
     }
 }

--- a/tests/Feature/DuplicateDocumentsControllerTest.php
+++ b/tests/Feature/DuplicateDocumentsControllerTest.php
@@ -6,6 +6,9 @@ use Tests\TestCase;
 use KBox\Capability;
 use KBox\DuplicateDocument;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use KBox\DocumentDescriptor;
+use KBox\Group;
+use KBox\User;
 
 class DuplicateDocumentsControllerTest extends TestCase
 {
@@ -163,5 +166,96 @@ class DuplicateDocumentsControllerTest extends TestCase
             'status' => 'error',
             'message' => trans('documents.duplicates.errors.already_resolved'),
         ]);
+    }
+
+    public function test_duplicate_in_same_collection_can_be_resolved()
+    {
+        $this->disableExceptionHandling();
+
+        $adapter = $this->withKlinkAdapterFake();
+
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $collection = factory(Group::class)->create([
+            'user_id' => $user->id,
+            'is_private' => true,
+        ]);
+
+        $existing_document = factory(DocumentDescriptor::class)->create([
+            'owner_id' => $user->id,
+        ]);
+
+        $duplicate_document = factory(DocumentDescriptor::class)->create([
+            'owner_id' => $user->id,
+        ]);
+
+        $collection->documents()->save($existing_document);
+        $collection->documents()->save($duplicate_document);
+
+        $duplicate = factory(DuplicateDocument::class)->create([
+            'user_id' => $user->id,
+            'document_id' => $existing_document->id,
+            'duplicate_document_id' => $duplicate_document->id,
+        ]);
+
+        $response = $this->actingAs($user)->json('DELETE', route('duplicates.destroy', ['id' => $duplicate->id]));
+
+        $response->assertStatus(200);
+
+        $this->assertTrue($duplicate_document->fresh()->trashed(), "Duplicate document not trashed");
+        $this->assertTrue($duplicate->fresh()->resolved, "Duplicate not marked as resolved");
+        $this->assertEquals(1, $collection->documents()->withTrashed()->where('document_id', $existing_document->id)->count(), "duplicate entry in document->collection relation for the existing file");
+    }
+
+    public function test_duplicate_in_different_collections_can_be_resolved()
+    {
+        $this->disableExceptionHandling();
+
+        $adapter = $this->withKlinkAdapterFake();
+
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $collection_for_existing = factory(Group::class)->create([
+            'user_id' => $user->id,
+            'is_private' => true,
+        ]);
+        
+        $collection_for_duplicate = factory(Group::class)->create([
+            'user_id' => $user->id,
+            'is_private' => true,
+        ]);
+
+        $existing_document = factory(DocumentDescriptor::class)->create([
+            'owner_id' => $user->id,
+        ]);
+
+        $duplicate_document = factory(DocumentDescriptor::class)->create([
+            'owner_id' => $user->id,
+        ]);
+
+        $collection_for_existing->documents()->save($existing_document);
+        $collection_for_duplicate->documents()->save($duplicate_document);
+
+        $duplicate = factory(DuplicateDocument::class)->create([
+            'user_id' => $user->id,
+            'document_id' => $existing_document->id,
+            'duplicate_document_id' => $duplicate_document->id,
+        ]);
+
+        $response = $this->actingAs($user)->json('DELETE', route('duplicates.destroy', ['id' => $duplicate->id]));
+
+        $response->assertStatus(200);
+
+        $this->assertTrue($duplicate_document->fresh()->trashed(), "Duplicate document not trashed");
+        $this->assertTrue($duplicate->fresh()->resolved, "Duplicate not marked as resolved");
+
+        $this->assertEquals(
+            [$collection_for_existing->id, $collection_for_duplicate->id],
+            $existing_document->fresh()->groups()->pluck('group_id')->toArray()
+        );
     }
 }


### PR DESCRIPTION
## What does this PR do?

Fix a case in which duplicate resolution caused the same document to appear twice in the list.

If the duplicate is found in the same collection, resolving it was causing the original existing file to be listed twice.

### Review checklist

* [x] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [x] Is history cleaned up? (or can be squashed on merge?)