### PR TITLE
Ensure that requested locale is supported by the application

### DIFF
--- a/app/Http/Middleware/Locale.php
+++ b/app/Http/Middleware/Locale.php
@@ -5,6 +5,8 @@ namespace KBox\Http\Middleware;
 use App;
 use Config;
 use Session;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Lang;
 use Jenssegers\Date\Date as LocalizedDate;
 
 /**
@@ -22,52 +24,87 @@ final class Locale
      */
     public function handle($request, $next)
     {
-        $language = Session::get('language', config('app.locale'));
-        $force = false;
-
-        if (auth()->check()) {
-            // if the user is authenticated get the language configured in the options
-            $user_selected = auth()->user()->optionLanguage();
-
-            if (! is_null($user_selected)) {
-                $language = $user_selected;
-                $force = true;
-            }
-        }
-
-        $browser_language_preference = $request->header('ACCEPT_LANGUAGE', null);
-
-        if (! $force && ! empty($browser_language_preference)) {
-            // set the locale of the browser if available
-
-            $languages = collect(explode(',', $browser_language_preference));
-
-            $keyed = $languages->map(function ($item) {
-                $lang = substr(ltrim($item), 0, 2);
-                if (strlen($lang) < 2) {
-                    $lang = config('app.locale');
-                }
-                $factor = '1.0';
-
-                if (str_contains($item, ';q=')) {
-                    $factor = str_after($item, ';q=');
-                }
-
-                return compact('lang', 'factor');
-            })->sortByDesc('factor')->first();
-
-            $language = $keyed['lang'];
-        }
-
-        if (empty($language)) {
-            // this because the user might not have a option language property defined or might be empty
-            $language = config('app.locale');
-        }
+        $language = $this->ensureLocaleSupported(
+            $this->getUserLocale() ?? $this->getRequestLocale($request),
+            Session::get('language', config('app.locale'))
+        );
 
         App::setLocale($language);
 
         LocalizedDate::setLocale($language);
 
         return $next($request);
+    }
+
+    /**
+     * Get the user configured locale, if authenticated
+     *
+     * @return string|null
+     */
+    private function getUserLocale()
+    {
+        if (! auth()->check()) {
+            return null;
+        }
+
+        $user_selected = auth()->user()->optionLanguage();
+
+        return $user_selected ?? null;
+    }
+
+    /**
+     * Retrieve the browser requested locale, if available
+     *
+     * @return string|null
+     */
+    private function getRequestLocale(Request $request)
+    {
+        $browser_language_preference = $request->header('ACCEPT_LANGUAGE', null);
+
+        if (empty($browser_language_preference)) {
+            return null;
+        }
+
+        $languages = collect(explode(',', $browser_language_preference));
+
+        $keyed = $languages->map(function ($item) {
+            $lang = substr(ltrim($item), 0, 2);
+            if (strlen($lang) < 2) {
+                $lang = config('app.locale');
+            }
+            $factor = '1.0';
+
+            if (str_contains($item, ';q=')) {
+                $factor = str_after($item, ';q=');
+            }
+
+            return compact('lang', 'factor');
+        })->sortByDesc('factor')->first();
+
+        return $keyed['lang'] ?? null;
+    }
+
+    /**
+     * Ensure that the selected locale is
+     * supported by the application
+     *
+     * @param string $locale
+     * @return string the locale, if supported, otherwise the default fallback locale
+     */
+    private function ensureLocaleSupported($locale, $default = null)
+    {
+        if (! $locale) {
+            return $default ?? config('app.locale');
+        }
+
+        if (! Lang::hasForLocale('validation.accepted', $locale)) {
+            // we check a known key that should be present
+            // if the language is supported (or partially supported)
+            // if the key is not present, the language
+            // is not supported and the fallback will be used
+            return $default ?? config('app.locale');
+        }
+
+        return $locale;
     }
 }


### PR DESCRIPTION
## What does this PR do?

Ensure that the locale, either requested by the browser or selected by the user, is supported by the application before setting it as current locale for the request.

This prevents the case of localized time ago date and time in the language specified by the browser even if that language is not supported (i.e. no language files are present).

To check that a locale is supported the `validation.accepted` key is used. If that key is translated into the specified locale, then the locale is considered supported for the UI localization.

### Review checklist

* [x] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [x] Is history cleaned up? (or can be squashed on merge?)