### PR TITLE
Ensure public link errors are reported

### DIFF
--- a/app/Http/Controllers/PublicLinksController.php
+++ b/app/Http/Controllers/PublicLinksController.php
@@ -26,17 +26,6 @@ class PublicLinksController extends Controller
     }
 
     /**
-     * Display the specified resource.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-    public function show($id)
-    {
-        // ???
-    }
-
-    /**
      * Store a newly created resource in storage.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -118,9 +107,7 @@ class PublicLinksController extends Controller
         $link = PublicLink::findOrFail($id);
         
         if ($user->id !== $link->user_id) {
-            throw new ForbiddenException(
-                trans('share.publiclinks.edit_forbidden_not_your')
-            );
+            return new JsonResponse(['error' => trans('share.publiclinks.edit_forbidden_not_your')], 422);
         }
 
         $slug = $request->input('slug', null);
@@ -157,9 +144,7 @@ class PublicLinksController extends Controller
         $link = PublicLink::findOrFail($id);
         
         if ($user->id !== $link->user_id) {
-            throw new ForbiddenException(
-                trans('share.publiclinks.delete_forbidden_not_your')
-            );
+            return new JsonResponse(['error' => trans('share.publiclinks.delete_forbidden_not_your')], 422);
         }
 
         $res = DB::transaction(function () use ($link) {

--- a/resources/lang/en/share.php
+++ b/resources/lang/en/share.php
@@ -104,7 +104,7 @@ return [
     'publiclinks' => [
         'public_link' => 'Public Link',
         'already_exist' => 'Public link for :name already exists.',
-        'delete_forbidden_not_your' => 'You cannot delete a link you did not create.',
-        'edit_forbidden_not_your' => 'You cannot modify a link you did not create.',
+        'delete_forbidden_not_your' => 'Only the creator of the public link can delete it.',
+        'edit_forbidden_not_your' => 'Only the creator of the public link can change it.',
     ],
 ];

--- a/resources/lang/ky/share.php
+++ b/resources/lang/ky/share.php
@@ -105,7 +105,7 @@ return [
     'publiclinks' => [
         'public_link' => 'Ачык шилтеме',
         'already_exist' => 'Бул документке :name ачык шилтеме түзүлгөн',
-        'delete_forbidden_not_your' => 'Шилтемени өчүрүү мүмкүн эмес',
+        'delete_forbidden_not_your' => 'Ачык шилтемени файлды жүктөгөн колдонуучу гана өчүрө алат',
         'edit_forbidden_not_your' => 'Шилтемени оңдоо мүмкүн эмес',
     ],
 ];

--- a/resources/lang/ru/share.php
+++ b/resources/lang/ru/share.php
@@ -105,7 +105,7 @@ return [
     'publiclinks' => [
         'public_link' => 'Открытая ссылка',
         'already_exist' => 'Открытая ссылка к :name уже существует.',
-        'delete_forbidden_not_your' => 'Вы не можете удалить чужую ссылку.',
+        'delete_forbidden_not_your' => 'Удалить публичную ссылку может только пользователь загрузивший файл',
         'edit_forbidden_not_your' => 'Вы не можете редактировать чужую ссылку.',
     ],
 ];

--- a/tests/Feature/PublicLinksTest.php
+++ b/tests/Feature/PublicLinksTest.php
@@ -149,6 +149,27 @@ class PublicLinksTest extends TestCase
         ]);
     }
 
+    public function testDeletePublicLinkIsNotPossibleByOtherUser()
+    {
+        $share = factory(Shared::class, 'publiclink')->create();
+
+        $creator = $share->user;
+        $creator->addCapabilities(Capability::$PARTNER);
+
+        $user = $this->createUser(Capability::$PARTNER);
+
+
+        $params = [
+            // '_token' => csrf_token(),
+            'links' => $share->sharedwith_id,
+            ];
+
+        $response = $this->actingAs($user)->json('delete', route('links.destroy', $params));
+        $response->assertJson([
+        'error' =>  trans('share.publiclinks.delete_forbidden_not_your'),
+        ]);
+    }
+
     public function testUpdatePublicLink()
     {
         $share = factory(Shared::class, 'publiclink')->create();

--- a/tests/Feature/PublicLinksTest.php
+++ b/tests/Feature/PublicLinksTest.php
@@ -158,7 +158,6 @@ class PublicLinksTest extends TestCase
 
         $user = $this->createUser(Capability::$PARTNER);
 
-
         $params = [
             // '_token' => csrf_token(),
             'links' => $share->sharedwith_id,


### PR DESCRIPTION
## What does this PR do?

Ensure that the description of why a user cannot edit/delete a public link is presented. Additionally it improves the wording of the message

### Review checklist

* [x] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)