### PR TITLE
Fix starred filter not shown

### DIFF
--- a/app/Http/Controllers/Document/StarredDocumentsController.php
+++ b/app/Http/Controllers/Document/StarredDocumentsController.php
@@ -83,8 +83,8 @@ class StarredDocumentsController extends Controller
             'starred' => $results,
             'pagination' => $results,
             'search_terms' => $req->term,
-            'facets' => $results && ! $has_starred ? $results->facets() : [],
-            'filters' => $results && ! $has_starred ? $results->filters() : [],
+            'facets' => $results && $has_starred ? $results->facets() : [],
+            'filters' => $results && $has_starred ? $results->filters() : [],
             'empty_message' => ($results->count()==0 && $req->term !== '*') ? trans('search.no_results_no_markup', ['term' => $req->term, 'collection' =>  trans('starred.page_title')])  : trans('starred.empty_message')
         ]);
     }


### PR DESCRIPTION
## What does this PR do?

Fix a regression that prevent filters for starred documents to appear

### Related issues

Fixes ...

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)