### PR TITLE
Fix link highlight same as background

### DIFF
--- a/resources/assets/css/components/grids.css
+++ b/resources/assets/css/components/grids.css
@@ -318,7 +318,9 @@
 }
 
 
-
+.item--selected:hover .item__link {
+	@apply text-white;
+}
 
 
 


### PR DESCRIPTION
## What does this PR do?

Fix selected item anchor mouse over style that was hiding the text

**before**

![image](https://user-images.githubusercontent.com/5672748/65973176-2848bd00-e46b-11e9-8260-5b33f0a0b976.png)

**after**

![image](https://user-images.githubusercontent.com/5672748/65973191-30086180-e46b-11e9-8f32-1d0782a08f93.png)



### Related issues

Fixes ...

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)