### PR TITLE
Dispatch immediately the quota calculation

### DIFF
--- a/app/Listeners/UploadCompletedHandler.php
+++ b/app/Listeners/UploadCompletedHandler.php
@@ -38,7 +38,7 @@ class UploadCompletedHandler implements ShouldQueue
             // to the elaboration queue
             elaborate($descriptor);
 
-            CalculateUserUsedQuota::dispatch($event->user)->delay(now()->addMinutes(10));
+            CalculateUserUsedQuota::dispatchNow($event->user);
         } catch (Exception $ex) {
             Log::error('Error while handling the UploadCompletedEvent.', ['event' => $event,'error' => $ex]);
             $event->descriptor->status = DocumentDescriptor::STATUS_ERROR;

--- a/tests/Unit/UploadCompletedHandlerTest.php
+++ b/tests/Unit/UploadCompletedHandlerTest.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\Event;
 use KBox\Events\FileDuplicateFoundEvent;
 use KBox\Listeners\UploadCompletedHandler;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
-use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Bus;
 use KBox\DocumentsElaboration\Facades\DocumentElaboration;
 use KBox\Jobs\CalculateUserUsedQuota;
 
@@ -178,7 +178,7 @@ class UploadCompletedHandlerTest extends TestCase
     public function test_calculate_used_quota_job_dispatched()
     {
         $this->disableExceptionHandling();
-        Queue::fake();
+        Bus::fake();
         $this->withKlinkAdapterFake();
         
         $service = app('KBox\Documents\Services\DocumentsService');
@@ -220,6 +220,6 @@ class UploadCompletedHandlerTest extends TestCase
 
         $handler->handle($uploadCompleteEvent);
 
-        Queue::assertPushed(CalculateUserUsedQuota::class);
+        Bus::assertDispatched(CalculateUserUsedQuota::class);
     }
 }


### PR DESCRIPTION
## What does this PR do?

Dispatch immediately the user quota calculation after a completed file upload

### Related issues

Fixes #307 

### Review checklist

* [x] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)