### PR TITLE
Use array_sort to ensure element order as Travis build fails

### DIFF
--- a/tests/Feature/DuplicateDocumentsControllerTest.php
+++ b/tests/Feature/DuplicateDocumentsControllerTest.php
@@ -254,8 +254,8 @@ class DuplicateDocumentsControllerTest extends TestCase
         $this->assertTrue($duplicate->fresh()->resolved, "Duplicate not marked as resolved");
 
         $this->assertEquals(
-            collect([$collection_for_existing->id, $collection_for_duplicate->id])->sort()->toArray(),
-            $existing_document->fresh()->groups()->pluck('group_id')->sort()->toArray()
+            array_sort([$collection_for_existing->id, $collection_for_duplicate->id]),
+            array_sort($existing_document->fresh()->groups()->pluck('group_id')->toArray())
         );
     }
 }

--- a/tests/Feature/DuplicateDocumentsControllerTest.php
+++ b/tests/Feature/DuplicateDocumentsControllerTest.php
@@ -253,13 +253,10 @@ class DuplicateDocumentsControllerTest extends TestCase
         $this->assertTrue($duplicate_document->fresh()->trashed(), "Duplicate document not trashed");
         $this->assertTrue($duplicate->fresh()->resolved, "Duplicate not marked as resolved");
 
-        $expected_collections = [$collection_for_existing->id, $collection_for_duplicate->id];
         $found_collections = $existing_document->fresh()->groups()->pluck('group_id')->toArray();
-        asort($expected_collections);
-        asort($found_collections);
-        $this->assertEquals(
-            $expected_collections,
-            $found_collections
-        );
+        
+        $this->assertCount(2, $found_collections);
+        $this->assertContains($collection_for_existing->id, $found_collections);
+        $this->assertContains($collection_for_duplicate->id, $found_collections);
     }
 }

--- a/tests/Feature/DuplicateDocumentsControllerTest.php
+++ b/tests/Feature/DuplicateDocumentsControllerTest.php
@@ -253,9 +253,13 @@ class DuplicateDocumentsControllerTest extends TestCase
         $this->assertTrue($duplicate_document->fresh()->trashed(), "Duplicate document not trashed");
         $this->assertTrue($duplicate->fresh()->resolved, "Duplicate not marked as resolved");
 
+        $expected_collections = [$collection_for_existing->id, $collection_for_duplicate->id];
+        $found_collections = $existing_document->fresh()->groups()->pluck('group_id')->toArray();
+        asort($expected_collections);
+        asort($found_collections);
         $this->assertEquals(
-            array_sort([$collection_for_existing->id, $collection_for_duplicate->id]),
-            array_sort($existing_document->fresh()->groups()->pluck('group_id')->toArray())
+            $expected_collections,
+            $found_collections
         );
     }
 }


### PR DESCRIPTION
## What does this PR do?

...

### Related issues

Fixes ...

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)