### PR TITLE
Search for share target users

### DIFF
--- a/app/Http/Controllers/FindSharingTargetsController.php
+++ b/app/Http/Controllers/FindSharingTargetsController.php
@@ -54,6 +54,14 @@ class FindSharingTargetsController extends Controller
 
         $is_multiple_selection = ! empty($documents_input) && ! empty($groups_input);
 
+        if ($groups->where('is_private', false)->isNotEmpty()) {
+            // if there is at least a project collection in the selection
+            // return an empty list. See
+            // https://github.com/k-box/k-box/pull/355#issuecomment-551448888
+            // and https://github.com/k-box/k-box/issues/356
+            return new ShareTargetCollection(collect([]));
+        }
+
         // users to exclude from the available for share
         // by default the current user is excluded as no one can share
         // with himself/herself

--- a/app/Http/Controllers/FindSharingTargetsController.php
+++ b/app/Http/Controllers/FindSharingTargetsController.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace KBox\Http\Controllers;
+
+use KBox\User;
+use KBox\Group;
+use KBox\Capability;
+use KBox\DocumentDescriptor;
+use Illuminate\Http\Request;
+use KBox\Http\Resources\ShareTargetCollection;
+
+class FindSharingTargetsController extends Controller
+{
+    /**
+     * Create a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->middleware('auth');
+
+        $this->middleware('capabilities');
+    }
+
+    /**
+     * List the users that can be select as target of a share.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index(Request $request)
+    {
+        $me = $request->user();
+
+        $validatedData = $request->validate([
+            'collections' => 'nullable|sometimes|array|exists:groups,id',
+            'documents' => 'nullable|sometimes|array|exists:document_descriptors,id',
+            's' => 'required|string|min:2',
+            'e' => 'sometimes|required|array|exists:users,id',
+        ]);
+
+        $search_query = $validatedData['s'];
+
+        $groups_input = $validatedData['collections'] ?? [];
+        $documents_input = $validatedData['documents'] ?? [];
+
+        $documents = DocumentDescriptor::whereIn('id', $documents_input)->get();
+
+        $groups = Group::whereIn('id', $groups_input)->get();
+
+        $all_in = $documents->merge($groups);
+        
+        $first = $all_in->first();
+
+        $is_multiple_selection = ! empty($documents_input) && ! empty($groups_input);
+
+        // users to exclude from the available for share
+        // by default the current user is excluded as no one can share
+        // with himself/herself
+        // additionally all ids passed as part of the `e` parameter are excluded
+        $users_to_exclude = collect([$me->id])->merge($validatedData['e'] ?? []);
+        
+        if ($first && ! $is_multiple_selection) {
+            $users_to_exclude = $users_to_exclude->merge($this->getExcludeListFor($first, $me));
+        }
+
+        $available_users = User::whereNotIn('id', $users_to_exclude->toArray())
+            ->whereHas('capabilities', function ($q) {
+                $q->where('key', '=', Capability::RECEIVE_AND_SEE_SHARE);
+            })
+            ->where(function ($query) use ($search_query) {
+                $query->where('email', e($search_query))
+                ->orWhere('users.name', 'like', '%'.$this->normalizeTerms($search_query).'%');
+            })
+            ->orderBy('users.id', 'DESC') // since the ids are autoincrement it is equivalent to order for creation date
+            ->take(6);
+
+        return new ShareTargetCollection($available_users->get());
+    }
+
+    /**
+     * Get the list of users to exclude from the targets
+     * for the specified resource
+     *
+     * @param \KBox\DocumentDescriptor|\KBox\Group $resource
+     * @param \KBox\User $user
+     * @return \Illuminate\Support\Collection
+     */
+    private function getExcludeListFor($resource, User $user)
+    {
+        $existing_shares = $resource->shares()->sharedByMe($user)->where('sharedwith_type', User::class)->get();
+
+        return $existing_shares->pluck('sharedwith_id')->unique();
+    }
+
+    /**
+     * Normalize the search terms to be used in the query
+     *
+     * it replaces % characters
+     *
+     * @param string $terms
+     * @return string
+     */
+    private function normalizeTerms($terms)
+    {
+        $decoded = urldecode($terms);
+
+        // in case of terms containing apostrophes or double quotes
+        // we replace them with ? to match any character.
+        // We replace also % and ? as the user should not
+        // make use of them
+        $cleaned = str_replace('%', '', $decoded);
+        $cleaned = str_replace('?', '', $cleaned);
+        $cleaned = str_replace('_', '', $cleaned);
+        $cleaned = str_replace('\'', '_', $cleaned);
+        $cleaned = str_replace('"', '_', $cleaned);
+
+        return str_replace(' ', '%', e($cleaned));
+    }
+}

--- a/app/Http/Resources/ShareTarget.php
+++ b/app/Http/Resources/ShareTarget.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace KBox\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ShareTarget extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'avatar' => $this->avatar ?? null,
+        ];
+    }
+}

--- a/app/Http/Resources/ShareTargetCollection.php
+++ b/app/Http/Resources/ShareTargetCollection.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace KBox\Http\Resources;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class ShareTargetCollection extends ResourceCollection
+{
+    /**
+     * The resource that this resource collects.
+     *
+     * @var string
+     */
+    public $collects = ShareTarget::class;
+
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return parent::toArray($request);
+    }
+}

--- a/config/route-permissions.php
+++ b/config/route-permissions.php
@@ -103,6 +103,9 @@ return [
         'update' => KBox\Capability::SHARE_WITH_USERS,
         'destroy' => KBox\Capability::SHARE_WITH_USERS,
         'deletemultiple' => KBox\Capability::SHARE_WITH_USERS,
+        'targets' => [
+            'find' => KBox\Capability::SHARE_WITH_USERS,
+        ],
     ],
     
     'links' => [

--- a/docs/user/share.md
+++ b/docs/user/share.md
@@ -4,6 +4,7 @@ Description: user documentation
 ---
 
 # Sharing
+
 K-Box sharing options are available through the Sharing window, that can be accessed through:
 
 _Share_ button on the top navigation bar 
@@ -25,3 +26,19 @@ If _Who has Access_ is set to **Anyone with link can access**, go ahead and send
 The recipient will not appear in the following list. 
 
 The latter is true for Public documents, too.
+
+## Sharing to a user
+
+Sharing a file or collection is done via the sharing dialog. To create a new share open the sharing dialog.
+
+On the sharing dialog there is a text field, under the _Who has access_ section, in which users can be added. 
+To add a new user start typing at least 2 letters of the name and the system will suggest 6 users that 
+matches your terms. To ensure a more precise completion type at least 4 letters.
+
+In case you know the exact email address you can type it and the K-Box will find the user that matches it.
+
+> For respecting the privacy the K-Box will not show the email address of the matched users.
+
+**I don't see the user in the completion**
+
+Users you already shared the same file with will not be included in the search.

--- a/resources/assets/js/dms/init.js
+++ b/resources/assets/js/dms/init.js
@@ -259,6 +259,7 @@ window.DMS = (function(_$, _nprogress, _rivets, _alert){
 			GROUPS_CREATE: 'documents/groups/create',
 			GROUPS_EDIT: 'documents/groups/{ID}/edit',
 			SHARES: 'shares',
+			SHARES_TARGET_FIND: 'shares/find-targets',
 			PUBLICLINK: 'links',
 			SHARE_CREATE: 'shares/create',
 			STORAGE_REINDEX_ALL: 'administration/storage/reindexall',

--- a/resources/assets/js/modules/share.js
+++ b/resources/assets/js/modules/share.js
@@ -449,6 +449,7 @@ define("modules/share", ["jquery", "DMS","lodash", "combokeys", "language", "swe
 					  s: params.term,
 					  documents: selection.documents,
 					  collections: selection.collections,
+					  e: (this.val) ? this.val() : [],
 					  _token: DMS.csrf()
 					}
 				

--- a/resources/lang/en/share.php
+++ b/resources/lang/en/share.php
@@ -95,7 +95,7 @@ return [
         'collection_already_accessible_by_all_users' => 'Collection is already accessible by all K-Box users.',
 
         'add_users' => 'Add users',
-        'select_users' => 'Enter username...',
+        'select_users' => 'Enter the username or the email address...',
 
         'access_by_direct_share' => 'Direct access',
         'access_by_project_membership' => 'Project ":project"',

--- a/resources/views/share/dialog.blade.php
+++ b/resources/views/share/dialog.blade.php
@@ -65,7 +65,7 @@
 
 					@endif
 					@if($is_multiple_selection)
-						<p class="description">{{ trans( $is_multiple_selection ? 'share.dialog.linkshare_multiple_selection_hint' : 'share.dialog.linkshare_hint') }}</p>
+						<p class="description mb-4">{{ trans( $is_multiple_selection ? 'share.dialog.linkshare_multiple_selection_hint' : 'share.dialog.linkshare_hint') }}</p>
 					@endif
 		
 			<div class="dialog__section__inner">
@@ -98,9 +98,7 @@
 
 				<select class="form-input js-select-users" name="users[]" id="users" multiple="multiple" style="min-width:auto !important">
 
-					{{-- @foreach ($users as $user)
-						<option value="{{$user->id}}">{{$user->name}} ({{$user->email}})</option>
-					@endforeach --}}
+					{{-- Data will be inserted at runtime using Ajax --}}
 									
 				</select>
 			

--- a/resources/views/share/dialog.blade.php
+++ b/resources/views/share/dialog.blade.php
@@ -95,13 +95,12 @@
 		@endif
 
 			<div class="dialog__section--add">
-				@unless($users->count() == 0)
 
 				<select class="form-input js-select-users" name="users[]" id="users" multiple="multiple" style="min-width:auto !important">
 
-					@foreach ($users as $user)
+					{{-- @foreach ($users as $user)
 						<option value="{{$user->id}}">{{$user->name}} ({{$user->email}})</option>
-					@endforeach
+					@endforeach --}}
 									
 				</select>
 			
@@ -109,11 +108,7 @@
 					<svg class="btn-icon" style="line-height: 38px;vertical-align: middle;margin-right: 6px;" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M15 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm-9-2V7H4v3H1v2h3v3h2v-3h3v-2H6zm9 4c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/></svg>
 					{{ trans('share.dialog.add_users') }}
 				</button>
-				@endif
 
-				@if($users->count() == 0)
-					{{ trans( $is_collection ? 'share.dialog.collection_already_accessible_by_all_users' : 'share.dialog.document_already_accessible_by_all_users' ) }}
-				@endif
 			</div>
 
 			</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -271,6 +271,11 @@ Route::get('shares/group/{id}', [
         'as' => 'shares.group',
     ]);
 
+Route::post('shares/find-targets', [
+    'uses' => 'FindSharingTargetsController@index',
+    'as' => 'shares.targets.find',
+]);
+
 Route::resource('shares', 'SharingController');
 
 // Public links creation and management

--- a/tests/Feature/FindSharingTargetsControllerTest.php
+++ b/tests/Feature/FindSharingTargetsControllerTest.php
@@ -1,0 +1,299 @@
+<?php
+
+namespace Tests\Feature;
+
+use KBox\User;
+use Tests\TestCase;
+use KBox\Capability;
+use KBox\DocumentDescriptor;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class FindSharingTargetsControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_share_users_autocomplete_without_current_selection()
+    {
+        $this->withKlinkAdapterFake();
+
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+        
+        $user_target = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $other_target = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $response = $this->actingAs($user)->json('POST', route('shares.targets.find'), [
+            's' => $user_target->email,
+        ]);
+        
+        $response->assertOk();
+        $response->assertExactJson([
+            'data' => [
+                [
+                    'id' => $user_target->id,
+                    'name' => $user_target->name,
+                    'avatar' => $user_target->avatar,
+                ]
+            ]
+        ]);
+    }
+
+    public function test_share_users_autocomplete_with_email_address()
+    {
+        $this->withKlinkAdapterFake();
+
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $document = factory(DocumentDescriptor::class)->create([
+            'owner_id' => $user->getKey()
+        ]);
+        
+        $user_target = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $other_target = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $response = $this->actingAs($user)->json('POST', route('shares.targets.find'), [
+            's' => $user_target->email,
+            'documents' => [$document->id],
+        ]);
+        
+        $response->assertOk();
+        $response->assertExactJson([
+            'data' => [
+                [
+                    'id' => $user_target->id,
+                    'name' => $user_target->name,
+                    'avatar' => $user_target->avatar,
+                ]
+            ]
+        ]);
+    }
+
+    public function test_share_users_autocomplete_with_name()
+    {
+        $this->withKlinkAdapterFake();
+
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $document = factory(DocumentDescriptor::class)->create([
+            'owner_id' => $user->getKey()
+        ]);
+        
+        $user_target = tap(factory(User::class)->create([
+            'name' => 'juliet o\'hara'
+        ]), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $other_target = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $response = $this->actingAs($user)->json('POST', route('shares.targets.find'), [
+            's' => 'j o\'h',
+            'documents' => [$document->id],
+        ]);
+        
+        $response->assertOk();
+        $response->assertExactJson([
+            'data' => [
+                [
+                    'id' => $user_target->id,
+                    'name' => $user_target->name,
+                    'avatar' => $user_target->avatar,
+                ]
+            ]
+        ]);
+    }
+    public function test_sql_is_properly_escaped()
+    {
+        $this->withKlinkAdapterFake();
+
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $document = factory(DocumentDescriptor::class)->create([
+            'owner_id' => $user->getKey()
+        ]);
+        
+        $user_target = tap(factory(User::class)->create([
+            'name' => 'juliet'
+        ]), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $other_target = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $response = $this->actingAs($user)->json('POST', route('shares.targets.find'), [
+            's' => "jul'; DROP TABLE users;",
+            'documents' => [$document->id],
+        ]);
+        
+        $response->assertOk();
+        $response->assertExactJson([
+            'data' => []
+        ]);
+    }
+
+    public function test_terms_are_normalized()
+    {
+        $this->withKlinkAdapterFake();
+
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $document = factory(DocumentDescriptor::class)->create([
+            'owner_id' => $user->getKey()
+        ]);
+        
+        $user_target = tap(factory(User::class)->create([
+            'name' => 'juliet'
+        ]), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $other_target = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $response = $this->actingAs($user)->json('POST', route('shares.targets.find'), [
+            's' => urlencode('jul%iet'),
+            'documents' => [$document->id],
+        ]);
+        
+        $response->assertOk();
+        $response->assertExactJson([
+            'data' => [
+                [
+                    'id' => $user_target->id,
+                    'name' => $user_target->name,
+                    'avatar' => $user_target->avatar,
+                ]
+            ]
+        ]);
+    }
+
+    public function test_targets_are_returned_in_the_correct_order()
+    {
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $targets = collect([
+            tap(factory(User::class)->create(['name' => 'juliet o\'hara']), function ($u) {
+                $u->addCapabilities(Capability::$PARTNER);
+            }),
+            tap(factory(User::class)->create(['name' => 'spencer o\'hara']), function ($u) {
+                $u->addCapabilities(Capability::$PARTNER);
+            }),
+            tap(factory(User::class)->create(['name' => 'henry o\'hara']), function ($u) {
+                $u->addCapabilities(Capability::$PARTNER);
+            }),
+            tap(factory(User::class)->create(['name' => 'barton o\'hara']), function ($u) {
+                $u->addCapabilities(Capability::$PARTNER);
+            }),
+            tap(factory(User::class)->create(['name' => 'carlton o\'hara']), function ($u) {
+                $u->addCapabilities(Capability::$PARTNER);
+            }),
+            tap(factory(User::class)->create(['name' => 'john o\'hara']), function ($u) {
+                $u->addCapabilities(Capability::$PARTNER);
+            }),
+            tap(factory(User::class)->create(['name' => 'james o\'hara']), function ($u) {
+                $u->addCapabilities(Capability::$PARTNER);
+            }),
+            tap(factory(User::class)->create(), function ($u) {
+                $u->addCapabilities(Capability::$PARTNER);
+            }),
+            tap(factory(User::class)->create(), function ($u) {
+                $u->addCapabilities(Capability::$PARTNER);
+            }),
+            tap(factory(User::class)->create(), function ($u) {
+                $u->addCapabilities(Capability::$PARTNER);
+            }),
+        ]);
+
+        $response = $this->actingAs($user)->json('POST', route('shares.targets.find'), [
+            's' => 'o\'h',
+        ]);
+
+        $expected_data = $targets->splice(1, 6)->map(function ($u) {
+            return [
+                'id' => $u->id,
+                'name' => $u->name,
+                'avatar' => $u->avatar ?? null,
+            ];
+        })->reverse();
+        
+        $response->assertOk();
+        $response->assertExactJson([
+            'data' => $expected_data->toArray()
+        ]);
+    }
+
+    public function test_already_selected_users_can_be_excluded()
+    {
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+
+        $targets = collect([
+            tap(factory(User::class)->create(['name' => 'juliet o\'hara']), function ($u) {
+                $u->addCapabilities(Capability::$PARTNER);
+            }),
+            tap(factory(User::class)->create(['name' => 'spencer o\'hara']), function ($u) {
+                $u->addCapabilities(Capability::$PARTNER);
+            }),
+            tap(factory(User::class)->create(['name' => 'henry o\'hara']), function ($u) {
+                $u->addCapabilities(Capability::$PARTNER);
+            }),
+            tap(factory(User::class)->create(['name' => 'barton o\'hara']), function ($u) {
+                $u->addCapabilities(Capability::$PARTNER);
+            }),
+            tap(factory(User::class)->create(['name' => 'carlton o\'hara']), function ($u) {
+                $u->addCapabilities(Capability::$PARTNER);
+            }),
+            tap(factory(User::class)->create(['name' => 'john o\'hara']), function ($u) {
+                $u->addCapabilities(Capability::$PARTNER);
+            }),
+            tap(factory(User::class)->create(['name' => 'james o\'hara']), function ($u) {
+                $u->addCapabilities(Capability::$PARTNER);
+            }),
+        ]);
+
+        $response = $this->actingAs($user)->json('POST', route('shares.targets.find'), [
+            's' => 'o\'h',
+            'e' => [$targets->last()->id]
+        ]);
+
+        $expected_data = $targets->take(6)->map(function ($u) {
+            return [
+                'id' => $u->id,
+                'name' => $u->name,
+                'avatar' => $u->avatar ?? null,
+            ];
+        })->reverse();
+        
+        $response->assertOk();
+        $response->assertExactJson([
+            'data' => $expected_data->toArray()
+        ]);
+    }
+}

--- a/tests/Feature/SharingControllerTest.php
+++ b/tests/Feature/SharingControllerTest.php
@@ -278,13 +278,12 @@ class SharingControllerTest extends TestCase
         $response->assertViewHas('is_multiple_selection', false);
         $response->assertViewHas('is_public', false);
         $response->assertViewHas('is_collection', false);
+        $response->assertViewMissing('users');
 
         $this->assertEmpty($response->getData('existing_shares'));
         $this->assertEmpty($response->getData('groups'));
 
         $this->assertEquals($document->id, $response->getData('documents')->first()->id);
-        $this->assertContains($user_target->id, $response->getData('users')->pluck('id'));
-        $this->assertNotContains($user->id, $response->getData('users')->pluck('id'));
     }
 
     public function test_share_dialog_with_multiple_documents()
@@ -320,13 +319,12 @@ class SharingControllerTest extends TestCase
         $response->assertViewHas('is_multiple_selection', true);
         $response->assertViewHas('is_public', false);
         $response->assertViewHas('is_collection', false);
+        $response->assertViewMissing('users');
 
         $this->assertEmpty($response->getData('existing_shares'));
         $this->assertEmpty($response->getData('groups'));
 
         $this->assertEquals([$document1->id, $document2->id], $response->getData('documents')->pluck('id')->toArray());
-        $this->assertContains($user_target->id, $response->getData('users')->pluck('id'));
-        $this->assertNotContains($user->id, $response->getData('users')->pluck('id'));
     }
 
     public function test_share_dialog_with_single_collection()
@@ -360,12 +358,11 @@ class SharingControllerTest extends TestCase
         $response->assertViewHas('is_multiple_selection', false);
         $response->assertViewHas('is_public', false);
         $response->assertViewHas('is_collection', true);
+        $response->assertViewMissing('users');
 
         $this->assertEmpty($response->getData('existing_shares'));
 
         $this->assertEquals([$collection->id], $response->getData('groups')->pluck('id')->toArray());
-        $this->assertContains($user_target->id, $response->getData('users')->pluck('id'));
-        $this->assertNotContains($user->id, $response->getData('users')->pluck('id'));
     }
 
     public function test_share_dialog_with_documents_and_collections()
@@ -410,12 +407,11 @@ class SharingControllerTest extends TestCase
         $response->assertViewHas('is_multiple_selection', true);
         $response->assertViewHas('is_public', false);
         $response->assertViewHas('is_collection', false);
+        $response->assertViewMissing('users');
 
         $this->assertEmpty($response->getData('existing_shares'));
 
         $this->assertEquals([$document1->id, $document2->id], $response->getData('documents')->pluck('id')->toArray());
         $this->assertEquals([$collection1->id, $collection2->id], $response->getData('groups')->pluck('id')->toArray());
-        $this->assertContains($user_target->id, $response->getData('users')->pluck('id'));
-        $this->assertNotContains($user->id, $response->getData('users')->pluck('id'));
     }
 }


### PR DESCRIPTION
## What does this PR do?

Transform the selection of users to add for share into an Ajax driven search to accomodate changes for large organizations while preserving the privacy of the users.

### Related issues

Fixes #309 

### Review checklist

* [x] Are unit tests required?
* [x] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)