### PR TITLE
Show public link sharing as coming soon for collections

### DIFF
--- a/resources/lang/en/notices.php
+++ b/resources/lang/en/notices.php
@@ -35,4 +35,6 @@ return [
     'uploads_blocked_admin' => 'Read-only mode is active. File uploads are blocked. Please review the configuration.',
 
     'disabled_user' => '[disabled user]',
+
+    'coming_soon' => 'Coming Soon',
 ];

--- a/resources/views/share/dialog.blade.php
+++ b/resources/views/share/dialog.blade.php
@@ -58,10 +58,8 @@
 
 						<select name="linktype" id="linktype" class="js-link-type form-select w-full">
 
-							<option value="internal" @unless($public_link) selected @endif>{{ trans('share.dialog.linkshare_members_only') }}</option>
-							@unless($has_groups)
-								<option value="public" @if($public_link) selected @endif>{{ trans('share.dialog.linkshare_public') }}</option>
-							@endunless
+							<option value="internal" @unless($public_link) selected @endif>{{ trans('share.dialog.linkshare_members_only') }}</option>							
+							<option value="public" @if($has_groups) disabled @endif @if($public_link) selected @endif>{{ trans('share.dialog.linkshare_public') }}@if($has_groups) ({{ trans('notices.coming_soon') }}) @endif</option>
 						
 						</select>
 


### PR DESCRIPTION
## What does this PR do?

Always show both options for "who has access" on a share

![image](https://user-images.githubusercontent.com/5672748/66552845-5d7b9c00-eb4a-11e9-8228-f9dcbf84b42c.png)

### Review checklist

* [x] Are unit tests required?
* [x] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)