### PR TITLE
Add events for tracking actions

### DIFF
--- a/app/Events/CausedEvent.php
+++ b/app/Events/CausedEvent.php
@@ -42,6 +42,8 @@ abstract class CausedEvent
     public function setCauser(User $user)
     {
         $this->user = $user;
+
+        return $this;
     }
 
     /**

--- a/app/Events/CausedEvent.php
+++ b/app/Events/CausedEvent.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace KBox\Events;
+
+use KBox\User;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * Events that are caused by a user
+ */
+abstract class CausedEvent
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * The user that triggered the document descriptor deletion
+     * @var KBox\User|null
+     */
+    public $user;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param KBox\DocumentDescriptor The document that has been deleted
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->user = Auth::user() ?? null;
+    }
+
+    /**
+     * Specify the user tha caused the event
+     *
+     * @param \KBox\User $user
+     * @return self
+     */
+    public function setCauser(User $user)
+    {
+        $this->user = $user;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return \Illuminate\Broadcasting\Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel('channel-name');
+    }
+}

--- a/app/Events/CollectionCreated.php
+++ b/app/Events/CollectionCreated.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace KBox\Events;
+
+use KBox\Group;
+
+class CollectionCreated extends CausedEvent
+{
+    
+    /**
+     * @var \KBox\Group
+     */
+    public $collection;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(Group $collection)
+    {
+        parent::__construct();
+
+        $this->collection = $collection;
+    }
+}

--- a/app/Events/CollectionTrashed.php
+++ b/app/Events/CollectionTrashed.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace KBox\Events;
+
+use KBox\Group;
+
+class CollectionTrashed extends CausedEvent
+{
+    /**
+     * @var \KBox\Group
+     */
+    public $collection;
+
+    /**
+     * If the collection was permanently deleted
+     * @var bool
+     */
+    public $forceDeleted = false;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(Group $collection)
+    {
+        parent::__construct();
+
+        $this->collection = $collection;
+
+        $this->forceDeleted = $collection->isForceDeleting();
+    }
+}

--- a/app/Events/DocumentDescriptorDeleted.php
+++ b/app/Events/DocumentDescriptorDeleted.php
@@ -2,11 +2,13 @@
 
 namespace KBox\Events;
 
+use KBox\User;
 use KBox\DocumentDescriptor;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Support\Facades\Auth;
 
 /**
  * Document Descriptor deleted event
@@ -22,6 +24,12 @@ class DocumentDescriptorDeleted
      * @var KBox\DocumentDescriptor
      */
     public $document;
+
+    /**
+     * The user that triggered the document descriptor deletion
+     * @var KBox\User|null
+     */
+    public $user;
     
     /**
      * If the document was permanently deleted
@@ -39,6 +47,18 @@ class DocumentDescriptorDeleted
     {
         $this->document = $document;
         $this->forceDeleted = $document->isForceDeleting();
+        $this->user = Auth::user() ?? null;
+    }
+
+    /**
+     * Specify the user tha caused the event
+     * 
+     * @param \KBox\User $user 
+     * @return self
+     */
+    public function setCauser(User $user)
+    {
+        $this->user = $user;
     }
 
     /**

--- a/app/Events/DocumentDescriptorDeleted.php
+++ b/app/Events/DocumentDescriptorDeleted.php
@@ -2,34 +2,21 @@
 
 namespace KBox\Events;
 
-use KBox\User;
 use KBox\DocumentDescriptor;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Foundation\Events\Dispatchable;
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Support\Facades\Auth;
 
 /**
  * Document Descriptor deleted event
  *
  * It is fired when a descriptor is trashed or permanently deleted.
  */
-class DocumentDescriptorDeleted
+class DocumentDescriptorDeleted extends CausedEvent
 {
-    use Dispatchable, InteractsWithSockets, SerializesModels;
 
     /**
      * The DocumentDescriptor that has been deleted
      * @var KBox\DocumentDescriptor
      */
     public $document;
-
-    /**
-     * The user that triggered the document descriptor deletion
-     * @var KBox\User|null
-     */
-    public $user;
     
     /**
      * If the document was permanently deleted
@@ -45,29 +32,9 @@ class DocumentDescriptorDeleted
      */
     public function __construct(DocumentDescriptor $document)
     {
+        parent::__construct();
+
         $this->document = $document;
         $this->forceDeleted = $document->isForceDeleting();
-        $this->user = Auth::user() ?? null;
-    }
-
-    /**
-     * Specify the user tha caused the event
-     * 
-     * @param \KBox\User $user 
-     * @return self
-     */
-    public function setCauser(User $user)
-    {
-        $this->user = $user;
-    }
-
-    /**
-     * Get the channels the event should broadcast on.
-     *
-     * @return \Illuminate\Broadcasting\Channel|array
-     */
-    public function broadcastOn()
-    {
-        return new PrivateChannel('channel-name');
     }
 }

--- a/app/Events/DocumentDescriptorRestored.php
+++ b/app/Events/DocumentDescriptorRestored.php
@@ -3,33 +3,20 @@
 namespace KBox\Events;
 
 use KBox\DocumentDescriptor;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Foundation\Events\Dispatchable;
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Support\Facades\Auth;
-use KBox\User;
 
 /**
  * Document Descriptor restored event
  *
  * It is fired when a descriptor is restored from trash.
  */
-class DocumentDescriptorRestored
+class DocumentDescriptorRestored extends CausedEvent
 {
-    use Dispatchable, InteractsWithSockets, SerializesModels;
 
     /**
      * The DocumentDescriptor that has been restored
      * @var KBox\DocumentDescriptor
      */
     public $document;
-
-    /**
-     * The user that triggered the document descriptor restore
-     * @var KBox\User|null
-     */
-    public $user;
 
     /**
      * Create a new event instance.
@@ -39,29 +26,8 @@ class DocumentDescriptorRestored
      */
     public function __construct(DocumentDescriptor $document)
     {
+        parent::__construct();
+
         $this->document = $document;
-        $this->user = Auth::user() ?? null;
-    }
-
-
-    /**
-     * Specify the user tha caused the event
-     * 
-     * @param \KBox\User $user 
-     * @return self
-     */
-    public function setCauser(User $user)
-    {
-        $this->user = $user;
-    }
-
-    /**
-     * Get the channels the event should broadcast on.
-     *
-     * @return \Illuminate\Broadcasting\Channel|array
-     */
-    public function broadcastOn()
-    {
-        return new PrivateChannel('channel-name');
     }
 }

--- a/app/Events/DocumentDescriptorRestored.php
+++ b/app/Events/DocumentDescriptorRestored.php
@@ -7,6 +7,8 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Support\Facades\Auth;
+use KBox\User;
 
 /**
  * Document Descriptor restored event
@@ -24,6 +26,12 @@ class DocumentDescriptorRestored
     public $document;
 
     /**
+     * The user that triggered the document descriptor restore
+     * @var KBox\User|null
+     */
+    public $user;
+
+    /**
      * Create a new event instance.
      *
      * @param KBox\DocumentDescriptor The document that has been restored
@@ -32,6 +40,19 @@ class DocumentDescriptorRestored
     public function __construct(DocumentDescriptor $document)
     {
         $this->document = $document;
+        $this->user = Auth::user() ?? null;
+    }
+
+
+    /**
+     * Specify the user tha caused the event
+     * 
+     * @param \KBox\User $user 
+     * @return self
+     */
+    public function setCauser(User $user)
+    {
+        $this->user = $user;
     }
 
     /**

--- a/app/Events/DocumentVersionUploaded.php
+++ b/app/Events/DocumentVersionUploaded.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace KBox\Events;
+
+use KBox\DocumentDescriptor;
+use KBox\File;
+
+class DocumentVersionUploaded extends CausedEvent
+{
+    
+    /**
+     * @var \KBox\File
+     */
+    public $file;
+    
+    /**
+     * @var \KBox\DocumentDescriptor
+     */
+    public $descriptor;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(DocumentDescriptor $descriptor, File $file)
+    {
+        parent::__construct();
+
+        $this->descriptor = $descriptor;
+        
+        $this->file = $file;
+    }
+}

--- a/app/Events/DocumentsAddedToCollection.php
+++ b/app/Events/DocumentsAddedToCollection.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace KBox\Events;
+
+use KBox\Group;
+
+class DocumentsAddedToCollection extends CausedEvent
+{
+    
+    /**
+     * @var \KBox\Group
+     */
+    public $collection;
+
+    /**
+     * Identifiers of the added documents
+     *
+     * @var array
+     */
+    public $documents;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(Group $collection, array $documents)
+    {
+        parent::__construct();
+
+        $this->collection = $collection;
+        $this->documents = $documents;
+    }
+}

--- a/app/Events/DocumentsRemovedFromCollection.php
+++ b/app/Events/DocumentsRemovedFromCollection.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace KBox\Events;
+
+use KBox\Group;
+
+class DocumentsRemovedFromCollection extends CausedEvent
+{
+    /**
+     * @var \KBox\Group
+     */
+    public $collection;
+
+    /**
+     * Identifiers of the removed documents
+     *
+     * @var array
+     */
+    public $documents;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(Group $collection, array $documents)
+    {
+        parent::__construct();
+
+        $this->collection = $collection;
+        $this->documents = $documents;
+    }
+}

--- a/app/Events/FileDeleted.php
+++ b/app/Events/FileDeleted.php
@@ -7,6 +7,8 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Support\Facades\Auth;
+use KBox\User;
 
 /**
  * File deleted event
@@ -24,6 +26,12 @@ class FileDeleted
     public $file;
 
     /**
+     * The user that triggered the document descriptor restore
+     * @var KBox\User
+     */
+    public $user;
+
+    /**
      * If the file was permanently deleted
      * @var bool
      */
@@ -39,6 +47,18 @@ class FileDeleted
     {
         $this->file = $file;
         $this->forceDeleted = $file->isForceDeleting();
+        $this->user = Auth::user() ?? null;
+    }
+
+    /**
+     * Specify the user tha caused the event
+     * 
+     * @param \KBox\User $user 
+     * @return self
+     */
+    public function setCauser(User $user)
+    {
+        $this->user = $user;
     }
 
     /**

--- a/app/Events/FileDeleted.php
+++ b/app/Events/FileDeleted.php
@@ -3,33 +3,20 @@
 namespace KBox\Events;
 
 use KBox\File;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Foundation\Events\Dispatchable;
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Support\Facades\Auth;
-use KBox\User;
 
 /**
  * File deleted event
  *
  * It is fired when a file is trashed or permanently deleted.
  */
-class FileDeleted
+class FileDeleted extends CausedEvent
 {
-    use Dispatchable, InteractsWithSockets, SerializesModels;
 
     /**
      * The file that has been deleted
      * @var KBox\File
      */
     public $file;
-
-    /**
-     * The user that triggered the document descriptor restore
-     * @var KBox\User
-     */
-    public $user;
 
     /**
      * If the file was permanently deleted
@@ -45,29 +32,9 @@ class FileDeleted
      */
     public function __construct(File $file)
     {
+        parent::__construct();
+
         $this->file = $file;
         $this->forceDeleted = $file->isForceDeleting();
-        $this->user = Auth::user() ?? null;
-    }
-
-    /**
-     * Specify the user tha caused the event
-     * 
-     * @param \KBox\User $user 
-     * @return self
-     */
-    public function setCauser(User $user)
-    {
-        $this->user = $user;
-    }
-
-    /**
-     * Get the channels the event should broadcast on.
-     *
-     * @return \Illuminate\Broadcasting\Channel|array
-     */
-    public function broadcastOn()
-    {
-        return new PrivateChannel('channel-name');
     }
 }

--- a/app/Events/FileDeleting.php
+++ b/app/Events/FileDeleting.php
@@ -3,36 +3,20 @@
 namespace KBox\Events;
 
 use KBox\File;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Foundation\Events\Dispatchable;
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Support\Facades\Auth;
-use KBox\User;
 
 /**
  * File deleting event
  *
  * It is fired immediately before a file is trashed or permanently deleted.
  */
-class FileDeleting
+class FileDeleting extends CausedEvent
 {
-    use Dispatchable, InteractsWithSockets, SerializesModels;
 
     /**
      * The file that has been deleted
      * @var KBox\File
      */
     public $file;
-
-    /**
-     * The user that triggered the document descriptor restore
-     * 
-     * It might
-     * 
-     * @var KBox\User|null
-     */
-    public $user;
 
     /**
      * If the file was permanently deleted
@@ -48,29 +32,9 @@ class FileDeleting
      */
     public function __construct(File $file)
     {
+        parent::__construct();
+
         $this->file = $file;
         $this->forceDeleted = $file->isForceDeleting();
-        $this->user = Auth::user() ?? null;
-    }
-
-    /**
-     * Specify the user tha caused the event
-     * 
-     * @param \KBox\User $user 
-     * @return self
-     */
-    public function setCauser(User $user)
-    {
-        $this->user = $user;
-    }
-
-    /**
-     * Get the channels the event should broadcast on.
-     *
-     * @return \Illuminate\Broadcasting\Channel|array
-     */
-    public function broadcastOn()
-    {
-        return new PrivateChannel('channel-name');
     }
 }

--- a/app/Events/FileDeleting.php
+++ b/app/Events/FileDeleting.php
@@ -7,6 +7,8 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Support\Facades\Auth;
+use KBox\User;
 
 /**
  * File deleting event
@@ -24,6 +26,15 @@ class FileDeleting
     public $file;
 
     /**
+     * The user that triggered the document descriptor restore
+     * 
+     * It might
+     * 
+     * @var KBox\User|null
+     */
+    public $user;
+
+    /**
      * If the file was permanently deleted
      * @var bool
      */
@@ -39,6 +50,18 @@ class FileDeleting
     {
         $this->file = $file;
         $this->forceDeleted = $file->isForceDeleting();
+        $this->user = Auth::user() ?? null;
+    }
+
+    /**
+     * Specify the user tha caused the event
+     * 
+     * @param \KBox\User $user 
+     * @return self
+     */
+    public function setCauser(User $user)
+    {
+        $this->user = $user;
     }
 
     /**

--- a/app/Events/FileRestored.php
+++ b/app/Events/FileRestored.php
@@ -3,36 +3,20 @@
 namespace KBox\Events;
 
 use KBox\File;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Foundation\Events\Dispatchable;
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Support\Facades\Auth;
-use KBox\User;
 
 /**
  * File restored event
  *
  * It is fired when a file is restored from trash.
  */
-class FileRestored
+class FileRestored extends CausedEvent
 {
-    use Dispatchable, InteractsWithSockets, SerializesModels;
 
     /**
      * The file that has been restored
      * @var KBox\File
      */
     public $file;
-
-    /**
-     * The user that triggered the document descriptor restore
-     * 
-     * It might
-     * 
-     * @var KBox\User|null
-     */
-    public $user;
 
     /**
      * Create a new event instance.
@@ -42,28 +26,8 @@ class FileRestored
      */
     public function __construct(File $file)
     {
+        parent::__construct();
+
         $this->file = $file;
-        $this->user = Auth::user() ?? null;
-    }
-
-    /**
-     * Specify the user tha caused the event
-     * 
-     * @param \KBox\User $user 
-     * @return self
-     */
-    public function setCauser(User $user)
-    {
-        $this->user = $user;
-    }
-
-    /**
-     * Get the channels the event should broadcast on.
-     *
-     * @return \Illuminate\Broadcasting\Channel|array
-     */
-    public function broadcastOn()
-    {
-        return new PrivateChannel('channel-name');
     }
 }

--- a/app/Events/FileRestored.php
+++ b/app/Events/FileRestored.php
@@ -7,6 +7,8 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Support\Facades\Auth;
+use KBox\User;
 
 /**
  * File restored event
@@ -24,6 +26,15 @@ class FileRestored
     public $file;
 
     /**
+     * The user that triggered the document descriptor restore
+     * 
+     * It might
+     * 
+     * @var KBox\User|null
+     */
+    public $user;
+
+    /**
      * Create a new event instance.
      *
      * @param KBox\File The file that has been restored
@@ -32,6 +43,18 @@ class FileRestored
     public function __construct(File $file)
     {
         $this->file = $file;
+        $this->user = Auth::user() ?? null;
+    }
+
+    /**
+     * Specify the user tha caused the event
+     * 
+     * @param \KBox\User $user 
+     * @return self
+     */
+    public function setCauser(User $user)
+    {
+        $this->user = $user;
     }
 
     /**

--- a/app/Events/ProjectCreated.php
+++ b/app/Events/ProjectCreated.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace KBox\Events;
+
+use KBox\Project;
+
+class ProjectCreated extends CausedEvent
+{
+
+    /**
+     * @var \KBox\Project
+     */
+    public $project;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(Project $project)
+    {
+        parent::__construct();
+
+        $this->project = $project;
+    }
+}

--- a/app/Events/ProjectMembersAdded.php
+++ b/app/Events/ProjectMembersAdded.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace KBox\Events;
+
+use KBox\Project;
+
+class ProjectMembersAdded extends ProjectCreated
+{
+    public $members = [];
+
+    /**
+     * Create a new event instance.
+     *
+     * @param \KBox\Project
+     * @param \KBox\User[]
+     * @return void
+     */
+    public function __construct(Project $project, array $users)
+    {
+        parent::__construct($project);
+
+        $this->members = $users;
+    }
+}

--- a/app/Events/ProjectMembersRemoved.php
+++ b/app/Events/ProjectMembersRemoved.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace KBox\Events;
+
+class ProjectMembersRemoved extends ProjectMembersAdded
+{
+}

--- a/app/Group.php
+++ b/app/Group.php
@@ -7,6 +7,8 @@ use KBox\Traits\LocalizableDateFields;
 use Franzose\ClosureTable\Models\Entity;
 use Dyrynda\Database\Support\GeneratesUuid;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use KBox\Events\CollectionCreated;
+use KBox\Events\CollectionTrashed;
 
 /**
  * A collection of document descriptors
@@ -90,6 +92,11 @@ class Group extends Entity implements GroupInterface
 
     protected $casts = [
         'uuid' => 'uuid',
+    ];
+
+    protected $dispatchesEvents = [
+        'created' => CollectionCreated::class,
+        'deleted' => CollectionTrashed::class,
     ];
 
     public function user()

--- a/app/Http/Controllers/Document/GroupsController.php
+++ b/app/Http/Controllers/Document/GroupsController.php
@@ -100,8 +100,7 @@ class GroupsController extends Controller
 
             \Cache::flush();
 
-            if ($request->ajax() && $request->wantsJson()) {
-                // return response()->json($created_group);
+            if ($request->wantsJson()) {
                 return new JsonResponse($created_group->toArray(), 201);
             } elseif ($request->ajax() && $request->input('ok_template', false)) {
                 return view('groups.tree');
@@ -111,13 +110,13 @@ class GroupsController extends Controller
         } catch (ForbiddenException $fe) {
             //return forbidden response
 
-            if ($request->ajax() && $request->wantsJson()) {
+            if ($request->wantsJson()) {
                 return new JsonResponse(['error' => $fe->getMessage()], 403);
             }
 
             return response("forbidden", 403);
         } catch (GroupAlreadyExistsException $fe) {
-            if ($request->ajax() && $request->wantsJson()) {
+            if ($request->wantsJson()) {
                 return new JsonResponse(['error' => $fe->getMessage()], 409);
             }
 

--- a/app/Http/Controllers/Projects/ProjectsController.php
+++ b/app/Http/Controllers/Projects/ProjectsController.php
@@ -157,9 +157,7 @@ class ProjectsController extends Controller
                 DB::transaction(function () use ($project, $request) {
                     $users = $request->get('users');
                     
-                    foreach ($users as $user) {
-                        $project->users()->attach($user);
-                    }
+                    $project->addMembers($users);
                 });
             }
 
@@ -230,15 +228,11 @@ class ProjectsController extends Controller
                     $users_to_remove = array_intersect($prj_users, $users);
                     
                     if (count($users_to_add) > 0) {
-                        foreach ($users_to_add as $user) {
-                            $project->users()->attach($user);
-                        }
+                        $project->addMembers($users_to_add);
                     }
                     
                     if (count($users_to_remove) > 0) {
-                        foreach ($users_to_remove as $user) {
-                            $project->users()->detach($user);
-                        }
+                        $project->removeMembers($users_to_remove);
                     }
                 }
                 

--- a/app/Project.php
+++ b/app/Project.php
@@ -7,6 +7,7 @@ use KBox\Traits\LocalizableDateFields;
 use Illuminate\Database\Eloquent\Model;
 use Dyrynda\Database\Support\GeneratesUuid;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use KBox\Events\ProjectCreated;
 
 /**
  * The project concept.
@@ -38,19 +39,10 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 class Project extends Model
 {
     use LocalizableDateFields, GeneratesUuid, ScopeNullUuid;
-    /*
 
-        $table->bigIncrements('id');
-        $table->string('name');
-        $table->text('description')->nullable();
-        $table->string('avatar')->nullable();
-
-        $table->bigInteger('user_id')->unsigned(); --> project manager
-        $table->bigInteger('collection_id')->unsigned(); --> root project collection
-
-        $table->timestamps();
-
-     */
+    protected $dispatchesEvents = [
+        'created' => ProjectCreated::class,
+    ];
 
     /**
      * The database table used by the model.

--- a/docs/developer/events.md
+++ b/docs/developer/events.md
@@ -1,0 +1,25 @@
+# Events
+
+The K-Box has an internal event system based on [Laravel's Events](https://laravel.com/docs/5.7/events).
+Events are used to track actions and workflows. An event can also trigger workflows and be used to process 
+asynchronous notifications or long-running actions.
+
+
+## Reference
+
+| Event                        | Description |
+| ---------------------------- | ----------- |
+| `DocumentDescriptorDeleted`  | A document descriptor was trashed by a user |
+| `DocumentDescriptorRestored` | A document descriptor was restored from the trash |
+| `EmailChanged`               | The user changed the email address |
+| `FileDeleted`                | A file is trashed |
+| `FileDeleting`               | It is fired immediately before a file is trashed or permanently deleted. |
+| `FileDuplicateFoundEvent`    | A duplicate of an existing file has been recognized |
+| `FileRestored`               | A file is restored from the trash |
+| `PageChanged`                | A static page, like terms of service, privacy policy has been changed on disk |
+| `PersonalExportCreated`      | The export of the user's personal data has been created |
+| `PrivacyPolicyUpdated`       | The privacy policy file was changed |
+| `ShareCreated`               | A share of a file or collection was created |
+| `UploadCompleted`            | A file upload completed |
+| `UserInviteAccepted`         | An invitation was accepted and the account created |
+| `UserInvited`                | An invitation request is sent to a potential user |

--- a/docs/developer/events.md
+++ b/docs/developer/events.md
@@ -9,6 +9,8 @@ asynchronous notifications or long-running actions.
 
 | Event                        | Description |
 | ---------------------------- | ----------- |
+| `CollectionCreated`          | When a user creates a collection |
+| `CollectionTrashed`          | When a user trashes a collection |
 | `DocumentDescriptorDeleted`  | A document descriptor was trashed by a user |
 | `DocumentDescriptorRestored` | A document descriptor was restored from the trash |
 | `EmailChanged`               | The user changed the email address |

--- a/docs/developer/events.md
+++ b/docs/developer/events.md
@@ -18,6 +18,7 @@ asynchronous notifications or long-running actions.
 | `FileDeleting`               | It is fired immediately before a file is trashed or permanently deleted. |
 | `FileDuplicateFoundEvent`    | A duplicate of an existing file has been recognized |
 | `FileRestored`               | A file is restored from the trash |
+| `DocumentVersionUploaded`    | A new file version for a Document Descriptor was succesfully uploaded | 
 | `PageChanged`                | A static page, like terms of service, privacy policy has been changed on disk |
 | `PersonalExportCreated`      | The export of the user's personal data has been created |
 | `PrivacyPolicyUpdated`       | The privacy policy file was changed |

--- a/docs/developer/events.md
+++ b/docs/developer/events.md
@@ -7,12 +7,16 @@ asynchronous notifications or long-running actions.
 
 ## Reference
 
+Here are the main events currently available:
+
 | Event                        | Description |
 | ---------------------------- | ----------- |
 | `CollectionCreated`          | When a user creates a collection |
 | `CollectionTrashed`          | When a user trashes a collection |
 | `DocumentDescriptorDeleted`  | A document descriptor was trashed by a user |
 | `DocumentDescriptorRestored` | A document descriptor was restored from the trash |
+| `DocumentsAddedToCollection`     | When a document is added to one or more collection |
+| `DocumentsRemovedFromCollection` | When a document is removed from one or more collection |
 | `EmailChanged`               | The user changed the email address |
 | `FileDeleted`                | A file is trashed |
 | `FileDeleting`               | It is fired immediately before a file is trashed or permanently deleted. |
@@ -29,3 +33,8 @@ asynchronous notifications or long-running actions.
 | `UploadCompleted`            | A file upload completed |
 | `UserInviteAccepted`         | An invitation was accepted and the account created |
 | `UserInvited`                | An invitation request is sent to a potential user |
+
+
+> the event name is equal to the class in the `KBox\Events` namespace.
+
+> For the difference between file and document descriptor please refer to the [database section](./database.md).

--- a/docs/developer/events.md
+++ b/docs/developer/events.md
@@ -20,6 +20,8 @@ asynchronous notifications or long-running actions.
 | `PersonalExportCreated`      | The export of the user's personal data has been created |
 | `PrivacyPolicyUpdated`       | The privacy policy file was changed |
 | `ProjectCreated`             | A project has been created by a user |
+| `ProjectMembersAdded`        | Triggered when one or more members are added to a Project |
+| `ProjectMembersRemoved`      | Triggered when one or more members are removed from a Project |
 | `ShareCreated`               | A share of a file or collection was created |
 | `UploadCompleted`            | A file upload completed |
 | `UserInviteAccepted`         | An invitation was accepted and the account created |

--- a/docs/developer/events.md
+++ b/docs/developer/events.md
@@ -19,6 +19,7 @@ asynchronous notifications or long-running actions.
 | `PageChanged`                | A static page, like terms of service, privacy policy has been changed on disk |
 | `PersonalExportCreated`      | The export of the user's personal data has been created |
 | `PrivacyPolicyUpdated`       | The privacy policy file was changed |
+| `ProjectCreated`             | A project has been created by a user |
 | `ShareCreated`               | A share of a file or collection was created |
 | `UploadCompleted`            | A file upload completed |
 | `UserInviteAccepted`         | An invitation was accepted and the account created |

--- a/tests/Feature/ProjectMembersTest.php
+++ b/tests/Feature/ProjectMembersTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Feature;
+
+use KBox\User;
+use KBox\Project;
+use Tests\TestCase;
+use KBox\Capability;
+use Tests\Concerns\ClearDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Event;
+use KBox\Events\ProjectMembersAdded;
+use KBox\Events\ProjectMembersRemoved;
+
+class ProjectMembersTest extends TestCase
+{
+    use DatabaseTransactions, ClearDatabase;
+
+    private function createUser($capabilities, $userParams = [])
+    {
+        return tap(factory(User::class)->create($userParams))->addCapabilities($capabilities);
+    }
+    
+    public function test_members_can_be_added()
+    {
+        $user = $this->createUser(Capability::$PROJECT_MANAGER);
+
+        $members = collect([
+            $this->createUser(Capability::$PARTNER),
+            $this->createUser(Capability::$PARTNER),
+        ]);
+
+        $params = [
+            'manager' => $user->id,
+            'name' => 'Project title',
+            'description' => null,
+            'users' => $members->pluck('id')->toArray(),
+        ];
+
+        Event::fake();
+
+        $response = $this->from(route('projects.create'))
+            ->actingAs($user)
+            ->post(route('projects.store'), $params);
+
+        $created_project = Project::where('name', 'Project title')->first();
+
+        $current_members = $created_project->users()->orderBy('id', 'asc')->get();
+
+        $this->assertCount(2, $current_members);
+
+        $this->assertEquals($members->pluck('id')->toArray(), $current_members->pluck('id')->toArray());
+
+        Event::assertDispatched(ProjectMembersAdded::class, function ($e) use ($created_project, $current_members) {
+            return $e->project->is($created_project)
+                && collect($e->members)->diff($current_members->pluck('id'))->isEmpty();
+        });
+    }
+
+    public function test_members_can_be_removed()
+    {
+        $user = $this->createUser(Capability::$PROJECT_MANAGER);
+
+        $members = collect([
+            $this->createUser(Capability::$PARTNER),
+            $this->createUser(Capability::$PARTNER),
+        ]);
+        
+        $project = factory(Project::class)->create([
+            'user_id' => $user->getKey()
+        ]);
+
+        $project->users()->toggle($members->pluck('id')->toArray());
+
+        $params = [
+            'manager' => $user->getKey(),
+            'name' => $project->name,
+            // 'description' => null,
+            'users' => $members->pluck('id')->toArray(),
+        ];
+
+        Event::fake();
+
+        $response = $this->from(route('projects.show', $project->getKey()))
+            ->actingAs($user)
+            ->put(route('projects.update', $project->getKey()), $params);
+
+        $response->assertSessionDoesntHaveErrors();
+
+        $updated_project = $project->fresh();
+
+        $current_members = $updated_project->users()->orderBy('id', 'asc')->get();
+
+        $this->assertCount(0, $current_members);
+
+        Event::assertDispatched(ProjectMembersRemoved::class, function ($e) use ($updated_project, $members) {
+            return $e->project->is($updated_project)
+                && collect($e->members)->diff($members->pluck('id'))->isEmpty();
+        });
+    }
+}

--- a/tests/Unit/DocumentDescriptorEventsTest.php
+++ b/tests/Unit/DocumentDescriptorEventsTest.php
@@ -17,11 +17,12 @@ class DocumentDescriptorEventsTest extends TestCase
     {
         Event::fake();
         $document = factory(DocumentDescriptor::class)->create();
+        $this->actingAs($document->owner);
 
         $document->delete();
 
         Event::assertDispatched(DocumentDescriptorDeleted::class, function ($e) use ($document) {
-            return $e->document->id === $document->id && ! $e->forceDeleted;
+            return $e->document->id === $document->id && ! $e->forceDeleted && $e->user->is($document->owner);
         });
     }
     
@@ -29,11 +30,12 @@ class DocumentDescriptorEventsTest extends TestCase
     {
         Event::fake();
         $document = factory(DocumentDescriptor::class)->create();
+        $this->actingAs($document->owner);
 
         $document->forceDelete();
 
         Event::assertDispatched(DocumentDescriptorDeleted::class, function ($e) use ($document) {
-            return $e->document->id === $document->id && $e->forceDeleted;
+            return $e->document->id === $document->id && $e->forceDeleted && $e->user->is($document->owner);
         });
     }
     
@@ -41,12 +43,13 @@ class DocumentDescriptorEventsTest extends TestCase
     {
         Event::fake();
         $document = factory(DocumentDescriptor::class)->create();
+        $this->actingAs($document->owner);
         $document->delete();
 
         $document->restore();
 
         Event::assertDispatched(DocumentDescriptorRestored::class, function ($e) use ($document) {
-            return $e->document->id === $document->id;
+            return $e->document->id === $document->id && $e->user->is($document->owner);
         });
     }
 }


### PR DESCRIPTION
## What does this PR do?

Add additional events to the K-Box event system to track changes on projects, collections and documents

| Event                        | Description |
| ---------------------------- | ----------- |
| `CollectionCreated`          | When a user creates a collection |
| `CollectionTrashed`          | When a user trashes a collection |
| `DocumentsAddedToCollection`     | When a document is added to one or more collection |
| `DocumentsRemovedFromCollection` | When a document is removed from one or more collection |
| `DocumentVersionUploaded`    | A new file version for a Document Descriptor was succesfully uploaded | 
| `ProjectCreated`             | A project has been created by a user |
| `ProjectMembersAdded`        | Triggered when one or more members are added to a Project |
| `ProjectMembersRemoved`      | Triggered when one or more members are removed from a Project |


### Related issues

Fixes ...

### Review checklist

* [x] Are unit tests required?
* [x] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)