### PR TITLE
Add explore layout as parent of document listings

### DIFF
--- a/resources/views/actions/selection.blade.php
+++ b/resources/views/actions/selection.blade.php
@@ -1,4 +1,4 @@
-<div class="action__button tristate-button js-document-selection-button tristate-button--none hint--bottom"  data-hint="{{trans('actions.selection.hint')}}">	
+<div class="action__button tristate-button js-document-selection-button tristate-button--none hint--bottom mr-2"  data-hint="{{trans('actions.selection.hint')}}">	
 	<input type="checkbox" name="selection-tristate" id="selection-tristate" style="display:none" />
 
 	@materialicon('toggle', 'check_box', 'inline-block tristate__all')

--- a/resources/views/documents/document-layout.blade.php
+++ b/resources/views/documents/document-layout.blade.php
@@ -1,65 +1,13 @@
-@extends('layout.sidebar')
+@extends('layout.explore')
 
 
-@section('breadcrumbs')
-
-	@if(isset($filter) && !is_null($filter) )
-		
-		@if($context ==='group' && isset($context_group_instance))
-		
-			@if(isset($context_group_shared) && $context_group_shared)
-
-				<a href="{{route('documents.sharedwithme')}}" class="breadcrumb__item">{{trans('documents.menu.shared')}}</a>
-
-			@elseif($context_group_instance->is_private)
-				
-				<span class="breadcrumb__item">{{trans('groups.collections.personal_title')}}</span>
-			
-			@else 
-				
-				<a href="{{route('documents.projects.index')}}" class="breadcrumb__item">{{trans('groups.collections.private_title')}}</a>
-			
-			@endif
-
-		@elseif($context!=='projectspage')
-		
-			<a href="{{route('documents.index')}}" class="breadcrumb__item">{{trans('documents.page_title')}}</a>
-		
-		@endif
-		
-		 
-
-		@if(isset($parents) && $context ==='group')
-
-			@foreach ($parents as $parent)
-
-				<a href="{{route('documents.groups.show', $parent->id)}}" class="breadcrumb__item">{{$parent->name}}</a>
-			
-			@endforeach
-
-		@endif
-
-
-		<span class="breadcrumb__item--current">{{$filter}}</span>
-
-	@else
-
-		<span class="breadcrumb__item--current">{{trans('documents.page_title')}}</span>
-
-	@endif
-
-
-
-@stop
 
 
 @section('action-menu')
 
 	@include('actions.selection')
 
-	
-
-		@yield('page-action')
+	@yield('page-action')
 
 		<div class="action__separator"></div>
 
@@ -68,9 +16,7 @@
 			isset($can_upload) && $can_upload
 		))
 
-		
-
-			<div class="action__button ml-2 dropdown">
+			<div class="action__button  dropdown">
 		
 				<span class="label">@materialicon('content', 'add_circle_outline', 'inline-block')<span class="hidden md:inline">{{ trans('actions.create_add_dropdown')}}</span></span>
 				<span class="btn-icon expand icon-navigation-white icon-navigation-white-ic_expand_more_white_24dp"></span>
@@ -142,83 +88,10 @@
 
 @stop
 
-@section('document_list_area')
-
-	<div class="list {{$list_style_current}}" >
-
-		<div class="list__header">
-			@section('list_header')
-				<div class="list__column list__column--large">{{trans('documents.descriptor.name')}}</div>
-				<div class="list__column list__column--hideable">{{trans('documents.descriptor.added_by')}}</div>
-				{{-- <div class="list__column">{{trans('share.shared_by_label')}}</div>
-				<div class="list__column">{{trans('share.shared_on')}}</div> --}}
-				<div class="list__column">{{trans('documents.descriptor.last_modified')}}</div>
-				<div class="list__column list__column--hideable">{{trans('documents.descriptor.language')}}</div>
-				{{-- <div class="list__column">File size</div> --}}
-			@endsection
-
-			@yield('list_header')
-		</div>
-
-		@yield('document_area')
-
-	</div>
-	
-	@if( isset($pagination) && !is_null($pagination) )
-		<div class="pagination-container">
-
-			{!! $pagination->render() !!}
-
-		</div>
-	@endif
-
-@stop
-
-@section('sidebar')
-
-	@include('documents.menu')
-	
-@endsection
-
-@section('page')
-
-<div id="documents-list">
-
-	<div id="document-area">
-		
-		@if(isset($hint) && $hint)
-		
-			<div class="alert info">
-				{{$hint}}
-			</div>
-		
-		@endif
-
-		@include('errors.list')
-		
-		@if(isset($context) && ($context!=='recent' && $context!=='uploads' && $context!=='trash'))
-			@include('documents.facets')
-		@endif
-
-		@yield('document_list_area')
-
-	</div>
-
-</div>
-
-@include('documents.partials.uploadinfo')
-
-@stop
 
 
 
 
-
-@section('panels')
-
-@include('panels.generic')
-
-@stop
 
 @section('scripts')
 

--- a/resources/views/documents/projects/layout.blade.php
+++ b/resources/views/documents/projects/layout.blade.php
@@ -1,53 +1,7 @@
-@extends('layout.sidebar')
+@extends('layout.explore')
 
 
 
-@section('breadcrumbs')
-
-	@if(isset($filter) && !is_null($filter) )
-		
-		@if($context ==='group' && isset($context_group_instance))
-		
-			@if($context_group_instance->is_private)
-				
-				<span  class="breadcrumb__item">{{trans('groups.collections.personal_title')}}</span>
-			
-			@else 
-				
-				<a href="{{route('documents.projects.index')}}"  class="breadcrumb__item">{{trans('groups.collections.private_title')}}</a>
-			
-			@endif
-
-		@elseif($context!=='projectspage')
-		
-			<a href="{{route('documents.index')}}"  class="breadcrumb__item">{{trans('documents.page_title')}}</a>
-		
-		@endif
-		
-		 
-
-		@if(isset($parents) && $context ==='group')
-
-			@foreach ($parents as $parent)
-
-				<a href="{{route('documents.groups.show', $parent->id)}}"  class="breadcrumb__item">{{$parent->name}}</a>
-			
-			@endforeach
-
-		@endif
-
-
-		<span class="breadcrumb__item--current">{{$filter}}</span>
-
-	@else
-
-		<span class="breadcrumb__item--current">{{trans('documents.page_title')}}</span>
-
-	@endif
-
-
-
-@stop
 
 
 @section('action-menu')
@@ -150,19 +104,7 @@
 
 @stop
 
-@section('document_list_area')
-
-
-@if(isset($info_message) && !is_null($info_message))
-<div class="c-message c-message--info">
-	{{$info_message}}
-</div>
-@endif
-
-	<div class="list {{$list_style_current}}" >
-
-		<div class="list__header">
-			@section('list_header')
+@section('list_header')
 
 				<div class="list__column list__column--large">{{trans('documents.descriptor.name')}}</div>
 
@@ -178,6 +120,16 @@
 				@endif
 			@endsection
 
+{{-- @section('document_list_area')
+
+
+
+
+	<div class="list {{$list_style_current}}" >
+
+		<div class="list__header">
+			
+
 			@yield('list_header')
 		</div>
 
@@ -185,80 +137,33 @@
 
 	</div>
 	
-	@if( isset($pagination) && !is_null($pagination) )
-		<div class="pagination-container">
 
-			{!! $pagination->render() !!}
-
-		</div>
-	@endif
-
-@stop
-
-@section('sidebar')
-
-@include('documents.menu')
-	
-@endsection
-
-@section('page')
-
-
-<div id="documents-list" class="non-map">
-
-	<div id="document-area">
-		
-		@if(isset($hint) && $hint)
-		
-			<div class="alert info">
-				{{$hint}}
-			</div>
-		
-		@endif
-
-		@include('errors.list')
-		
-		
-		@include('documents.facets')
-		
-
-		@yield('document_list_area')
-
-	</div>
-
-</div>
-
-@include('documents.partials.uploadinfo')
-
-@stop
+@stop --}}
 
 
 
 
 
-@section('panels')
 
-@include('panels.generic')
 
-@stop
 
 @section('scripts')
 
 	<script>
 
-	(function(){
+	// (function(){
 
-		var subHeader = $(".breadcrumbs");
+	// 	var subHeader = $(".breadcrumbs");
 
-		if(subHeader){
+	// 	if(subHeader){
 			
-			var actions = subHeader.find(".actions");
-			var parentNavigation = subHeader.find(".parent-navigation");
+	// 		var actions = subHeader.find(".actions");
+	// 		var parentNavigation = subHeader.find(".parent-navigation");
 
-			parentNavigation.width(subHeader.width() - actions.width() - 50 /*scrollbar width*/);
-		}
+	// 		parentNavigation.width(subHeader.width() - actions.width() - 50 /*scrollbar width*/);
+	// 	}
 
-	})();
+	// })();
 
 	require(['modules/documents', 'modules/list-switcher'], function(Documents){
 

--- a/resources/views/documents/recent.blade.php
+++ b/resources/views/documents/recent.blade.php
@@ -1,42 +1,43 @@
 @extends('documents.document-layout')
 
-@section('page-action')
 
-
-@stop
-
-
-@section('document_list_area')
+@section('additional_actions')
 
 	<div class="page-actions">
 
-			@unless(isset($is_search_requested) && $is_search_requested)
-				<div class="page-actions__label hint--bottom" data-hint="{{ trans('actions.sort_by.label') }}">
-					<a href="?o=a" class="button @if($order==='ASC') button--selected @endif">{{ trans('actions.sort_by.oldest_first') }}</a>
-					<a href="?o=d" class="button @if($order==='DESC') button--selected @endif">{{ trans('actions.sort_by.newest_first') }}</a>
-				</div>
-			@endif
-
-			<div class="page-actions__label hint--bottom" data-hint="{{ trans('documents.filtering.date_range_hint') }}">
-					<a href="{{ route('documents.recent', array_merge(['range' => 'today'], $search_replica_parameters)) }}" class="button @if($range==='today') button--selected @endif">{{ trans('documents.filtering.today') }}</a>
-					<a href="{{ route('documents.recent', array_merge(['range' => 'yesterday'], $search_replica_parameters)) }}" class="button @if($range==='yesterday') button--selected @endif">{{ trans('documents.filtering.yesterday') }}</a>
-					<a href="{{ route('documents.recent', array_merge(['range' => 'currentweek'], $search_replica_parameters)) }}" class="button @if($range==='currentweek') button--selected @endif">{{ trans('documents.filtering.currentweek') }}</a>
-					<a href="{{ route('documents.recent', array_merge(['range' => 'currentmonth'], $search_replica_parameters)) }}" class="button @if($range==='currentmonth') button--selected @endif">{{ trans('documents.filtering.currentmonth') }}</a> 
+		@unless(isset($is_search_requested) && $is_search_requested)
+			<div class="page-actions__label hint--bottom" data-hint="{{ trans('actions.sort_by.label') }}">
+				<a href="?o=a" class="button @if($order==='ASC') button--selected @endif">{{ trans('actions.sort_by.oldest_first') }}</a>
+				<a href="?o=d" class="button @if($order==='DESC') button--selected @endif">{{ trans('actions.sort_by.newest_first') }}</a>
 			</div>
+		@endif
 
-			<div class="page-actions__label hint--bottom" data-hint="{{ trans('documents.filtering.items_per_page_hint') }}">
-					<a href="{{ route('documents.recent', array_merge(['range' => $range, 'n' => 12], $search_replica_parameters)) }}" class="button @if(auth()->user()->optionItemsPerPage() == 12) button--selected @endif">12</a>
-					<a href="{{ route('documents.recent', array_merge(['range' => $range, 'n' => 24], $search_replica_parameters)) }}" class="button @if(auth()->user()->optionItemsPerPage() == 24) button--selected @endif">24</a>
-					<a href="{{ route('documents.recent', array_merge(['range' => $range, 'n' => 50], $search_replica_parameters)) }}" class="button @if(auth()->user()->optionItemsPerPage() == 50) button--selected @endif">50</a>
-			</div>
-		
-	</div>
+		<div class="page-actions__label hint--bottom" data-hint="{{ trans('documents.filtering.date_range_hint') }}">
+				<a href="{{ route('documents.recent', array_merge(['range' => 'today'], $search_replica_parameters)) }}" class="button @if($range==='today') button--selected @endif">{{ trans('documents.filtering.today') }}</a>
+				<a href="{{ route('documents.recent', array_merge(['range' => 'yesterday'], $search_replica_parameters)) }}" class="button @if($range==='yesterday') button--selected @endif">{{ trans('documents.filtering.yesterday') }}</a>
+				<a href="{{ route('documents.recent', array_merge(['range' => 'currentweek'], $search_replica_parameters)) }}" class="button @if($range==='currentweek') button--selected @endif">{{ trans('documents.filtering.currentweek') }}</a>
+				<a href="{{ route('documents.recent', array_merge(['range' => 'currentmonth'], $search_replica_parameters)) }}" class="button @if($range==='currentmonth') button--selected @endif">{{ trans('documents.filtering.currentmonth') }}</a> 
+		</div>
+
+		<div class="page-actions__label hint--bottom" data-hint="{{ trans('documents.filtering.items_per_page_hint') }}">
+				<a href="{{ route('documents.recent', array_merge(['range' => $range, 'n' => 12], $search_replica_parameters)) }}" class="button @if(auth()->user()->optionItemsPerPage() == 12) button--selected @endif">12</a>
+				<a href="{{ route('documents.recent', array_merge(['range' => $range, 'n' => 24], $search_replica_parameters)) }}" class="button @if(auth()->user()->optionItemsPerPage() == 24) button--selected @endif">24</a>
+				<a href="{{ route('documents.recent', array_merge(['range' => $range, 'n' => 50], $search_replica_parameters)) }}" class="button @if(auth()->user()->optionItemsPerPage() == 50) button--selected @endif">50</a>
+		</div>
 	
-	@if(isset($info_message) && !is_null($info_message))
-	<div class="c-message">
-		@materialicon('action', 'info_outline', 'button__icon fill-current'){{$info_message}}
 	</div>
-	@endif
+
+@endsection
+
+@section('list_header')
+	<div class="list__column list__column--large">{{trans('documents.descriptor.name')}}</div>
+	<div class="list__column list__column--hideable">{{trans('documents.descriptor.added_by')}}</div>
+	<div class="list__column">{{trans('documents.descriptor.last_modified')}}</div>
+	<div class="list__column list__column--hideable">{{trans('documents.descriptor.language')}}</div>
+@endsection
+
+
+@section('document_area')
 
 	@if(empty($groupings))
 
@@ -58,34 +59,16 @@
 
 	@else 
 
-		<div class="list {{$list_style_current}}" >
+		@foreach($groupings as $group)
 
-			<div class="list__header">
-					<div class="list__column list__column--large">{{trans('documents.descriptor.name')}}</div>
-					<div class="list__column list__column--hideable">{{trans('documents.descriptor.added_by')}}</div>
-					<div class="list__column">{{trans('documents.descriptor.last_modified')}}</div>
-					<div class="list__column list__column--hideable">{{trans('documents.descriptor.language')}}</div>
-			</div>
+			<div class="list__section">{{$group}}</div>
 
+			@include('documents.partials.listing', ['documents' => $documents[$group], 'documents_count' => count($documents[$group])])
 
-			@foreach($groupings as $group)
+		@endforeach
 
-				<div class="list__section">{{$group}}</div>
-
-				@include('documents.partials.listing', ['documents' => $documents[$group], 'documents_count' => count($documents[$group])])
-
-			@endforeach
-
-		</div>
 	@endif
 	
-	@if( isset($pagination) && !is_null($pagination) )
-		<div class="pagination-container">
-
-			{!! $pagination->render() !!}
-
-		</div>
-	@endif
 
 @stop
 

--- a/resources/views/documents/trash.blade.php
+++ b/resources/views/documents/trash.blade.php
@@ -2,7 +2,7 @@
 
 @section('page-action')
 
-	<a href="#" class="action__button" rv-disabled="nothingIsSelected" rv-on-click="restore">
+	<a href="#" class="action__button mr-2" rv-disabled="nothingIsSelected" rv-on-click="restore">
 		@materialicon('action','settings_backup_restore'){{trans('actions.restore')}}
 	</a>
 	

--- a/resources/views/layout/explore.blade.php
+++ b/resources/views/layout/explore.blade.php
@@ -1,0 +1,139 @@
+@extends('layout.sidebar')
+
+
+@section('page')
+
+    <div id="documents-list">
+
+        @yield('additional_actions')
+
+        @if(isset($info_message) && !is_null($info_message))
+            <div class="c-message c-message--info mt-4">
+                @materialicon('action', 'info_outline', 'button__icon fill-current'){{$info_message}}
+            </div>
+        @endif
+
+        <div id="document-area">
+            
+            
+            
+            @if(isset($hint) && $hint)
+            
+                <div class="alert info">
+                    {{$hint}}
+                </div>
+            
+            @endif
+
+            @include('errors.list')
+
+            
+            @if(isset($context) && ($context!=='recent' && $context!=='uploads' && $context!=='trash'))
+                @include('documents.facets')
+            @endif
+
+            
+
+            <div class="list {{$list_style_current}}" >
+
+                <div class="list__header">
+
+                    @hasSection ('list_header')
+
+                        @yield('list_header')
+
+                    @else
+                        
+                        <div class="list__column list__column--large">{{trans('documents.descriptor.name')}}</div>
+                        <div class="list__column list__column--hideable">{{trans('documents.descriptor.added_by')}}</div>
+                        
+                        <div class="list__column">{{trans('documents.descriptor.last_modified')}}</div>
+                        <div class="list__column list__column--hideable">{{trans('documents.descriptor.language')}}</div>
+                    @endif
+                    
+                </div>
+
+                @yield('document_area')
+
+            </div>
+
+
+
+            @if( isset($pagination) && !is_null($pagination) )
+                <div class="pagination-container">
+
+                    {!! $pagination->render() !!}
+
+                </div>
+            @endif
+
+        </div>
+
+    </div>
+
+    @include('documents.partials.uploadinfo')
+
+@stop
+
+@section('sidebar')
+
+    @include('documents.menu')
+	
+@endsection
+
+@section('breadcrumbs')
+
+	@if(isset($filter) && !is_null($filter) )
+		
+		@if($context ==='group' && isset($context_group_instance))
+		
+			@if(isset($context_group_shared) && $context_group_shared)
+
+				<a href="{{route('documents.sharedwithme')}}" class="breadcrumb__item">{{trans('documents.menu.shared')}}</a>
+
+			@elseif($context_group_instance->is_private)
+				
+				<span class="breadcrumb__item">{{trans('groups.collections.personal_title')}}</span>
+			
+			@else 
+				
+				<a href="{{route('documents.projects.index')}}" class="breadcrumb__item">{{trans('groups.collections.private_title')}}</a>
+			
+			@endif
+
+		@elseif($context!=='projectspage')
+		
+			<a href="{{route('documents.index')}}" class="breadcrumb__item">{{trans('documents.page_title')}}</a>
+		
+		@endif
+		
+		 
+
+		@if(isset($parents) && $context ==='group')
+
+			@foreach ($parents as $parent)
+
+				<a href="{{route('documents.groups.show', $parent->id)}}" class="breadcrumb__item">{{$parent->name}}</a>
+			
+			@endforeach
+
+		@endif
+
+
+		<span class="breadcrumb__item--current">{{$filter}}</span>
+
+	@else
+
+		<span class="breadcrumb__item--current">{{trans('documents.page_title')}}</span>
+
+	@endif
+
+
+
+@stop
+
+@section('panels')
+
+    @include('panels.generic')
+
+@stop

--- a/resources/views/share/list.blade.php
+++ b/resources/views/share/list.blade.php
@@ -7,11 +7,11 @@
 
 	<a href="{{route('shares.index')}}"  class="breadcrumb__item">{{trans('share.page_title')}}</a>
 	
-	<span  class="breadcrumb__item"{{$shared_group->name}}</span>
+	<span  class="breadcrumb__item">{{$shared_group->name}}</span>
 
 @else
 
-	<span  class="breadcrumb__item"{{trans('share.page_title')}}</span>
+	<span  class="breadcrumb__item">{{trans('share.page_title')}}</span>
 
 @endif
 		


### PR DESCRIPTION
## What does this PR do?

Add a common ancestor to `documents-layout` and `document.projects.layout`. The layout is called `explore` and inherit the sidebar layout. It serve as a way to reduce boilerplate code needed in case of document listing

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)