### PR TITLE
Move microsite feature behind flag

### DIFF
--- a/app/Flags.php
+++ b/app/Flags.php
@@ -24,7 +24,10 @@ final class Flags
      */
     const PLUGINS = 'plugins';
     
-    const PLUGIN_GEO = 'plugins.geo';
+    /**
+     * The microsites feature flag
+     */
+    const MICROSITES = 'microsites';
     
     /**
      * Feature flag for notifications consent

--- a/app/Http/Middleware/VerifyFlag.php
+++ b/app/Http/Middleware/VerifyFlag.php
@@ -34,8 +34,8 @@ class VerifyFlag
         }
             
         if ($request->wantsJson()) {
-            return new JsonResponse(['error' => trans('errors.forbidden_exception')], 403);
+            return new JsonResponse(['error' => trans('errors.not_found')], 404);
         }
-        return response()->make(view('errors.403', []), 200);
+        return response()->make(view('errors.404', []), 200);
     }
 }

--- a/docs/developer/flags.md
+++ b/docs/developer/flags.md
@@ -8,6 +8,7 @@ Flag status is stored in the database.
 ## Available flags
 
 - `plugins`: this feature is about a [plugin system](./plugins/plugins.md)
+- `microsites`: this feature is about a [project microsites](../user/microsites.md)
 
 
 _temporary flags for A/B testing_

--- a/docs/developer/flags.md
+++ b/docs/developer/flags.md
@@ -8,7 +8,7 @@ Flag status is stored in the database.
 ## Available flags
 
 - `plugins`: this feature is about a [plugin system](./plugins/plugins.md)
-- `microsites`: this feature is about a [project microsites](../user/microsites.md)
+- `microsites`: this feature enable/disable [project microsites](../user/microsites.md)
 
 
 _temporary flags for A/B testing_

--- a/docs/user/microsites.md
+++ b/docs/user/microsites.md
@@ -10,7 +10,7 @@ With the usage of Microsite(beta) you can create a single page website for your 
 
 Microsites are attached to Projects. You can only create a Microsite for an existing Project. A microsite can be seen as a public page that does not require login to be viewed.
 
-> Microsite support are behind [feature-flag](../developer/flags.md)
+> Microsite support is behind [feature-flag](../developer/flags.md)
 
 ## Viewing a Microsite
 

--- a/docs/user/microsites.md
+++ b/docs/user/microsites.md
@@ -10,6 +10,8 @@ With the usage of Microsite(beta) you can create a single page website for your 
 
 Microsites are attached to Projects. You can only create a Microsite for an existing Project. A microsite can be seen as a public page that does not require login to be viewed.
 
+> Microsite support are behind [feature-flag](../developer/flags.md)
+
 ## Viewing a Microsite
 
 Microsites are reachable through a URL hosted on the K-Link K-Box. The URL is in the form

--- a/resources/views/documents/projects/detail.blade.php
+++ b/resources/views/documents/projects/detail.blade.php
@@ -15,7 +15,7 @@
 <div class="c-panel__actions">
 	<a href="{{route('documents.groups.show', $project->collection->id)}}" class="button">{{ trans('projects.show_documents') }}</a>
 
-	@if( flag('microsite') && !is_null( $project->microsite ) )
+	@if( flags('microsites') && !is_null( $project->microsite ) )
 		<a target="_blank" href="{{ route('projects.site', ['slug' => $project->microsite->slug]) }}" class="button">{{ trans('microsites.actions.view_site') }}</a>
 	@endif
 
@@ -44,7 +44,7 @@
 	</div>
 
 
-	@if(auth()->check() && flag('microsite') && (auth()->user()->id === $project->user_id || !is_null( $project->microsite )))
+	@if(auth()->check() && flags('microsites') && (auth()->user()->id === $project->user_id || !is_null( $project->microsite )))
 
 	<div class="c-panel__meta">
 		<h4 class="c-panel__section">{!! trans('microsites.labels.microsite') !!}</h4>

--- a/resources/views/documents/projects/detail.blade.php
+++ b/resources/views/documents/projects/detail.blade.php
@@ -15,7 +15,7 @@
 <div class="c-panel__actions">
 	<a href="{{route('documents.groups.show', $project->collection->id)}}" class="button">{{ trans('projects.show_documents') }}</a>
 
-	@if( !is_null( $project->microsite ) )
+	@if( flag('microsite') && !is_null( $project->microsite ) )
 		<a target="_blank" href="{{ route('projects.site', ['slug' => $project->microsite->slug]) }}" class="button">{{ trans('microsites.actions.view_site') }}</a>
 	@endif
 
@@ -44,7 +44,7 @@
 	</div>
 
 
-	@if(auth()->check() && (auth()->user()->id === $project->user_id || !is_null( $project->microsite )))
+	@if(auth()->check() && flag('microsite') && (auth()->user()->id === $project->user_id || !is_null( $project->microsite )))
 
 	<div class="c-panel__meta">
 		<h4 class="c-panel__section">{!! trans('microsites.labels.microsite') !!}</h4>

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -43,7 +43,8 @@
             @include('projects.partials.userlist', ['users' => $project_users, 'description' => null, 'empty_message' => trans('projects.no_members'), 'edit' => false ])
 
 		</div>
-		
+        
+        @flag('microsites')
         <div class="six columns">
 			<h4>{!! trans('microsites.labels.microsite') !!}</h4>
 			<p>
@@ -75,7 +76,8 @@
             
             @endif
             
-		</div>
+        </div>
+        @endflag
 		
 	</div>
 

--- a/tests/Unit/Middleware/VerifyFlagMiddlewareTest.php
+++ b/tests/Unit/Middleware/VerifyFlagMiddlewareTest.php
@@ -36,7 +36,7 @@ class VerifyFlagMiddlewareTest extends TestCase
 
         $this->assertFalse($next->called);
         $response->assertStatus(200);
-        $response->assertViewIs('errors.403');
+        $response->assertViewIs('errors.404');
     }
 
     public function test_request_accepted_if_flag_enabled()

--- a/workbench/klink/dms-project-microsites/src/Controllers/MicrositeController.php
+++ b/workbench/klink/dms-project-microsites/src/Controllers/MicrositeController.php
@@ -28,6 +28,9 @@ class MicrositeController extends Controller
      */
     public function __construct()
     {
+
+        $this->middleware('flags:microsites');
+
         $this->middleware('auth', ['except' => ['show']]);
 
         $this->middleware('capabilities', ['except' => ['show']]);


### PR DESCRIPTION
## What does this PR do?

Project Microsites are experimental and should not be enabled by default.

This pull request create a feature flag, called `microsites`, and ensure that the microsite feature could not be accessed if not enabled for the particular instance.

This is a breaking change since microsites are disabled by default.

### Review checklist

* [x] Are unit tests required?
* [x] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)