### PR TITLE
Pin shellcheck version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ test-syntax:
 
 test-shell-syntax:
   stage: lint
-  image: "koalaman/shellcheck-alpine:latest"
+  image: "koalaman/shellcheck-alpine:v0.7.0"
   script:
     - shellcheck ./docker/configure.sh
     - shellcheck ./docker/start.sh


### PR DESCRIPTION
## What does this PR do?

Pin shellcheck version to version 0.7.0 on Gitlab CI due to https://github.com/koalaman/shellcheck/issues/1751

### Related issues

Fixes ...

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)