### PR TITLE
Fix #308 Profile update denied if user didn't change the nicename/use…

### DIFF
--- a/app/Http/Requests/ProfileUpdateRequest.php
+++ b/app/Http/Requests/ProfileUpdateRequest.php
@@ -3,6 +3,7 @@
 namespace KBox\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest as Request;
+use Illuminate\Validation\Rule;
 use KBox\User;
 
 class ProfileUpdateRequest extends Request
@@ -26,7 +27,7 @@ class ProfileUpdateRequest extends Request
     public function rules()
     {
         return [
-            'name' => 'sometimes|required|string|unique:users,name',
+            'name' => 'sometimes|required|string|' . Rule::unique('users', 'name')->ignore($this->user()->id),
             'organization_name' => 'sometimes|nullable|string',
             'organization_website' => 'sometimes|nullable|url',
         ];

--- a/app/Http/Requests/ProfileUpdateRequest.php
+++ b/app/Http/Requests/ProfileUpdateRequest.php
@@ -27,7 +27,7 @@ class ProfileUpdateRequest extends Request
     public function rules()
     {
         return [
-            'name' => 'sometimes|required|string|' . Rule::unique('users', 'name')->ignore($this->user()->id),
+            'name' => 'sometimes|required|string|'.Rule::unique('users', 'name')->ignore($this->user()->id),
             'organization_name' => 'sometimes|nullable|string',
             'organization_website' => 'sometimes|nullable|url',
         ];

--- a/tests/Feature/UserProfileControllerTest.php
+++ b/tests/Feature/UserProfileControllerTest.php
@@ -89,6 +89,7 @@ class UserProfileControllerTest extends TestCase
         $old_organization_website = $user->organization_website;
         
         $response = $this->from(route('profile.index'))->actingAs($user)->put(route('profile.update'), [
+            'name' => $user->name,
             'organization_name' => 'New organization',
             'organization_website' => 'https://www.org.new',
             '_token' => csrf_token()
@@ -117,6 +118,7 @@ class UserProfileControllerTest extends TestCase
         $old_organization_website = $user->organization_website;
         
         $response = $this->from(route('profile.index'))->actingAs($user)->put(route('profile.update'), [
+            'name' => $user->name,
             'organization_name' => '',
             'organization_website' => '',
             '_token' => csrf_token()


### PR DESCRIPTION
## What does this PR do?

Allows users to update their profile without changing their username.

### Related issues

Fixes #308 

### Review checklist

* [x] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)