### PR TITLE
Fix current language not reported in profile

### DIFF
--- a/app/Http/Controllers/UserProfileController.php
+++ b/app/Http/Controllers/UserProfileController.php
@@ -3,6 +3,7 @@
 namespace KBox\Http\Controllers;
 
 use Illuminate\Contracts\Auth\Guard as Auth;
+use Illuminate\Support\Facades\App;
 use KBox\Http\Requests\ProfileUpdateRequest;
 
 class UserProfileController extends Controller
@@ -34,7 +35,7 @@ class UserProfileController extends Controller
 
         $pagetitle = trans('profile.page_title', ['name' => $user->name]);
         
-        $language = $user->optionLanguage('en');
+        $language = $user->optionLanguage(App::getLocale() ?? config('app.locale'));
 
         return view('profile.user', compact('pagetitle', 'user', 'stars_count', 'shares_count', 'documents_count', 'collections_count', 'language'));
     }

--- a/resources/views/profile/user.blade.php
+++ b/resources/views/profile/user.blade.php
@@ -85,7 +85,11 @@
 				<span class="field-error">{{ implode(",", $errors->get('language'))  }}</span>
 			@endif
 			
-			<select class="form-select" name="language">
+			<select class="form-select block mt-1" name="language" autocomplete="off">
+				{{-- 
+					autocomplete="off" force Firefox to not cache the selected value and use always the latest
+					https://stackoverflow.com/questions/10870567/firefox-not-refreshing-select-tag-on-page-refresh
+				--}}
 				<option value="en" @if($language=='en') selected @endif>{{trans('languages.en')}}</option>
 				<option value="ru" @if($language=='ru') selected @endif>{{trans('languages.ru')}}</option>
 				<option value="tg" @if($language=='tg') selected @endif>{{trans('languages.tg')}}</option>

--- a/tests/Feature/UserProfileControllerTest.php
+++ b/tests/Feature/UserProfileControllerTest.php
@@ -35,6 +35,44 @@ class UserProfileControllerTest extends TestCase
         $response->assertSuccessful();
         $response->assertViewIs('profile.user');
     }
+
+    public function test_current_requested_language_is_visible()
+    {
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+        
+        $response = $this
+            ->withHeaders([
+                'ACCEPT_LANGUAGE' => 'fr',
+            ])
+            ->actingAs($user)
+            ->get(route('profile.index'));
+            
+        $response->assertSuccessful();
+        $response->assertViewIs('profile.user');
+        $response->assertViewHas('language', 'fr');
+    }
+    
+    public function test_user_set_language_is_visible()
+    {
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+            $u->options()->create([
+                'key' => User::OPTION_LANGUAGE,
+                'value' => 'fr'
+            ]);
+        });
+        
+        $response = $this
+            ->actingAs($user)
+            ->get(route('profile.index'));
+            
+        $response->assertSuccessful();
+        $response->assertViewIs('profile.user');
+
+        $response->assertViewHas('language', 'fr');
+    }
     
     public function test_user_can_change_name()
     {


### PR DESCRIPTION
## What does this PR do?

Ensure that the current language of the UI is reported, as selected, in the user profile page


### Review checklist

* [x] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [x] Is history cleaned up? (or can be squashed on merge?)