### PR TITLE
Update Laravel version in links

### DIFF
--- a/docs/developer/commands/index.md
+++ b/docs/developer/commands/index.md
@@ -4,7 +4,7 @@
 > K-Box instance.
 
 
-The K-Box command line suite of commands rely on the [Laravel Artisan CLI](https://laravel.com/docs/5.2/artisan).
+The K-Box command line suite of commands rely on the [Laravel Artisan CLI](https://laravel.com/docs/5.7/artisan).
 
 Here are only listed the specific commands added by the K-Box:
 

--- a/docs/developer/database.md
+++ b/docs/developer/database.md
@@ -142,7 +142,7 @@ A Project cannot be deleted.
 
 Sharing of documents and collection is realized with the help of the *shared* table.
 
-In this table there are two [polymorphic relations](http://laravel.com/docs/5.0/eloquent#polymorphic-relations):
+In this table there are two [polymorphic relations](http://laravel.com/docs/5.7/eloquent#polymorphic-relations):
 
 1. `shareable`: the shared element, could be an instance of *document_descriptor* or a *group*
 2. `sharedwith`: with who I'm sharing something. Can be a *users* or a *peoplegroups* instance
@@ -150,7 +150,7 @@ In this table there are two [polymorphic relations](http://laravel.com/docs/5.0/
 
 ## Database to PHP Class and Database table construction
 
-The mapping between database tables and PHP classes are handled by [Laravel Eloquent](http://laravel.com/docs/5.0/eloquent). All the models that pertain to a database table is stored in the `app` folder in the source code.
+The mapping between database tables and PHP classes are handled by [Laravel Eloquent](http://laravel.com/docs/5.7/eloquent). All the models that pertain to a database table is stored in the `app` folder in the source code.
 
-The database tables are created using [Laravel's migrations](http://laravel.com/docs/5.0/migrations). The source code is stored in the `database` folder.
+The database tables are created using [Laravel's migrations](http://laravel.com/docs/5.7/migrations). The source code is stored in the `database` folder.
 

--- a/docs/developer/database.md
+++ b/docs/developer/database.md
@@ -142,7 +142,7 @@ A Project cannot be deleted.
 
 Sharing of documents and collection is realized with the help of the *shared* table.
 
-In this table there are two [polymorphic relations](http://laravel.com/docs/5.7/eloquent#polymorphic-relations):
+In this table there are two [polymorphic relations](https://laravel.com/docs/5.7/eloquent-relationships#polymorphic-relationships):
 
 1. `shareable`: the shared element, could be an instance of *document_descriptor* or a *group*
 2. `sharedwith`: with who I'm sharing something. Can be a *users* or a *peoplegroups* instance

--- a/docs/developer/facades.md
+++ b/docs/developer/facades.md
@@ -18,4 +18,4 @@ This is a useful tool for quickly digging into the API documentation.
 
 ## Laravel Facades
 
-As the K-Box is based on Laravel, we suggest to read also the [Laravel Facade documentation](https://laravel.com/docs/5.5/facades).
+As the K-Box is based on Laravel, we suggest to read also the [Laravel Facade documentation](https://laravel.com/docs/5.7/facades).

--- a/docs/developer/localization.md
+++ b/docs/developer/localization.md
@@ -24,7 +24,7 @@ Once logged in, the user, can select its preferred language for the User Interfa
 
 ## Language files
 
-Language files an localization rules follows the [Laravel Localization](http://laravel.com/docs/5.5/localization). 
+Language files an localization rules follows the [Laravel Localization](http://laravel.com/docs/5.7/localization). 
 
 The files are stored in `language` folders, represented by the two-letter language code (ISO 639-1).
 
@@ -74,8 +74,8 @@ The files are named accordingly to the license id in lower case and must be in m
 
 Laravel offer some helper methods to write localized strings in the PHP source code and in blade templates.
 
-- [`trans`](https://laravel.com/docs/5.2/helpers#method-trans)
-- [`trans_choice`](https://laravel.com/docs/5.2/helpers#method-trans-choice)
+- [`trans`](https://laravel.com/docs/5.7/helpers#method-trans)
+- [`trans_choice`](https://laravel.com/docs/5.7/helpers#method-trans-choice)
 
 
 ### Date and time localization

--- a/docs/developer/plugins/plugins.md
+++ b/docs/developer/plugins/plugins.md
@@ -7,7 +7,7 @@
 
 A plugin delivers customizations to the K-Box without the requirement to have a custom build (or fork) of the codebase.
 
-As of now a K-Box plugin is highly inspired by the [Laravel Packages](https://laravel.com/docs/5.5/packages) approach, 
+As of now a K-Box plugin is highly inspired by the [Laravel Packages](https://laravel.com/docs/5.7/packages) approach, 
 in fact, as described in the [limitations](#limitations), it is loaded like a Laravel Package with the help of Composer.
 
 ## How to create a plugin

--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -19,10 +19,18 @@ $ php artisan db:seed --env=testing
 After that you can run
 
 ```
-$ ./vendor/bin/phpunit
+./vendor/bin/phpunit
 ```
 
-> Please consider that the documentation might be out-dated as Laravel 5.5 deprecated the core support for BrowserKit tests. Currently most of the unit tests in the K-Box code are BrowserKit based. **Newly created tests should follow the Laravel 5.5 (and above) approach.**
+## Create new tests
+
+To create new feature or unit test execute
+
+```bash
+php artisan make:test [--unit] {TestClass}
+```
+
+> For more information please refer to [Laravel's official documentation](https://laravel.com/docs/5.7/testing#creating-and-running-tests)
 
 ## Helper methods
 
@@ -42,7 +50,7 @@ $this->swap('Class', new SubstituteClass());
 
 ## Mocking
 
-Beside the [Mocks](https://laravel.com/docs/5.5/mocking) and testing helpers defined 
+Beside the [Mocks](https://laravel.com/docs/5.7/mocking) and testing helpers defined 
 by Laravel, the K-Box offers some utilities.
 
 ### KlinkAdapter mock
@@ -58,7 +66,7 @@ at the beginning of your unit test. The method returns the Mockery\MockInterface
 you can use to set expectations on method calls. At the same time the mock instance is added to 
 the Laravel service container for binding resolution.
 
-## DocumentElaboration Fake
+### DocumentElaboration Fake
 
 As an alternative to mocking, you may use the `DocumentElaboration` facade's `fake` method to 
 prevent the elaboration pipeline from executing. You may then assert that a pipeline was 


### PR DESCRIPTION
## What does this PR do?

Update the links that points to the Laravel documentation to the current version we are using (5.7)

### Related issues

Fixes ...

### Review checklist

* [ ] Are unit tests required?
* [x] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)