### PR TITLE
Fix test failure due to check of unescaped strings

### DIFF
--- a/tests/Feature/GroupDetailsControllerTest.php
+++ b/tests/Feature/GroupDetailsControllerTest.php
@@ -36,7 +36,7 @@ class GroupDetailsControllerTest extends TestCase
         $response->assertViewHas('is_project', false);
         $response->assertViewHas('can_share', true);
 
-        $response->assertSee($user->name);
+        $response->assertSee(e($user->name));
     }
 
     public function test_details_forbidden_if_collection_not_mine()
@@ -79,7 +79,7 @@ class GroupDetailsControllerTest extends TestCase
         $response->assertViewHas('is_project', true);
         $response->assertViewHas('can_share', true);
 
-        $response->assertSee($user->name);
+        $response->assertSee(e($user->name));
     }
 
     public function test_details_for_shared_collection()
@@ -114,7 +114,7 @@ class GroupDetailsControllerTest extends TestCase
         $response->assertViewHas('share', $share);
         $response->assertViewHas('can_share', true);
 
-        $response->assertSee($user->name);
+        $response->assertSee(e($user->name));
         $response->assertSee(trans('documents.descriptor.shared'));
         $response->assertSee(trans('share.shared_on'));
     }


### PR DESCRIPTION
## What does this PR do?

Fixes a couple of tests that do not check for escaped strings

### Related issues

Fixes ...

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)