### PR TITLE
Disable project collection sharing

### DIFF
--- a/app/Http/Controllers/SharingController.php
+++ b/app/Http/Controllers/SharingController.php
@@ -251,6 +251,7 @@ class SharingController extends Controller
             'publication' => $publication,
             'publication_status' => $publication ? $publication->status : null,
             'is_collection' => $first instanceof Group,
+            'can_add_users' => $groups->isEmpty() || ($groups->isNotEmpty() && $groups->where('is_private', false)->isEmpty()),
         ]);
     }
 

--- a/app/Http/Controllers/SharingController.php
+++ b/app/Http/Controllers/SharingController.php
@@ -252,6 +252,8 @@ class SharingController extends Controller
             'publication_status' => $publication ? $publication->status : null,
             'is_collection' => $first instanceof Group,
             'can_add_users' => $groups->isEmpty() || ($groups->isNotEmpty() && $groups->where('is_private', false)->isEmpty()),
+            'can_edit_project' => $groups->count() === 1 ? (optional($groups->first()->getProject())->isManagedBy($me) ?? false) : false,
+            'project' => $groups->count() === 1 ? optional($groups->first()->getProject())->getKey() : null,
         ]);
     }
 

--- a/app/Http/Requests/CreateShareRequest.php
+++ b/app/Http/Requests/CreateShareRequest.php
@@ -3,6 +3,7 @@
 namespace KBox\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest as Request;
+use Illuminate\Validation\Rule;
 
 class CreateShareRequest extends Request
 {
@@ -26,7 +27,14 @@ class CreateShareRequest extends Request
     {
         return [
             'with_users' => 'required|exists:users,id',
-            'groups' => 'required_without:documents|exists:groups,id',
+            'groups' => [
+                'required_without:documents',
+                Rule::exists('groups', 'id')->where(function ($query) {
+                    // limiting the allowed collections to be personal only
+                    // https://github.com/k-box/k-box/issues/356
+                    $query->where('is_private', true);
+                }),
+            ],
             'documents' => 'required_without:groups|exists:document_descriptors,id'
         ];
     }

--- a/app/Project.php
+++ b/app/Project.php
@@ -98,6 +98,17 @@ class Project extends Model
     {
         return $query->where('user_id', $user);
     }
+
+    /**
+     * Check if a user is the project manager
+     *
+     * @param User $user
+     * @return bool
+     */
+    public function isManagedBy(User $user)
+    {
+        return $this->user_id === $user->getKey();
+    }
     
     /**
      * The associated microsite

--- a/docs/user/share.md
+++ b/docs/user/share.md
@@ -31,6 +31,10 @@ The latter is true for Public documents, too.
 
 Sharing a file or collection is done via the sharing dialog. To create a new share open the sharing dialog.
 
+> As of version 0.29 sharing a project or a collection inside it will be disabled due to information 
+disclosure concern. Existing shares will continue to be available and you can still copy the link and send it
+via email. For more information refer to https://github.com/k-box/k-box/issues/356.
+
 On the sharing dialog there is a text field, under the _Who has access_ section, in which users can be added. 
 To add a new user start typing at least 2 letters of the name and the system will suggest 6 users that 
 matches your terms. To ensure a more precise completion type at least 4 letters.

--- a/resources/lang/en/actions.php
+++ b/resources/lang/en/actions.php
@@ -139,4 +139,5 @@ return [
     ],
 
     'contact_support' => 'Contact Support',
+    'more_information' => 'More information',
 ];

--- a/resources/lang/en/groups.php
+++ b/resources/lang/en/groups.php
@@ -96,6 +96,7 @@ return [
             'personal_not_all_same_user_empty_cause' => 'Cannot move ":collection" to your personal as you are not the creator of it',
             'no_project_collection_permission' => 'You do not have the necessary permission to move a project collection',
             'no_access_to_collection' => 'You do not have access to the collection',
+            'has_shares_to_non_members' => 'The collection cannot be moved as is currently shared to users that are not member of the destination project. To prevent information disclosure the operation is currently not allowed.',
         ],
 
     ],

--- a/resources/lang/en/groups.php
+++ b/resources/lang/en/groups.php
@@ -96,7 +96,7 @@ return [
             'personal_not_all_same_user_empty_cause' => 'Cannot move ":collection" to your personal as you are not the creator of it',
             'no_project_collection_permission' => 'You do not have the necessary permission to move a project collection',
             'no_access_to_collection' => 'You do not have access to the collection',
-            'has_shares_to_non_members' => 'The collection cannot be moved as is currently shared to users that are not member of the destination project. To prevent information disclosure the operation is currently not allowed.',
+            'has_shares_to_non_members' => 'Some users of the collection are not project members. You cannot move it until they are included into the project. To see the current shares right click on the collection and then Share.',
         ],
 
     ],

--- a/resources/lang/en/groups.php
+++ b/resources/lang/en/groups.php
@@ -96,7 +96,7 @@ return [
             'personal_not_all_same_user_empty_cause' => 'Cannot move ":collection" to your personal as you are not the creator of it',
             'no_project_collection_permission' => 'You do not have the necessary permission to move a project collection',
             'no_access_to_collection' => 'You do not have access to the collection',
-            'has_shares_to_non_members' => 'Some users of the collection are not project members. You cannot move it until they are included into the project. To see the current shares right click on the collection and then Share.',
+            'has_shares_to_non_members' => 'Some users of the collection are not project members. You cannot move it until they are included into the project. Add new members to the project before moving the collection.',
         ],
 
     ],

--- a/resources/lang/en/share.php
+++ b/resources/lang/en/share.php
@@ -101,7 +101,7 @@ return [
         'access_by_project_membership' => 'Project ":project"',
         'access_by_project_membership_hint' => 'Member of ":project"',
 
-        'cannot_add_users_because_of_project_collection' => 'Sharing a collection located into a project is temporarily disabled.',
+        'cannot_add_users_because_of_project_collection' => 'Add new members to the project for sharing a project collection.',
     ],
     'publiclinks' => [
         'public_link' => 'Public Link',

--- a/resources/lang/en/share.php
+++ b/resources/lang/en/share.php
@@ -100,6 +100,8 @@ return [
         'access_by_direct_share' => 'Direct access',
         'access_by_project_membership' => 'Project ":project"',
         'access_by_project_membership_hint' => 'Member of ":project"',
+
+        'cannot_add_users_because_of_project_collection' => 'Sharing a collection located into a project is temporarily disabled.',
     ],
     'publiclinks' => [
         'public_link' => 'Public Link',

--- a/resources/views/share/dialog.blade.php
+++ b/resources/views/share/dialog.blade.php
@@ -111,7 +111,17 @@
 			
 				@else
 					<div class="c-message c-message--warning">
-						<a href="https://github.com/k-box/k-box/blob/master/docs/user/share.md#sharing-to-a-user" target="_blank" rel="noopener noreferrer">{{ trans('share.dialog.cannot_add_users_because_of_project_collection') }}</a>
+						<p>
+							{{ trans('share.dialog.cannot_add_users_because_of_project_collection') }}
+						</p>
+						<p class="">
+							@if ($can_edit_project && $project)	
+								<a class="inline-block mr-2" href="{{ route('projects.edit', $project) }}" target="_blank" rel="noopener noreferrer">{{ trans('projects.labels.add_users_button') }}</a>
+							@endif
+
+							<a href="https://github.com/k-box/k-box/blob/master/docs/user/share.md#sharing-to-a-user" target="_blank" rel="noopener noreferrer">{{ trans('actions.more_information') }}</a>
+						</p>
+
 					</div>
 				@endif
 

--- a/resources/views/share/dialog.blade.php
+++ b/resources/views/share/dialog.blade.php
@@ -96,16 +96,24 @@
 
 			<div class="dialog__section--add">
 
-				<select class="form-input js-select-users" name="users[]" id="users" multiple="multiple" style="min-width:auto !important">
+				@if ($can_add_users)
+				
+					<select class="form-input js-select-users" name="users[]" id="users" multiple="multiple" style="min-width:auto !important">
 
-					{{-- Data will be inserted at runtime using Ajax --}}
-									
-				</select>
+						{{-- Data will be inserted at runtime using Ajax --}}
+										
+					</select>
+				
+					<button class="js-share button">
+						<svg class="btn-icon" style="line-height: 38px;vertical-align: middle;margin-right: 6px;" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M15 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm-9-2V7H4v3H1v2h3v3h2v-3h3v-2H6zm9 4c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/></svg>
+						{{ trans('share.dialog.add_users') }}
+					</button>
 			
-				<button class="js-share button">
-					<svg class="btn-icon" style="line-height: 38px;vertical-align: middle;margin-right: 6px;" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M15 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm-9-2V7H4v3H1v2h3v3h2v-3h3v-2H6zm9 4c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/></svg>
-					{{ trans('share.dialog.add_users') }}
-				</button>
+				@else
+					<div class="c-message c-message--warning">
+						<a href="https://github.com/k-box/k-box/blob/master/docs/user/share.md#sharing-to-a-user" target="_blank" rel="noopener noreferrer">{{ trans('share.dialog.cannot_add_users_because_of_project_collection') }}</a>
+					</div>
+				@endif
 
 			</div>
 


### PR DESCRIPTION
## What does this PR do?

As per #356 this pull request temporarily disable sharing of projects and its sub-collections using the sharing dialog

### Related issues

Fixes #356

### Review checklist

* [x] Are unit tests required?
* [x] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)