### PR TITLE
Make username an edit link if user is not disabled

### DIFF
--- a/resources/views/administration/users.blade.php
+++ b/resources/views/administration/users.blade.php
@@ -39,15 +39,19 @@
             <tbody>
 
                 @foreach($users as $user)
-                    <tr @if ($user->trashed()) class="trashed" @endif>
+                    <tr @if ($user->trashed()) class="text-gray-500" @endif>
                         <td>
                             @component('avatar.full', ['image' => $user->avatar, 'name' => $user->name])
 
-                                {{$user->name}}
+                                @if ($user->trashed())
+                                    {{$user->name}}
+                                @else
+                                    <a href="{{ route('administration.users.show', $user->id) }}">{{$user->name}}</a>
+                                @endif
 
                             @endcomponent
                         </td>
-                        <td><a href="{{ route('administration.users.show', $user->id) }}">{{$user->email}}</a></td>
+                        <td>{{$user->email}}</td>
                         <td>&nbsp;</td>
                         <td>
 


### PR DESCRIPTION
## What does this PR do?

Switch the link for editing a user from the email to the name. The email link was giving a false affordance of sending the email instead editing the user.

In addition edit link is now not visible if the user is disabled

_before_

![image](https://user-images.githubusercontent.com/5672748/70938692-f21ce180-2046-11ea-9d75-b3a0c03ede68.png)


_after_

![image](https://user-images.githubusercontent.com/5672748/70940370-6f962100-204a-11ea-9721-4b71244aa50f.png)


### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)