### PR TITLE
Use Arr class instead of deprecated array_* helpers

### DIFF
--- a/app/Console/Commands/DmsSessionChecker.php
+++ b/app/Console/Commands/DmsSessionChecker.php
@@ -3,6 +3,7 @@
 namespace KBox\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Symfony\Component\Console\Input\InputOption;
 use KBox\User;
@@ -69,7 +70,7 @@ class DmsSessionChecker extends Command
         foreach ($sessions as $session) {
             $payload = @unserialize(base64_decode($session->payload));
             
-            $login_user = array_first($payload, function ($value, $key) {
+            $login_user = Arr::first($payload, function ($value, $key) {
                 return starts_with($key, 'login_');
             });
             

--- a/app/Console/Commands/FlagsCommand.php
+++ b/app/Console/Commands/FlagsCommand.php
@@ -3,6 +3,7 @@
 namespace KBox\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use KBox\Flags;
 
@@ -42,7 +43,7 @@ class FlagsCommand extends Command
      */
     public function handle()
     {
-        $flags = array_wrap($this->argument('flag'));
+        $flags = Arr::wrap($this->argument('flag'));
 
         $enable = $this->option('enable');
 

--- a/app/Console/Commands/Language/LanguageCheckCommand.php
+++ b/app/Console/Commands/Language/LanguageCheckCommand.php
@@ -9,6 +9,7 @@ use KBox\Console\Traits\DebugOutput;
 use Carbon\Carbon;
 
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Arr;
 
 /**
  * Verify that all the strings in english language files can be found in the other languages.
@@ -118,8 +119,8 @@ class LanguageCheckCommand extends Command
             $this->line("Checking $current_lang translations...");
             
             foreach ($lang_groups as $group) {
-                $expected_translations = array_keys(array_dot($translationLoader->load('en', $group)));
-                $loaded_translations = array_keys(array_dot($translationLoader->load($current_lang, $group)));
+                $expected_translations = array_keys(Arr::dot($translationLoader->load('en', $group)));
+                $loaded_translations = array_keys(Arr::dot($translationLoader->load($current_lang, $group)));
                 $diff_translations = array_diff($expected_translations, $loaded_translations);
 
                 $current_count_expected = count($expected_translations);
@@ -140,7 +141,7 @@ class LanguageCheckCommand extends Command
             $this->info("  {$current_count_percentage}% [{$count_strings} / {$count_total_strings}] ");
         }
 
-        $percentages = array_pluck($this->report, 'percentage');
+        $percentages = Arr::pluck($this->report, 'percentage');
 
         $this->line('');
         $this->comment("languages: ".count($directories));

--- a/app/DocumentsElaboration/Actions/GuessLanguage.php
+++ b/app/DocumentsElaboration/Actions/GuessLanguage.php
@@ -4,6 +4,7 @@ namespace KBox\DocumentsElaboration\Actions;
 
 use Log;
 use Exception;
+use Illuminate\Support\Arr;
 use KBox\Contracts\Action;
 use Rinvex\Language\LanguageLoader;
 use KBox\Documents\Services\TextExtractionService;
@@ -52,7 +53,7 @@ class GuessLanguage extends Action
             $language = LanguageLoader::where('iso_639_3', '=', $language_code);
 
             if ($language) {
-                $language = array_first($language);
+                $language = Arr::first($language);
                 $iso_639_1 = $language['iso_639_1'];
 
                 if (in_array($iso_639_1, config('dms.language_whitelist'))) {

--- a/app/Exceptions/CollectionMoveException.php
+++ b/app/Exceptions/CollectionMoveException.php
@@ -3,6 +3,7 @@
 namespace KBox\Exceptions;
 
 use Exception;
+use Illuminate\Support\Arr;
 use KBox\Group;
 
 /**
@@ -26,7 +27,7 @@ final class CollectionMoveException extends Exception
     {
         $this->collection = $collection;
         $this->reason = $reason;
-        $this->causedBy = collect(array_wrap($causedBy))->flatten();
+        $this->causedBy = collect(Arr::wrap($causedBy))->flatten();
         $names = $this->causedBy->map(function ($c) {
             if (\is_a($c, Group::class)) {
                 return $c->name;

--- a/app/FileProperties.php
+++ b/app/FileProperties.php
@@ -2,6 +2,7 @@
 
 namespace KBox;
 
+use Illuminate\Support\Arr;
 use ReflectionClass;
 use ReflectionException;
 use Illuminate\Support\Fluent;
@@ -36,7 +37,7 @@ class FileProperties extends Fluent
         // serialize with dot notation only the
         // attributes that are not excluded
 
-        $dotted = array_dot(collect($attributes)->except($this->exclude));
+        $dotted = Arr::dot(collect($attributes)->except($this->exclude));
         $preserve = collect($attributes)->only($this->exclude);
 
         return $preserve->merge($dotted);
@@ -95,7 +96,7 @@ class FileProperties extends Fluent
      */
     public function toArray()
     {
-        return array_prepend($this->attributes, get_class($this), '@class');
+        return Arr::prepend($this->attributes, get_class($this), '@class');
     }
 
     public function getClass()

--- a/app/Http/Controllers/Administration/UserAdministrationController.php
+++ b/app/Http/Controllers/Administration/UserAdministrationController.php
@@ -12,6 +12,7 @@ use KBox\Option;
 use Illuminate\Contracts\Auth\Guard;
 use Klink\DmsAdapter\KlinkAdapter;
 use Illuminate\Contracts\Auth\PasswordBroker as PasswordBrokerContract;
+use Illuminate\Support\Arr;
 use KBox\Notifications\UserCreatedNotification;
 use Illuminate\Support\Facades\DB;
 
@@ -219,7 +220,7 @@ class UserAdministrationController extends Controller
         'capabilities' => array_values($perms),
         'type_resolutor' => $type_resolutor,
         'edit_enabled' => $auth->user()->id != $user->id,
-        'caps' => array_pluck($user->capabilities()->get()->toArray(), 'key')
+        'caps' => Arr::pluck($user->capabilities()->get()->toArray(), 'key')
         ];
       
         return view('administration.users.edit', $viewBag);
@@ -259,7 +260,7 @@ class UserAdministrationController extends Controller
 
         if ($request->has('capabilities')) {
             $current_submitted = $request->get('capabilities');
-            $current_saved = array_pluck($user->capabilities()->get()->toArray(), 'key');
+            $current_saved = Arr::pluck($user->capabilities()->get()->toArray(), 'key');
         
             DB::transaction(function () use ($current_saved, $current_submitted, $user) {
                 $to_be_removed = array_diff($current_saved, $current_submitted);

--- a/app/Http/Controllers/SharingController.php
+++ b/app/Http/Controllers/SharingController.php
@@ -13,6 +13,7 @@ use Illuminate\Http\JsonResponse;
 use KBox\Http\Requests\CreateShareRequest;
 use KBox\Http\Requests\ShareDialogRequest;
 use Illuminate\Contracts\Auth\Guard as AuthGuard;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use KBox\Traits\Searchable;
@@ -75,7 +76,7 @@ class SharingController extends Controller
             $all_shared = $all_single->unique();
             
             $shared_docs = $all_shared->pluck('shareable.uuid')->all();
-            $shared_files_in_groups = array_flatten(array_filter($all_shared->map(function ($g) {
+            $shared_files_in_groups = Arr::flatten(array_filter($all_shared->map(function ($g) {
                 if ($g->shareable_type === \KBox\Group::class && ! is_null($g->shareable)) {
                     return $g->shareable->documents->pluck('uuid')->all();
                 }

--- a/app/Option.php
+++ b/app/Option.php
@@ -3,6 +3,7 @@
 namespace KBox;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use OneOffTech\Licenses\Contracts\LicenseRepository;
 
 /**
@@ -121,12 +122,12 @@ class Option extends Model
 
         $flat = $items->toArray();
 
-        $keys = array_pluck($flat, 'key');
-        $values = array_pluck($flat, 'value');
+        $keys = Arr::pluck($flat, 'key');
+        $values = Arr::pluck($flat, 'value');
 
         $non_flat = [];
         foreach (array_combine($keys, $values) as $key => $value) {
-            array_set($non_flat, $key, $value);
+            Arr::set($non_flat, $key, $value);
         }
 
         return $non_flat;

--- a/app/Pages/PageModel.php
+++ b/app/Pages/PageModel.php
@@ -12,6 +12,7 @@ use Spatie\YamlFrontMatter\YamlFrontMatter;
 use Illuminate\Database\Eloquent\Concerns\HasAttributes;
 use Illuminate\Database\Eloquent\Concerns\HasTimestamps;
 use Illuminate\Database\Eloquent\Concerns\HidesAttributes;
+use Illuminate\Support\Arr;
 
 /**
  *
@@ -229,7 +230,7 @@ abstract class PageModel
 
     public function setAuthorsAttribute($value)
     {
-        $this->attributes['authors'] = array_wrap($value);
+        $this->attributes['authors'] = Arr::wrap($value);
     }
 
     public function getIdAttribute($value)

--- a/app/Providers/SettingsServiceProvider.php
+++ b/app/Providers/SettingsServiceProvider.php
@@ -5,6 +5,7 @@ namespace KBox\Providers;
 use Illuminate\Support\ServiceProvider;
 use KBox\Option;
 use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Support\Arr;
 
 class SettingsServiceProvider extends ServiceProvider
 {
@@ -42,12 +43,12 @@ class SettingsServiceProvider extends ServiceProvider
             if (! $sections->isEmpty()) {
                 $flat = $sections->toArray();
 
-                $keys = array_pluck($flat, 'key');
-                $values = array_pluck($flat, 'value');
+                $keys = Arr::pluck($flat, 'key');
+                $values = Arr::pluck($flat, 'value');
 
                 $non_flat = [];
                 foreach (array_combine($keys, $values) as $key => $value) {
-                    array_set($non_flat, $key, $value);
+                    Arr::set($non_flat, $key, $value);
                 }
 
                 if (array_key_exists('mail', $non_flat)) {

--- a/app/Traits/HasCapability.php
+++ b/app/Traits/HasCapability.php
@@ -2,6 +2,7 @@
 
 namespace KBox\Traits;
 
+use Illuminate\Support\Arr;
 use KBox\Capability;
 use Illuminate\Support\Facades\DB;
 
@@ -45,7 +46,7 @@ trait HasCapability
             return false;
         }
 
-        $names = array_pluck($caps, 'key');
+        $names = Arr::pluck($caps, 'key');
 
         if (empty($names)) {
             return false;
@@ -82,7 +83,7 @@ trait HasCapability
             return false;
         }
 
-        $names = array_pluck($caps, 'key');
+        $names = Arr::pluck($caps, 'key');
 
         $intersect = array_intersect($capabilities, $names);
 

--- a/packages/contentprocessing/src/FileHelper.php
+++ b/packages/contentprocessing/src/FileHelper.php
@@ -3,6 +3,7 @@
 namespace KBox\Documents;
 
 use Exception;
+use Illuminate\Support\Arr;
 use InvalidArgumentException;
 
 /**
@@ -268,7 +269,7 @@ final class FileHelper
         $possible_extensions_count = count($possible_extensions);
 
         if ($possible_extensions_count > 0) {
-            $possible_extension = array_first(array_keys($possible_extensions));
+            $possible_extension = Arr::first(array_keys($possible_extensions));
             
             if (! is_null($documentType) && $possible_extensions_count > 1) {
                 $filtered_by_doc_type = array_keys(array_filter($possible_extensions, function ($value, $key) use ($mimeType, $documentType) {
@@ -280,7 +281,7 @@ final class FileHelper
                 }, ARRAY_FILTER_USE_BOTH));
 
                 if (count($filtered_by_doc_type) > 0) {
-                    $possible_extension = array_first($filtered_by_doc_type);
+                    $possible_extension = Arr::first($filtered_by_doc_type);
                 }
             }
             

--- a/packages/contentprocessing/src/Preview/AudioPreviewDriver.php
+++ b/packages/contentprocessing/src/Preview/AudioPreviewDriver.php
@@ -4,6 +4,7 @@ namespace KBox\Documents\Preview;
 
 use KBox\File;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Support\Arr;
 
 /**
  * Audio preview.
@@ -20,7 +21,7 @@ class AudioPreviewDriver extends BasePreviewDriver implements Renderable
 
     public function with($data)
     {
-        $this->view_data = array_merge($this->view_data, array_wrap($data));
+        $this->view_data = array_merge($this->view_data, Arr::wrap($data));
         return $this;
     }
 

--- a/packages/contentprocessing/src/Preview/ImagePreviewDriver.php
+++ b/packages/contentprocessing/src/Preview/ImagePreviewDriver.php
@@ -4,6 +4,7 @@ namespace KBox\Documents\Preview;
 
 use KBox\File;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Support\Arr;
 
 /**
  * Image preview.
@@ -20,7 +21,7 @@ class ImagePreviewDriver extends BasePreviewDriver implements Renderable
 
     public function with($data)
     {
-        $this->view_data = array_merge($this->view_data, array_wrap($data));
+        $this->view_data = array_merge($this->view_data, Arr::wrap($data));
         return $this;
     }
 

--- a/packages/contentprocessing/src/Preview/MapPreviewDriver.php
+++ b/packages/contentprocessing/src/Preview/MapPreviewDriver.php
@@ -4,6 +4,7 @@ namespace KBox\Documents\Preview;
 
 use KBox\File;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Support\Arr;
 
 /**
  * Map based preview.
@@ -34,7 +35,7 @@ class MapPreviewDriver extends BasePreviewDriver implements Renderable
 
     public function with($data)
     {
-        $this->view_data = array_merge($this->view_data, array_wrap($data));
+        $this->view_data = array_merge($this->view_data, Arr::wrap($data));
         return $this;
     }
 

--- a/packages/contentprocessing/src/Preview/PdfPreviewDriver.php
+++ b/packages/contentprocessing/src/Preview/PdfPreviewDriver.php
@@ -4,6 +4,7 @@ namespace KBox\Documents\Preview;
 
 use KBox\File;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Support\Arr;
 
 /**
  * PDF preview.
@@ -20,7 +21,7 @@ class PdfPreviewDriver extends BasePreviewDriver implements Renderable
 
     public function with($data)
     {
-        $this->view_data = array_merge($this->view_data, array_wrap($data));
+        $this->view_data = array_merge($this->view_data, Arr::wrap($data));
         return $this;
     }
 

--- a/packages/contentprocessing/src/Preview/VideoPreviewDriver.php
+++ b/packages/contentprocessing/src/Preview/VideoPreviewDriver.php
@@ -4,6 +4,7 @@ namespace KBox\Documents\Preview;
 
 use KBox\File;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Support\Arr;
 
 /**
  * Video preview.
@@ -20,7 +21,7 @@ class VideoPreviewDriver extends BasePreviewDriver implements Renderable
 
     public function with($data)
     {
-        $this->view_data = array_merge($this->view_data, array_wrap($data));
+        $this->view_data = array_merge($this->view_data, Arr::wrap($data));
         return $this;
     }
 

--- a/packages/contentprocessing/src/Services/DocumentsService.php
+++ b/packages/contentprocessing/src/Services/DocumentsService.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 use KBox\Exceptions\ForbiddenException;
 use Illuminate\Support\Collection;
 use Carbon\Carbon;
+use Illuminate\Support\Arr;
 use KBox\Exceptions\GroupAlreadyExistsException;
 use KBox\Exceptions\CollectionMoveException;
 use KBox\Documents\Facades\Files;
@@ -792,7 +793,7 @@ class DocumentsService
                     whereIn($closure_table->getAncestorColumn(), $project_collections_ids)->
                     whereNotIn($closure_table->getDescendantColumn(), $project_collections_ids)->get([$closure_table->getDescendantColumn()])->all();
                 
-                $descendants_array = array_pluck($descendants, $closure_table->getDescendantColumn());
+                $descendants_array = Arr::pluck($descendants, $closure_table->getDescendantColumn());
                 
                 $project_trashed_collections = Group::onlyTrashed()->public()->whereIn('id', $descendants_array)->get();
                 
@@ -942,7 +943,7 @@ class DocumentsService
                                 whereIn($closure_table->getAncestorColumn(), $collection_ids)->
                                 whereNotIn($closure_table->getDescendantColumn(), $collection_ids)->get([$closure_table->getDescendantColumn()])->all();
                                 
-                $descendants_ids = array_pluck($descendants, $closure_table->getDescendantColumn());
+                $descendants_ids = Arr::pluck($descendants, $closure_table->getDescendantColumn());
 
                 return Collection::make([$group])->merge(Group::whereIn('id', $descendants_ids)->get()->filter(function ($c) use ($user) {
                     // remove sub-collections not accessible by $user
@@ -981,7 +982,7 @@ class DocumentsService
                         whereIn($closure_table->getAncestorColumn(), $project_collections_ids_method1)->
                         whereNotIn($closure_table->getDescendantColumn(), $project_collections_ids_method1)->get([$closure_table->getDescendantColumn()])->all();
                         
-            $descendants_array = array_pluck($descendants, $closure_table->getDescendantColumn());
+            $descendants_array = Arr::pluck($descendants, $closure_table->getDescendantColumn());
             
             $project_collections_ids = array_merge($project_collections_ids_method1, $descendants_array);
 

--- a/packages/contentprocessing/src/Services/FileService.php
+++ b/packages/contentprocessing/src/Services/FileService.php
@@ -5,6 +5,7 @@ namespace KBox\Documents\Services;
 use Log;
 use Exception;
 use ErrorException;
+use Illuminate\Support\Arr;
 use ReflectionClass;
 use ReflectionException;
 use InvalidArgumentException;
@@ -270,7 +271,7 @@ class FileService
     private function getIdentifiersFor($mimeType)
     {
         $matching = $this->identifiers->filter(function ($item) use ($mimeType) {
-            $accepted = array_wrap(data_get($item, 'accept'));
+            $accepted = Arr::wrap(data_get($item, 'accept'));
             return in_array('*', $accepted) || in_array($mimeType, $accepted);
         });
         return $matching;

--- a/packages/language-guesser/src/Drivers/LanguageCli.php
+++ b/packages/language-guesser/src/Drivers/LanguageCli.php
@@ -2,6 +2,7 @@
 
 namespace OneOffTech\LanguageGuesser\Drivers;
 
+use Illuminate\Support\Arr;
 use RuntimeException;
 use OneOffTech\LanguageGuesser\Exceptions\LanguageGuessFailedException;
 use Symfony\Component\Process\Process;
@@ -64,11 +65,11 @@ class LanguageCli
         }
 
         if (! empty($this->blacklist)) {
-            $options[] = '--blacklist '.join(',', array_wrap($this->blacklist));
+            $options[] = '--blacklist '.join(',', Arr::wrap($this->blacklist));
         }
 
         if (! empty($this->whitelist)) {
-            $options[] = '--whitelist '.join(',', array_wrap($this->whitelist));
+            $options[] = '--whitelist '.join(',', Arr::wrap($this->whitelist));
         }
 
         $this->process = $process = new Process(

--- a/plugins/geo/src/Actions/ProcessGeodata.php
+++ b/plugins/geo/src/Actions/ProcessGeodata.php
@@ -4,6 +4,7 @@ namespace KBox\Geo\Actions;
 
 use Log;
 use Exception;
+use Illuminate\Support\Arr;
 use KBox\Geo\GeoService;
 use Klink\DmsAdapter\Geometries;
 use OneOffTech\GeoServer\GeoFile;
@@ -93,7 +94,7 @@ class ProcessGeodata extends Action
                 'type' => $properties->type ?? optional($details)->type(), //although it might be already set, we add it twice in case Gdal extraction fails
                 'crs.geoserver' => $geoserverCrs ?? '',
                 'boundings.geoserver' => optional($details)->boundingBox ?? [],
-                'geoserver.layers' => array_wrap($baseLayer),
+                'geoserver.layers' => Arr::wrap($baseLayer),
                 'geoserver.store' => optional($details)->name,
             ]);
 

--- a/plugins/geo/src/GeoProperties.php
+++ b/plugins/geo/src/GeoProperties.php
@@ -2,6 +2,7 @@
 
 namespace KBox\Geo;
 
+use Illuminate\Support\Arr;
 use KBox\File;
 use proj4php\Wkt;
 use KBox\FileProperties;
@@ -126,7 +127,7 @@ final class GeoProperties extends FileProperties
                 'label' => $projection ?? '',
                 'wkt' => $parsed['layer-srs-wkt'],
             ],
-            'layers' => array_wrap($parsed['layer-name']),
+            'layers' => Arr::wrap($parsed['layer-name']),
             'boundings' => [
                 'geojson' => $geojsonExtent,
                 'wkt' => null,

--- a/plugins/geo/src/Http/Controllers/GeoPluginEnableDisableMapProviderController.php
+++ b/plugins/geo/src/Http/Controllers/GeoPluginEnableDisableMapProviderController.php
@@ -5,6 +5,7 @@ namespace KBox\Geo\Http\Controllers;
 use Exception;
 use KBox\Geo\GeoService;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use KBox\Plugins\PluginManager;
 use KBox\Http\Controllers\Controller;
 use KBox\Geo\Http\Requests\EnableDisableMapProviderRequest;
@@ -40,7 +41,7 @@ class GeoPluginEnableDisableMapProviderController extends Controller
 
         $providerSettings = $mapSettings['providers'] ?? [];
         
-        $providersToChange = array_wrap($request->input('provider', []));
+        $providersToChange = Arr::wrap($request->input('provider', []));
         $enableProvider = (bool)$request->input('enable');
         $changedProviders = 0;
         

--- a/resources/views/panels/network_data.blade.php
+++ b/resources/views/panels/network_data.blade.php
@@ -52,7 +52,7 @@
 			
 			@if(!empty($item->author))
 
-				{{ join(', ', array_pluck($item->author, 'name')) }}
+				{{ join(', ', \Illuminate\Support\Arr::pluck($item->author, 'name')) }}
 
 			@endif
 			

--- a/workbench/klink/dms-project-microsites/src/Controllers/MicrositeController.php
+++ b/workbench/klink/dms-project-microsites/src/Controllers/MicrositeController.php
@@ -11,6 +11,7 @@ use Illuminate\Http\Request;
 use Illuminate\Contracts\Auth\Guard as AuthGuard;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Arr;
 use KBox\Exceptions\ForbiddenException;
 use Illuminate\Support\Facades\DB;
 use Klink\DmsMicrosites\Requests\MicrositeCreationRequest;
@@ -306,13 +307,13 @@ class MicrositeController extends Controller
 
                 if (! empty($pages)) {
                     foreach ($pages as $page) {
-                        MicrositeContent::findOrFail($page['id'])->update(array_except($page, ['id']));
+                        MicrositeContent::findOrFail($page['id'])->update(Arr::except($page, ['id']));
                     }
                 }
                 
                 if (! empty($menus)) {
                     foreach ($menus as $menu) {
-                        MicrositeContent::findOrFail($menu['id'])->update(array_except($menu, ['id']));
+                        MicrositeContent::findOrFail($menu['id'])->update(Arr::except($menu, ['id']));
                     }
                 }
                 

--- a/workbench/klink/dms-search/src/Klink/DmsSearch/SearchService.php
+++ b/workbench/klink/dms-search/src/Klink/DmsSearch/SearchService.php
@@ -16,6 +16,7 @@ use Klink\DmsAdapter\KlinkVisibilityType;
 use Klink\DmsAdapter\KlinkSearchRequest;
 use Klink\DmsAdapter\KlinkSearchResults;
 use Exception;
+use Illuminate\Support\Arr;
 use KBox\Documents\Services\DocumentsService;
 use KBox\Group;
 use KBox\Project;
@@ -276,7 +277,7 @@ class SearchService
     {
         $whitelist = array_merge(config('dms.language_whitelist', []), ['__']);
         
-        $lang_facets = array_first($facets, function ($value, $key) {
+        $lang_facets = Arr::first($facets, function ($value, $key) {
             return $key === KlinkFacets::LANGUAGE;
         }, null);
     


### PR DESCRIPTION
## What does this PR do?

Use `Illuminate\Support\Arr` static methods instead of `array_*` helpers. This to ensure Laravel 5.8+ compatibility https://laravel.com/docs/5.8/upgrade#string-and-array-helpers

### Related issues

Fixes ...

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)