### PR TITLE
Update xpdf tools to version 4.02

### DIFF
--- a/packages/contentprocessing/src/ComposerScripts.php
+++ b/packages/contentprocessing/src/ComposerScripts.php
@@ -16,15 +16,15 @@ class ComposerScripts
      * Maps the OS family (according to PHP) to the required file
      */
     private static $file_for_os = [
-        'windows' => 'xpdf-tools-win-4.01.01.zip',
-        'linux' => 'xpdf-tools-linux-4.01.01.tar.gz',
-        'darwin' => 'xpdf-tools-mac-4.01.01.tar.gz'
+        'windows' => 'xpdf-tools-win-4.02.zip',
+        'linux' => 'xpdf-tools-linux-4.02.tar.gz',
+        'darwin' => 'xpdf-tools-mac-4.02.tar.gz'
     ];
 
     private static $version = [
-        'windows' => 'xpdf-tools-win-4.01.01',
-        'linux' => 'xpdf-tools-linux-4.01.01',
-        'darwin' => 'xpdf-tools-mac-4.01.01'
+        'windows' => 'xpdf-tools-win-4.02',
+        'linux' => 'xpdf-tools-linux-4.02',
+        'darwin' => 'xpdf-tools-mac-4.02'
     ];
 
     private static $architecture = 'bin64';


### PR DESCRIPTION
## What does this PR do?

Update xpdf tools to version 4.02 as current version cannot be downloaded anymore

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)