### PR TITLE
Allow dropdown to be closed by clicking outside

### DIFF
--- a/resources/assets/js/modules/dropdown.js
+++ b/resources/assets/js/modules/dropdown.js
@@ -1,20 +1,22 @@
 define("modules/dropdown", ["jquery"], function (_$) {
 
-	// data-dropdown
-	// data-dropdown-trigger (it might contain an item with class arrow)
-	// data-dropdown-panel
-
 	var DropMenu = function(element)
 	{
 		this.trigger = element.find("[data-dropdown-trigger]");
 		this.arrow = this.trigger ? this.trigger.find(".arrow") : null;
 		this.panel = element.find("[data-dropdown-panel]");
+		this.obscurer = element.find("[data-dropdown-obscurer]");
 		this.isOpen = false;
 
 		this.open = function(){
 			if(this.panel && !this.isOpen){
 
 				this.panel.removeClass('hidden');
+				
+				if(this.obscurer){
+					this.obscurer.removeClass('hidden');
+					this.obscurer.on('click', this.close.bind(this));
+				}
 	
 				if(this.arrow){
 					this.arrow.addClass("rotate-180");
@@ -26,6 +28,11 @@ define("modules/dropdown", ["jquery"], function (_$) {
 		this.close = function(){
 			if(this.panel && this.isOpen) {
 				this.panel.addClass('hidden');
+
+				if(this.obscurer){
+					this.obscurer.addClass('hidden');
+					this.obscurer.off('click', this.close.bind(this));
+				}
 	
 				if(this.arrow){
 					this.arrow.removeClass("rotate-180");

--- a/resources/views/avatar/avatar.blade.php
+++ b/resources/views/avatar/avatar.blade.php
@@ -1,4 +1,4 @@
-<div class="relative {{ isset($inline) && $inline ? 'inline' : 'inline-block' }} rounded-full overflow-hidden flex-shrink-0 h-10 w-10 bg-gray-800 @if(isset($url) && $url) hover:bg-blue-600 @endif">
+<div class="{{ isset($inline) && $inline ? 'inline' : 'inline-block' }} rounded-full overflow-hidden flex-shrink-0 h-10 w-10 bg-gray-800 @if(isset($url) && $url) hover:bg-blue-600 @endif">
 	@if(isset($url) && $url)
 	<a href="{{ $url }}" title="{{ $alt ?? '' }}">
 	@endif

--- a/resources/views/components/dropdown.blade.php
+++ b/resources/views/components/dropdown.blade.php
@@ -1,4 +1,7 @@
-<div class="{{ $classes ?? 'sm:relative' }}" data-dropdown>
+<div class="{{ $classes ?? '' }}" data-dropdown>
+
+    <div data-dropdown-obscurer class="fixed top-0 left-0 w-screen h-screen hidden bg-black opacity-25"></div>
+
     <button type="button" data-dropdown-trigger class="flex hover:text-blue-600 items-center js-profile-link " @isset($title) title="{{$title}}" @endisset>
         {{ $slot }}
     </button>


### PR DESCRIPTION
## What does this PR do?

Allow a dropdown to be closed by clicking outside. It also prevent that two dropdowns can be opened at the same time.

**before**

![image](https://user-images.githubusercontent.com/5672748/64853292-6779b000-d61b-11e9-80a3-6c69db774361.png)


**after**

![image](https://user-images.githubusercontent.com/5672748/64853328-73fe0880-d61b-11e9-8006-e6b8d2e6153c.png)


### Related issues

Fixes ...

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)