### PR TITLE
Improve project duplicate error

### DIFF
--- a/app/Http/Requests/ProjectRequest.php
+++ b/app/Http/Requests/ProjectRequest.php
@@ -19,7 +19,7 @@ class ProjectRequest extends Request
 
         $is_update = $action['as'] == 'projects.update';
 
-        $name_unique_rule = Rule::unique('projects', 'name');
+        $name_unique_rule = Rule::unique('projects', 'name')->where('user_id', $this->user()->id);
 
         $tests = [
             'name' => [

--- a/app/Http/Requests/ProjectRequest.php
+++ b/app/Http/Requests/ProjectRequest.php
@@ -2,6 +2,7 @@
 
 namespace KBox\Http\Requests;
 
+use Illuminate\Validation\Rule;
 use Illuminate\Foundation\Http\FormRequest as Request;
 
 class ProjectRequest extends Request
@@ -16,8 +17,16 @@ class ProjectRequest extends Request
     {
         $action = $this->route()->getAction();
 
+        $is_update = $action['as'] == 'projects.update';
+
+        $name_unique_rule = Rule::unique('projects', 'name');
+
         $tests = [
-            'name' => 'required|string',
+            'name' => [
+                'required',
+                'string',
+                $is_update ? $name_unique_rule->ignore($this->route('project')) : $name_unique_rule,
+            ],
             'description' => 'nullable|sometimes|string',
             'users' => 'nullable|sometimes|required|array|exists:users,id',
             'manager' => 'required|exists:users,id',
@@ -35,5 +44,12 @@ class ProjectRequest extends Request
     public function authorize()
     {
         return true;
+    }
+
+    public function messages()
+    {
+        return [
+            'name.unique' => trans('projects.errors.already_existing'),
+        ];
     }
 }

--- a/database/migrations/2019_09_12_110535_update_project_uniqueness.php
+++ b/database/migrations/2019_09_12_110535_update_project_uniqueness.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class UpdateProjectUniqueness extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->dropUnique('projects_name_unique');
+            $table->unique(['user_id', 'name'], 'projects_name_user_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            // required to drop foreign key before the unique index
+            // as the index used a column on which a foreign key was
+            // defined
+            $table->dropForeign('projects_user_id_foreign');
+
+            $table->dropUnique('projects_name_user_unique');
+            $table->unique('name');
+
+            // restore the foreign key afterwards
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+}

--- a/docs/administration/projects.md
+++ b/docs/administration/projects.md
@@ -26,6 +26,8 @@ To create a project, press the button _New Project_ that is on the top right of 
 
 After inserting the project name, description and users, press the _Create Project_ to save your changes.
 
+> Project name must be unique within the user's managed projects
+
 ## <a id="prjDetails"></a>Project details
 
 This page shows project members and personalization options.

--- a/resources/lang/en/projects.php
+++ b/resources/lang/en/projects.php
@@ -74,6 +74,8 @@ return [
 
         'exception' => 'The project cannot be created. (:exception)',
         
+        'already_existing' => 'A project with the same name already exists.',
+        
         'prevent_edit_description' => 'The Project collection cannot be edited from here. Please goto <a href=":link">Projects > Edit :name</a> to make the edits.',
         
         'prevent_delete_description' => 'The Project collection cannot be deleted.'

--- a/resources/lang/ky/projects.php
+++ b/resources/lang/ky/projects.php
@@ -72,6 +72,8 @@ return [
     'errors' => [
 
         'exception' => 'Долбоор түзүү мүмкүн эмес (:exception)',
+
+        'already_existing' => 'Мындай ат менен долбоор түзүлгөн',
         
         'prevent_edit_description' => 'Долбоорду <a href=":link">Долбоорлор > Өзгөртүү :name</a> өзгөртүү мүмкүн',
         

--- a/resources/lang/ru/projects.php
+++ b/resources/lang/ru/projects.php
@@ -72,6 +72,8 @@ return [
     'errors' => [
 
         'exception' => 'Невозможно создать проект. (:exception)',
+
+        'already_existing' => 'Проект с таким названием уже существует',
         
         'prevent_edit_description' => 'Изменение проекта возможно в <a href=":link">Проекты > Изменить :name</a>',
         

--- a/tests/Feature/ProjectsTest.php
+++ b/tests/Feature/ProjectsTest.php
@@ -163,6 +163,28 @@ class ProjectsTest extends TestCase
             $response->assertRedirect(route('documents.groups.show', $created_project->collection_id));
         }
     }
+    
+    public function test_project_cannot_be_created_if_already_existing()
+    {
+        $user = $this->createUser(Capability::$PROJECT_MANAGER);
+
+        $project = factory(Project::class)->create([
+            'user_id' => $user->id
+        ]);
+
+        $expected_available_users = collect([$this->createUser(Capability::$PARTNER)]);
+
+        $params = [
+            'manager' => $user->id,
+            'name' => $project->name,
+            'description' => 'Project description',
+        ];
+
+        $response = $this->from(route('projects.create'))->actingAs($user)->post(route('projects.store'), $params);
+
+        $response->assertRedirect(route('projects.create'));
+        $response->assertSessionHasErrors(['name' => trans('projects.errors.already_existing')]);
+    }
 
     public function test_project_edit()
     {

--- a/tests/Feature/ProjectsTest.php
+++ b/tests/Feature/ProjectsTest.php
@@ -172,8 +172,6 @@ class ProjectsTest extends TestCase
             'user_id' => $user->id
         ]);
 
-        $expected_available_users = collect([$this->createUser(Capability::$PARTNER)]);
-
         $params = [
             'manager' => $user->id,
             'name' => $project->name,
@@ -184,6 +182,31 @@ class ProjectsTest extends TestCase
 
         $response->assertRedirect(route('projects.create'));
         $response->assertSessionHasErrors(['name' => trans('projects.errors.already_existing')]);
+    }
+    
+    public function test_two_users_can_have_equally_named_projects()
+    {
+        $user1 = $this->createUser(Capability::$PROJECT_MANAGER);
+        $user2 = $this->createUser(Capability::$PROJECT_MANAGER);
+
+        $params1 = [
+            'manager' => $user1->id,
+            'name' => 'A project',
+            'description' => 'Project description',
+        ];
+
+        $params2 = [
+            'manager' => $user2->id,
+            'name' => 'A project',
+            'description' => 'Project description',
+        ];
+
+        $response1 = $this->from(route('projects.create'))->actingAs($user1)->post(route('projects.store'), $params1);
+
+        $response2 = $this->from(route('projects.create'))->actingAs($user2)->post(route('projects.store'), $params2);
+
+        $created_project = Project::where('name', $params1['name'])->count();
+        $this->assertEquals(2, $created_project);
     }
 
     public function test_project_edit()


### PR DESCRIPTION
## What does this PR do?

Improve the check for duplicate project name by allowing two users to use the same project name. In case of project name being duplicate an validation error message is reported.

### Review checklist

* [x] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)