### PR TITLE
Remove deprecated string helpers

### DIFF
--- a/app/Console/Commands/DmsModelCreation.php
+++ b/app/Console/Commands/DmsModelCreation.php
@@ -7,6 +7,7 @@ use Illuminate\Console\DetectsApplicationNamespace;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
 
 class DmsModelCreation extends Command
 {
@@ -196,7 +197,7 @@ class DmsModelCreation extends Command
             $populated_relation_stub ='';
         
             foreach ($foreignKeys as $key) {
-                $populated_relation_stub = str_replace('{{relation_method_name}}', camel_case($this->getClassName($key['table'])), $clean_stub);
+                $populated_relation_stub = str_replace('{{relation_method_name}}', Str::camel($this->getClassName($key['table'])), $clean_stub);
 
                 $populated_relation_stub = str_replace('{{model}}', $this->getClassName($key['table']), $populated_relation_stub);
 

--- a/app/Console/Commands/DmsModelCreation.php
+++ b/app/Console/Commands/DmsModelCreation.php
@@ -15,13 +15,13 @@ class DmsModelCreation extends Command
 
     /*
 
-    str_plural Convert a string to its plural form (English only).
+    Str::plural Convert a string to its plural form (English only).
 
-    str_singular Convert a string to its singular form (English only).
+    Str::singular Convert a string to its singular form (English only).
 
-    studly_case: foo_bar => FooBar
+    Str::studly: foo_bar => FooBar
 
-    snake_case: fooBar => foo_bar
+    Str::snake: fooBar => foo_bar
 
     camel_case: foo_bar => fooBar
 
@@ -302,6 +302,6 @@ class DmsModelCreation extends Command
      */
     protected function getClassName($table)
     {
-        return str_singular(studly_case($table));
+        return Str::singular(Str::studly($table));
     }
 }

--- a/app/Console/Commands/DmsSessionChecker.php
+++ b/app/Console/Commands/DmsSessionChecker.php
@@ -4,6 +4,7 @@ namespace KBox\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\DB;
 use Symfony\Component\Console\Input\InputOption;
 use KBox\User;
@@ -71,7 +72,7 @@ class DmsSessionChecker extends Command
             $payload = @unserialize(base64_decode($session->payload));
             
             $login_user = Arr::first($payload, function ($value, $key) {
-                return starts_with($key, 'login_');
+                return Str::startsWith($key, 'login_');
             });
             
             try {

--- a/app/Console/Commands/DmsUpdateCommand.php
+++ b/app/Console/Commands/DmsUpdateCommand.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\DB;
 use KBox\Group;
 use KBox\Project;
+use Illuminate\Support\Str;
 
 class DmsUpdateCommand extends Command
 {
@@ -605,7 +606,7 @@ class DmsUpdateCommand extends Command
         
         $files->each(function ($file) use (&$counter) {
             if (is_file($file->absolute_path) &&
-                ! ends_with(dirname($file->path), "$file->uuid")) {
+                ! Str::endsWith(dirname($file->path), "$file->uuid")) {
                 $dir = dirname($file->path);
     
                 Storage::disk('local')->makeDirectory("$dir/$file->uuid");

--- a/app/Console/Commands/Language/LanguageCheckCommand.php
+++ b/app/Console/Commands/Language/LanguageCheckCommand.php
@@ -10,6 +10,7 @@ use Carbon\Carbon;
 
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 /**
  * Verify that all the strings in english language files can be found in the other languages.
@@ -91,7 +92,7 @@ class LanguageCheckCommand extends Command
         );
 
         $directories = array_filter($this->filesystem->directories($language_path), function ($i) {
-            return ! ends_with($i, 'en');
+            return ! Str::endsWith($i, 'en');
         });
 
         $translationLoader = app('translation.loader');

--- a/app/DocumentDescriptor.php
+++ b/app/DocumentDescriptor.php
@@ -15,6 +15,7 @@ use OneOffTech\Licenses\Contracts\LicenseRepository;
 use KBox\Events\DocumentDescriptorDeleted;
 use KBox\Events\DocumentDescriptorRestored;
 use KBox\Traits\ScopeNullUuid;
+use Illuminate\Support\Str;
 
 /**
  * A Document Descriptor
@@ -546,7 +547,7 @@ class DocumentDescriptor extends Model
 
     public function isRemoteWebPage()
     {
-        return ($this->document_type == 'web-page' || $this->document_type == 'document') && ! is_null($this->file) && starts_with($this->file->original_uri, 'http');
+        return ($this->document_type == 'web-page' || $this->document_type == 'document') && ! is_null($this->file) && Str::startsWith($this->file->original_uri, 'http');
     }
     
     /**

--- a/app/File.php
+++ b/app/File.php
@@ -17,6 +17,7 @@ use KBox\Events\FileDeleted;
 use KBox\Events\FileDeleting;
 use KBox\Events\FileRestored;
 use KBox\Traits\ScopeNullUuid;
+use Illuminate\Support\Str;
 
 /**
  * The representation of a File on disk
@@ -182,7 +183,7 @@ class File extends Model
      */
     public function isRemoteWebPage()
     {
-        return starts_with($this->mime_type, 'text/html') && starts_with($this->original_uri, 'http');
+        return Str::startsWith($this->mime_type, 'text/html') && Str::startsWith($this->original_uri, 'http');
     }
 
     /**
@@ -307,7 +308,7 @@ class File extends Model
     {
         $disk_path = rtrim(Storage::disk('local')->path('/'), '/');
 
-        if (starts_with($value, $disk_path)) {
+        if (Str::startsWith($value, $disk_path)) {
             return ltrim(str_replace($disk_path, '', $value), '/');
         }
 
@@ -326,7 +327,7 @@ class File extends Model
     {
         $disk_path = rtrim(Storage::disk('local')->path('/'), '/');
 
-        if (starts_with($value, $disk_path)) {
+        if (Str::startsWith($value, $disk_path)) {
             return ltrim(str_replace($disk_path, '', $value), '/');
         }
 
@@ -378,7 +379,7 @@ class File extends Model
             return null;
         }
         
-        if (starts_with($path, $disk_path)) {
+        if (Str::startsWith($path, $disk_path)) {
             return $path;
         }
         return Storage::disk('local')->path($path);
@@ -457,7 +458,7 @@ class File extends Model
         if (empty($path)) {
             return;
         }
-        if (! starts_with($path, rtrim(public_path('/'), '/'))) {
+        if (! Str::startsWith($path, rtrim(public_path('/'), '/'))) {
             $storage = Storage::disk('local');
             @$storage->delete($path);
         }
@@ -585,13 +586,13 @@ class File extends Model
         $resources = collect();
 
         $dash_manifest = $files->filter(function ($value, $key) {
-            return ends_with($value, 'mpd');
+            return Str::endsWith($value, 'mpd');
         })->first();
 
         $resources->put('dash', $dash_manifest);
 
         $videos = $files->filter(function ($value, $key) {
-            return ends_with($value, 'mp4') && $this->path !== $value;
+            return Str::endsWith($value, 'mp4') && $this->path !== $value;
         });
 
         $resources->put('streams', $videos);

--- a/app/Flags.php
+++ b/app/Flags.php
@@ -3,6 +3,7 @@
 namespace KBox;
 
 use KBox\Traits\HasEnums;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 
 /**
@@ -170,7 +171,7 @@ final class Flags
     {
         if (str_is('is*Enabled', $method)) {
             $keys = self::constants();
-            $key = strtolower(str_before(str_after($method, 'is'), 'Enabled'));
+            $key = strtolower(Str::before(Str::after($method, 'is'), 'Enabled'));
             if (self::isValidEnumKey(strtoupper($key))) {
                 return static::isEnabled($key);
             }
@@ -181,7 +182,7 @@ final class Flags
     {
         if (str_is('is*Enabled', $method)) {
             $keys = self::constants();
-            $key = strtolower(str_before(str_after($method, 'is'), 'Enabled'));
+            $key = strtolower(Str::before(Str::after($method, 'is'), 'Enabled'));
             if (self::isValidEnumKey(strtoupper($key))) {
                 return static::isEnabled($key);
             }

--- a/app/Flags.php
+++ b/app/Flags.php
@@ -169,7 +169,7 @@ final class Flags
 
     public function __call($method, $arguments)
     {
-        if (str_is('is*Enabled', $method)) {
+        if (Str::is('is*Enabled', $method)) {
             $keys = self::constants();
             $key = strtolower(Str::before(Str::after($method, 'is'), 'Enabled'));
             if (self::isValidEnumKey(strtoupper($key))) {
@@ -180,7 +180,7 @@ final class Flags
 
     public static function __callStatic($method, $arguments)
     {
-        if (str_is('is*Enabled', $method)) {
+        if (Str::is('is*Enabled', $method)) {
             $keys = self::constants();
             $key = strtolower(Str::before(Str::after($method, 'is'), 'Enabled'));
             if (self::isValidEnumKey(strtoupper($key))) {

--- a/app/Http/Composers/AllComposer.php
+++ b/app/Http/Composers/AllComposer.php
@@ -3,6 +3,7 @@
 namespace KBox\Http\Composers;
 
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Str;
 
 class AllComposer
 {
@@ -36,7 +37,7 @@ class AllComposer
         if ($is_logged) {
             $logged_in_user = \Auth::user();
             
-            if (! ends_with($logged_in_user->email, 'klink.local')) {
+            if (! Str::endsWith($logged_in_user->email, 'klink.local')) {
                 $view->with('feedback_loggedin', $is_logged);
                 $view->with('feedback_user_name', $logged_in_user->name);
                 $view->with('feedback_user_mail', $logged_in_user->email);
@@ -51,7 +52,7 @@ class AllComposer
             $body_classes[] = 'frontpage';
         }
 
-        if (! is_null($route_name) && starts_with($route_name, 'documents')) {
+        if (! is_null($route_name) && Str::startsWith($route_name, 'documents')) {
             $body_classes[] = 'dropzone-container';
         }
 

--- a/app/Http/Composers/DocumentsComposer.php
+++ b/app/Http/Composers/DocumentsComposer.php
@@ -8,7 +8,7 @@ use KBox\DocumentDescriptor;
 use KBox\File;
 use KBox\Group;
 use KBox\Project;
-
+use Illuminate\Support\Str;
 use Illuminate\Contracts\View\View;
 
 use Illuminate\Support\Collection;
@@ -450,10 +450,10 @@ class DocumentsComposer
             
             foreach ($items as $group_facet) {
                 if ($group_facet->count > 0) {
-                    if (starts_with($group_facet->term, '0:')) {
+                    if (Str::startsWith($group_facet->term, '0:')) {
                         // private
                         $private[] = \KBox\Group::findOrFail(str_replace('0:', '', $group_facet->term));
-                    } elseif (starts_with($group_facet->term, $auth_user->id.':')) {
+                    } elseif (Str::startsWith($group_facet->term, $auth_user->id.':')) {
                         //personal
                         $personal[] = $group_facet;
                     }

--- a/app/Http/Composers/FrontpageComposer.php
+++ b/app/Http/Composers/FrontpageComposer.php
@@ -2,6 +2,7 @@
 
 namespace KBox\Http\Composers;
 
+use Illuminate\Support\Str;
 use Illuminate\Contracts\View\View;
 
 /**
@@ -38,7 +39,7 @@ class FrontpageComposer
             $body_classes[] = $route_name;
         }
 
-        if (! is_null($route_name) && starts_with($route_name, 'documents')) {
+        if (! is_null($route_name) && Str::startsWith($route_name, 'documents')) {
             $body_classes[] = 'dropzone-container';
         }
 

--- a/app/Http/Composers/HeadersComposer.php
+++ b/app/Http/Composers/HeadersComposer.php
@@ -3,6 +3,7 @@
 namespace KBox\Http\Composers;
 
 use KBox\HomeRoute;
+use Illuminate\Support\Str;
 use Illuminate\Contracts\View\View;
 
 class HeadersComposer
@@ -53,21 +54,21 @@ class HeadersComposer
 
         $is_klink_public_enabled = config('dms.are_guest_public_search_enabled') && network_enabled();
 
-        $show_search = (! $is_logged && $is_klink_public_enabled && ! starts_with($route_name, 'password') && ! str_contains($route_name, 'help') && ! starts_with($route_name, 'terms') && ! str_contains($route_name, 'contact')) ||
+        $show_search = (! $is_logged && $is_klink_public_enabled && ! Str::startsWith($route_name, 'password') && ! Str::contains($route_name, 'help') && ! Str::startsWith($route_name, 'terms') && ! Str::contains($route_name, 'contact')) ||
                         ($is_logged && ! is_null($route_name) &&
-                       (! starts_with($route_name, 'admin') ||  starts_with($route_name, 'admin') && str_contains($route_name, 'storage.files'))  &&
-                       ! str_contains($route_name, 'contact') &&
-                       ! str_contains($route_name, 'help') && ! starts_with($route_name, 'terms') && ! str_contains($route_name, 'trash') &&
-                       ! starts_with($route_name, 'projects')  &&
-                       ! str_contains($route_name, 'profile.') &&
-                       ! starts_with($route_name, 'consent') &&
-                       ! starts_with($route_name, 'register') &&
-                       ! starts_with($route_name, 'verification') &&
-                       ! starts_with($route_name, 'documents.edit') &&
-                       ! starts_with($route_name, 'plugins') &&
-                       ! starts_with($route_name, 'uploads') &&
-                       ! starts_with($route_name, 'privacy') &&
-                       ! starts_with($route_name, 'password') && ! starts_with($route_name, 'microsite'));
+                       (! Str::startsWith($route_name, 'admin') ||  Str::startsWith($route_name, 'admin') && Str::contains($route_name, 'storage.files'))  &&
+                       ! Str::contains($route_name, 'contact') &&
+                       ! Str::contains($route_name, 'help') && ! Str::startsWith($route_name, 'terms') && ! Str::contains($route_name, 'trash') &&
+                       ! Str::startsWith($route_name, 'projects')  &&
+                       ! Str::contains($route_name, 'profile.') &&
+                       ! Str::startsWith($route_name, 'consent') &&
+                       ! Str::startsWith($route_name, 'register') &&
+                       ! Str::startsWith($route_name, 'verification') &&
+                       ! Str::startsWith($route_name, 'documents.edit') &&
+                       ! Str::startsWith($route_name, 'plugins') &&
+                       ! Str::startsWith($route_name, 'uploads') &&
+                       ! Str::startsWith($route_name, 'privacy') &&
+                       ! Str::startsWith($route_name, 'password') && ! Str::startsWith($route_name, 'microsite'));
 
         $view->with('show_search', $show_search);
 

--- a/app/Http/Controllers/Administration/MessagingController.php
+++ b/app/Http/Controllers/Administration/MessagingController.php
@@ -4,6 +4,7 @@ namespace KBox\Http\Controllers\Administration;
 
 use KBox\User;
 use KBox\Option;
+use Illuminate\Support\Str;
 use KBox\Mail\UserDirectMessage;
 use Illuminate\Support\Facades\Mail;
 use KBox\Http\Controllers\Controller;
@@ -102,7 +103,7 @@ class MessagingController extends Controller
             $from_mail = Option::mailFrom();
             $from_name = Option::mailFromName();
         
-            if (! ends_with($me->email, 'klink.local')) {
+            if (! Str::endsWith($me->email, 'klink.local')) {
                 $from_name = $me->name;
             }
         

--- a/app/Http/Controllers/OembedController.php
+++ b/app/Http/Controllers/OembedController.php
@@ -4,6 +4,7 @@ namespace KBox\Http\Controllers;
 
 use KBox\DocumentDescriptor;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 
 class OembedController extends Controller
 {
@@ -28,8 +29,8 @@ class OembedController extends Controller
 
         // if the url don't start with this application URL, or
         // contains query parameters => abort
-        abort_unless(starts_with($url, $base_url), 404);
-        abort_if(str_contains($url, '?') || str_contains($url, '#'), 404);
+        abort_unless(Str::startsWith($url, $base_url), 404);
+        abort_if(Str::contains($url, '?') || Str::contains($url, '#'), 404);
         
         $id = e(str_replace($base_url, '', $url));
 

--- a/app/Http/Controllers/SharingController.php
+++ b/app/Http/Controllers/SharingController.php
@@ -14,6 +14,7 @@ use KBox\Http\Requests\CreateShareRequest;
 use KBox\Http\Requests\ShareDialogRequest;
 use Illuminate\Contracts\Auth\Guard as AuthGuard;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use KBox\Traits\Searchable;
@@ -221,7 +222,7 @@ class SharingController extends Controller
             if (! is_null($item) && ! $item instanceof Group) {
                 $real_preview_link = \DmsRouting::preview($item);
 
-                if (! $item->isRemoteWebPage() && starts_with($item->document_uri, 'http://msri-hub.ucentralasia.org/') || starts_with($item->document_uri, 'http://staging-uca.cloudapp.net/')) {
+                if (! $item->isRemoteWebPage() && Str::startsWith($item->document_uri, 'http://msri-hub.ucentralasia.org/') || Str::startsWith($item->document_uri, 'http://staging-uca.cloudapp.net/')) {
                     $real_preview_link = $item->document_uri;
                 } elseif ($item->isRemoteWebPage() && ! is_null($item->file)) {
                     $real_preview_link = $item->file->original_uri;

--- a/app/Http/Controllers/VideoPlaybackController.php
+++ b/app/Http/Controllers/VideoPlaybackController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use KBox\Exceptions\ForbiddenException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Str;
 
 /**
  * Handle the video streaming.
@@ -69,7 +70,7 @@ class VideoPlaybackController extends Controller
         }
 
         $resource_path = $resources->get('streams')->first(function ($value, $key) use ($resource) {
-            return ends_with($value, $resource);
+            return Str::endsWith($value, $resource);
         });
 
         if (is_null($resource_path)) {

--- a/app/Http/Middleware/Locale.php
+++ b/app/Http/Middleware/Locale.php
@@ -5,6 +5,7 @@ namespace KBox\Http\Middleware;
 use App;
 use Config;
 use Session;
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Lang;
 use Jenssegers\Date\Date as LocalizedDate;
@@ -74,8 +75,8 @@ final class Locale
             }
             $factor = '1.0';
 
-            if (str_contains($item, ';q=')) {
-                $factor = str_after($item, ';q=');
+            if (Str::contains($item, ';q=')) {
+                $factor = Str::after($item, ';q=');
             }
 
             return compact('lang', 'factor');

--- a/app/Mail/UserDirectMessage.php
+++ b/app/Mail/UserDirectMessage.php
@@ -4,6 +4,7 @@ namespace KBox\Mail;
 
 use KBox\User;
 use KBox\Option;
+use Illuminate\Support\Str;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
@@ -52,7 +53,7 @@ class UserDirectMessage extends Mailable
         $from_mail = Option::mailFrom();
         $from_name = Option::mailFromName();
       
-        if (! ends_with($this->sender->email, 'klink.local')) {
+        if (! Str::endsWith($this->sender->email, 'klink.local')) {
             $from_name = $this->sender->name."($from_name)";
         }
 

--- a/app/Pages/Finder.php
+++ b/app/Pages/Finder.php
@@ -2,6 +2,7 @@
 
 namespace KBox\Pages;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
 
@@ -60,7 +61,7 @@ class Finder
     {
         if (! $this->pages) {
             $this->pages = collect(Storage::disk($this->disk)->files($this->basePath))->map(function ($file) {
-                if (ends_with($file, 'md')) {
+                if (Str::endsWith($file, 'md')) {
                     return $this->model->newInstanceFromFile($file);
                 }
             })->filter();

--- a/app/Pages/PageModel.php
+++ b/app/Pages/PageModel.php
@@ -3,6 +3,7 @@
 namespace KBox\Pages;
 
 use Markdown;
+use Illuminate\Support\Str;
 use KBox\Events\PageChanged;
 use Symfony\Component\Yaml\Yaml;
 use Illuminate\Support\Collection;
@@ -235,7 +236,7 @@ abstract class PageModel
 
     public function getIdAttribute($value)
     {
-        return $value ?? ($this->title ? str_slug($this->title) : null);
+        return $value ?? ($this->title ? Str::slug($this->title) : null);
     }
     
     public function getLanguageAttribute($value)

--- a/app/Plugins/PluginManifest.php
+++ b/app/Plugins/PluginManifest.php
@@ -2,6 +2,7 @@
 
 namespace KBox\Plugins;
 
+use Illuminate\Support\Str;
 use Illuminate\Foundation\PackageManifest;
 
 /**
@@ -65,7 +66,7 @@ class PluginManifest extends PackageManifest
      */
     protected function format($package)
     {
-        return str_slug(str_replace('/', '-', $package));
+        return Str::slug(str_replace('/', '-', $package));
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ namespace KBox\Providers;
 
 use Carbon\Carbon;
 use Validator;
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
@@ -40,7 +41,7 @@ class AppServiceProvider extends ServiceProvider
             // the real host and IP addresses are not available
             return $this->isMethod('get')
                    && network_enabled()
-                   && str_contains(strtolower($this->userAgent()), 'guzzlehttp');
+                   && Str::contains(strtolower($this->userAgent()), 'guzzlehttp');
         });
 
         /**

--- a/app/RoutingHelpers.php
+++ b/app/RoutingHelpers.php
@@ -2,6 +2,8 @@
 
 namespace KBox;
 
+use Illuminate\Support\Str;
+
 final class RoutingHelpers
 {
     private static $group_route_cache = null;
@@ -135,6 +137,6 @@ final class RoutingHelpers
 
         $url_to_return = implode('&', $url_components);
 
-        return (! starts_with($url_to_return, '?') ? '?' : '').$url_to_return;
+        return (! Str::startsWith($url_to_return, '?') ? '?' : '').$url_to_return;
     }
 }

--- a/config/dms.php
+++ b/config/dms.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Str;
+
 return [
 
     /*
@@ -114,7 +116,7 @@ return [
     | @var boolean
     */
 
-    'use_https' => starts_with(env('APP_URL'), 'https') ? true : false,
+    'use_https' => Str::startsWith(env('APP_URL'), 'https') ? true : false,
     
     /*
     |--------------------------------------------------------------------------

--- a/packages/contentprocessing/src/DocumentType.php
+++ b/packages/contentprocessing/src/DocumentType.php
@@ -3,6 +3,7 @@
 namespace KBox\Documents;
 
 use KBox\Traits\HasEnums;
+use Illuminate\Support\Str;
 
 /**
  * The document types.
@@ -235,8 +236,8 @@ final class DocumentType
      */
     public static function from($mimeType)
     {
-        if (str_contains($mimeType, ';')) {
-            $mimeType = str_before($mimeType, ';');
+        if (Str::contains($mimeType, ';')) {
+            $mimeType = Str::before($mimeType, ';');
         }
 
         if (array_key_exists($mimeType, self::$mimeTypesToDocType)) {

--- a/packages/contentprocessing/src/FileHelper.php
+++ b/packages/contentprocessing/src/FileHelper.php
@@ -4,6 +4,7 @@ namespace KBox\Documents;
 
 use Exception;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 
 /**
@@ -256,7 +257,7 @@ final class FileHelper
      */
     public static function getExtensionFromType($mimeType, $documentType = null)
     {
-        $mimeType = self::normalizeMimeType(str_before($mimeType, ';'));
+        $mimeType = self::normalizeMimeType(Str::before($mimeType, ';'));
    
         $possible_extensions = array_filter(self::$fileExtensionToMimeType, function ($value, $key) use ($mimeType, $documentType) {
             if (is_array($value) && ! is_null($documentType) &&  array_key_exists($documentType, $value)) {
@@ -285,7 +286,7 @@ final class FileHelper
                 }
             }
             
-            return str_before($possible_extension, '|');
+            return Str::before($possible_extension, '|');
         }
 
         throw new InvalidArgumentException("Unknown mime type.");

--- a/packages/contentprocessing/src/Pdf/PdfCli.php
+++ b/packages/contentprocessing/src/Pdf/PdfCli.php
@@ -3,6 +3,7 @@
 namespace KBox\Documents\Pdf;
 
 use RuntimeException;
+use Illuminate\Support\Str;
 use Symfony\Component\Process\Process;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\Process\Exception\ProcessFailedException;
@@ -114,7 +115,7 @@ class PdfCli
 
             return true;
         } catch (RuntimeException $ex) {
-            if (starts_with($ex->getMessage(), "No PDF CLI executable found")) {
+            if (Str::startsWith($ex->getMessage(), "No PDF CLI executable found")) {
                 return false;
             }
 

--- a/packages/contentprocessing/src/Thumbnail/VideoThumbnailGenerator.php
+++ b/packages/contentprocessing/src/Thumbnail/VideoThumbnailGenerator.php
@@ -3,6 +3,7 @@
 namespace KBox\Documents\Thumbnail;
 
 use KBox\File;
+use Illuminate\Support\Str;
 use KBox\Documents\DocumentType;
 use KBox\Documents\Contracts\ThumbnailGenerator;
 use OneOffTech\VideoProcessing\VideoProcessorFactory;
@@ -20,7 +21,7 @@ class VideoThumbnailGenerator implements ThumbnailGenerator
                 
         $out = $videoProcessor->thumbnail($file->absolute_path);
                 
-        $thumb_path = str_finish(dirname($file->absolute_path), '/').str_replace_last('.mp4', '.png', basename($file->absolute_path));
+        $thumb_path = str_finish(dirname($file->absolute_path), '/').Str::replaceLast('.mp4', '.png', basename($file->absolute_path));
 
         return ThumbnailImage::load($thumb_path)->widen(ThumbnailImage::DEFAULT_WIDTH);
     }

--- a/packages/language-guesser/src/Drivers/LanguageCli.php
+++ b/packages/language-guesser/src/Drivers/LanguageCli.php
@@ -3,6 +3,7 @@
 namespace OneOffTech\LanguageGuesser\Drivers;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use RuntimeException;
 use OneOffTech\LanguageGuesser\Exceptions\LanguageGuessFailedException;
 use Symfony\Component\Process\Process;
@@ -153,7 +154,7 @@ class LanguageCli
 
             return true;
         } catch (RuntimeException $ex) {
-            if (starts_with($ex->getMessage(), "No Language CLI executable found")) {
+            if (Str::startsWith($ex->getMessage(), "No Language CLI executable found")) {
                 return false;
             }
 

--- a/packages/video-processing/src/Drivers/VideoCli.php
+++ b/packages/video-processing/src/Drivers/VideoCli.php
@@ -5,6 +5,7 @@ namespace OneOffTech\VideoProcessing\Drivers;
 use RuntimeException;
 use OneOffTech\VideoProcessing\Exceptions\VideoProcessingFailedException;
 use Symfony\Component\Process\Process;
+use Illuminate\Support\Str;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 
 class VideoCli
@@ -130,7 +131,7 @@ class VideoCli
 
             return true;
         } catch (RuntimeException $ex) {
-            if (starts_with($ex->getMessage(), "No Video CLI executable found")) {
+            if (Str::startsWith($ex->getMessage(), "No Video CLI executable found")) {
                 return false;
             }
 

--- a/plugins/geo/src/Gdal/Gdal.php
+++ b/plugins/geo/src/Gdal/Gdal.php
@@ -4,6 +4,7 @@ namespace KBox\Geo\Gdal;
 
 use ZipArchive;
 use SplFileInfo;
+use Illuminate\Support\Str;
 use KBox\Geo\GeoProperties;
 use KBox\Geo\Gdal\Drivers\WindowsDriver;
 use KBox\Geo\Gdal\Drivers\LinuxDriver;
@@ -98,7 +99,7 @@ final class Gdal
         
         // Gdal requires a folder to convert a file into a shapefile, as at least 3 files will be produced
         // then we zip everything and return the ZIP as temporary file
-        $tmpFolder = str_replace_last('.', '', $tmpfilename);
+        $tmpFolder = Str::replaceLast('.', '', $tmpfilename);
         @mkdir($tmpFolder);
 
         $folderInfo = $this->driver()->convert($path, $tmpFolder, $format, $crs);

--- a/plugins/geo/src/GeoProperties.php
+++ b/plugins/geo/src/GeoProperties.php
@@ -2,6 +2,7 @@
 
 namespace KBox\Geo;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\Arr;
 use KBox\File;
 use proj4php\Wkt;
@@ -106,9 +107,9 @@ final class GeoProperties extends FileProperties
         $key = null;
 
         foreach ($lines as $line) {
-            if(str_contains($line, ':')){
-                $key = str_slug(str_before($line, ':'));
-                $value = str_after($line, ':');
+            if(Str::contains($line, ':')){
+                $key = Str::slug(Str::before($line, ':'));
+                $value = Str::after($line, ':');
                 $parsed[$key] = trim($value);
             }
             else if($key != null && isset($parsed[$key])) {

--- a/plugins/geo/src/Http/Controllers/GeoPluginMapProvidersController.php
+++ b/plugins/geo/src/Http/Controllers/GeoPluginMapProvidersController.php
@@ -6,6 +6,7 @@ use Exception;
 use KBox\Geo\GeoService;
 use Illuminate\Http\Request;
 use KBox\Plugins\PluginManager;
+use Illuminate\Support\Str;
 use KBox\Http\Controllers\Controller;
 use KBox\Geo\Http\Requests\NewMapProviderRequest;
 use KBox\Geo\Http\Requests\UpdateMapProviderRequest;
@@ -101,7 +102,7 @@ class GeoPluginMapProvidersController extends Controller
         $providersSetting = $mapSettings['providers'];
 
         // inject the new provider into the array
-        $providersSetting[str_slug($parameters['label'])] = $parameters;
+        $providersSetting[Str::slug($parameters['label'])] = $parameters;
         $mapSettings['providers'] = $providersSetting;
 
         $this->service->config(['map' => $mapSettings]); // save the new configuration

--- a/plugins/geo/src/Http/Controllers/WebMapServiceController.php
+++ b/plugins/geo/src/Http/Controllers/WebMapServiceController.php
@@ -6,6 +6,7 @@ use Log;
 use KBox\User;
 use KBox\File;
 use KBox\Geo\GeoService;
+use Illuminate\Support\Str;
 use KBox\DocumentDescriptor;
 use Illuminate\Http\Request;
 use Illuminate\Contracts\Auth\Guard;
@@ -101,7 +102,7 @@ class WebMapServiceController extends Controller
         $layers = $request->input('layers', '');
         $fingerprint = $this->fingerprint($request);
 
-        $uuid = trim(str_after($layers, ':'));
+        $uuid = trim(Str::after($layers, ':'));
 
         if(!$uuid){
             return $this->createEmptyResponse($request);

--- a/resources/views/avatar/avatar.blade.php
+++ b/resources/views/avatar/avatar.blade.php
@@ -7,7 +7,7 @@
 		@if(isset($image) && is_string($image))
 			<img class="block h-10 w-auto" src="{{$image}}">
 		@elseif(isset($name) && is_string($name))
-			<span class="text-gray-200 pb-1 text-2xl leading-none">{{ mb_substr(studly_case($name), 0, 1) }}</span>
+			<span class="text-gray-200 pb-1 text-2xl leading-none">{{ mb_substr(\Illuminate\Support\Str::studly($name), 0, 1) }}</span>
 		@else
 			@materialicon('social', 'person', 'inline-block fill-current text-gray-200')
 		@endif

--- a/resources/views/panels/document.blade.php
+++ b/resources/views/panels/document.blade.php
@@ -51,7 +51,7 @@
 	
 	@if(!$item->trashed())
 
-		@if(!$item->isRemoteWebPage() && !starts_with($item->document_uri, 'http://msri-hub.ucentralasia.org/') && !starts_with($item->document_uri, 'http://staging-uca.cloudapp.net/'))
+		@if(!$item->isRemoteWebPage() && !\Illuminate\Support\Str::startsWith($item->document_uri, 'http://msri-hub.ucentralasia.org/') && !Str::startsWith($item->document_uri, 'http://staging-uca.cloudapp.net/'))
 	
 			@if(!is_null($item->file) )
 	           <?php $real_preview_link = DmsRouting::preview($item); ?>
@@ -68,7 +68,7 @@
 					({{KBox\Documents\Services\DocumentsService::extension_from_file($item->file)}}, {{KBox\Documents\Services\DocumentsService::human_filesize($item->file->size)}})
 				@endif
 			</a>
-		@elseif(starts_with($item->document_uri, 'http://msri-hub.ucentralasia.org/') || starts_with($item->document_uri, 'http://staging-uca.cloudapp.net/'))
+		@elseif(Str::startsWith($item->document_uri, 'http://msri-hub.ucentralasia.org/') || Str::startsWith($item->document_uri, 'http://staging-uca.cloudapp.net/'))
 		      <?php $real_preview_link = $item->document_uri; ?>
 			<a href="{{$item->document_uri}}" class="button"  target="_blank">{!!trans('panels.open_site_btn')!!} </a>
 		

--- a/resources/views/plugins/index.blade.php
+++ b/resources/views/plugins/index.blade.php
@@ -40,14 +40,14 @@
                                     <a class="button" href="{{ route("plugins.$plugin->name.settings") }}">{{trans('plugins.actions.settings')}}</a>
                                 @endif
 
-                                <button class="button button--danger" onclick="event.preventDefault();document.getElementById('plugin-disable-form-{{str_slug($plugin->name)}}').submit();">{{trans('plugins.actions.disable')}}</button>
-                                <form id="plugin-disable-form-{{str_slug($plugin->name)}}" action="{{ route('administration.plugins.destroy', $plugin->name) }}" method="POST" style="display: none;">
+                                <button class="button button--danger" onclick="event.preventDefault();document.getElementById('plugin-disable-form-{{\Illuminate\Support\Str::slug($plugin->name)}}').submit();">{{trans('plugins.actions.disable')}}</button>
+                                <form id="plugin-disable-form-{{\Illuminate\Support\Str::slug($plugin->name)}}" action="{{ route('administration.plugins.destroy', $plugin->name) }}" method="POST" style="display: none;">
                                     {{ csrf_field() }}
                                     {{ method_field('DELETE') }}
                                 </form>
                             @else
-                                <button class="button" onclick="event.preventDefault();document.getElementById('plugin-enable-form-{{str_slug($plugin->name)}}').submit();">{{trans('plugins.actions.enable')}}</button>
-                                <form id="plugin-enable-form-{{str_slug($plugin->name)}}" action="{{ route('administration.plugins.update', $plugin->name) }}" method="POST" style="display: none;">
+                                <button class="button" onclick="event.preventDefault();document.getElementById('plugin-enable-form-{{\Illuminate\Support\Str::slug($plugin->name)}}').submit();">{{trans('plugins.actions.enable')}}</button>
+                                <form id="plugin-enable-form-{{\Illuminate\Support\Str::slug($plugin->name)}}" action="{{ route('administration.plugins.update', $plugin->name) }}" method="POST" style="display: none;">
                                     {{ csrf_field() }}
                                     {{ method_field('PUT') }}
                                 </form>

--- a/tests/Feature/Plugins/PluginDiscoverCommandTest.php
+++ b/tests/Feature/Plugins/PluginDiscoverCommandTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Plugins;
 
 use Tests\TestCase;
+use Illuminate\Support\Str;
 use KBox\Plugins\PluginManifest;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Storage;
@@ -38,6 +39,6 @@ class PluginDiscoverCommandTest extends TestCase
         $command->run(new ArrayInput([]), $output);
 
         Storage::disk('app')->assertExists($pluginManifest);
-        $this->assertTrue(str_contains($output->fetch(), "Discovered Plugin: k-box-unittest-demo-plugin"));
+        $this->assertTrue(Str::contains($output->fetch(), "Discovered Plugin: k-box-unittest-demo-plugin"));
     }
 }

--- a/tests/Feature/ProjectAvatarsTest.php
+++ b/tests/Feature/ProjectAvatarsTest.php
@@ -6,6 +6,7 @@ use KBox\User;
 use KBox\Project;
 use Tests\TestCase;
 use KBox\Capability;
+use Illuminate\Support\Str;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
@@ -101,17 +102,17 @@ class ProjectAvatarsTest extends TestCase
             'avatar' => base_path('tests/data/project-avatar.png')
         ]);
 
-        $method = ends_with($route, 'index') ? 'get' : (ends_with($route, 'store') ? 'post' : 'delete');
+        $method = Str::endsWith($route, 'index') ? 'get' : (Str::endsWith($route, 'store') ? 'post' : 'delete');
 
         $params = ['id' => $project->id ];
 
-        if (! ends_with($route, 'index')) {
+        if (! Str::endsWith($route, 'index')) {
             $params['_token'] = csrf_token();
         }
 
         $content = [];
 
-        if (ends_with($route, 'store')) {
+        if (Str::endsWith($route, 'store')) {
             $content = ['avatar' => $this->getFileForUpload()];
         }
 

--- a/tests/Unit/Commands/FlagsCommandTest.php
+++ b/tests/Unit/Commands/FlagsCommandTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Commands;
 use Artisan;
 use KBox\Flags;
 use Tests\TestCase;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
@@ -90,7 +91,7 @@ class FlagsCommandTest extends TestCase
 
         $this->assertTrue(Flags::isEnabled($flag));
         $this->assertFalse(Flags::isDisabled($flag));
-        $this->assertTrue(str_contains($output, 'Flag plugins enabled'));
+        $this->assertTrue(Str::contains($output, 'Flag plugins enabled'));
     }
     
     public function test_flag_can_be_disabled()
@@ -106,6 +107,6 @@ class FlagsCommandTest extends TestCase
 
         $this->assertFalse(Flags::isEnabled($flag));
         $this->assertTrue(Flags::isDisabled($flag));
-        $this->assertTrue(str_contains($output, 'Flag plugins disabled'));
+        $this->assertTrue(Str::contains($output, 'Flag plugins disabled'));
     }
 }

--- a/tests/Unit/Commands/PrivacyLoadCommandTest.php
+++ b/tests/Unit/Commands/PrivacyLoadCommandTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Commands;
 use Artisan;
 use Tests\TestCase;
 use KBox\Pages\Page;
+use Illuminate\Support\Str;
 use KBox\Events\PageChanged;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
@@ -23,7 +24,7 @@ class PrivacyLoadCommandTest extends TestCase
         $output = Artisan::output();
 
         $this->assertEquals(0, $exitCode);
-        $this->assertTrue(str_contains($output, "Privacy policy loaded"));
+        $this->assertTrue(Str::contains($output, "Privacy policy loaded"));
         
         Storage::disk('app')->assertExists('pages/privacy-legal.en.md');
         Storage::disk('app')->assertExists('pages/privacy-summary.en.md');
@@ -53,7 +54,7 @@ class PrivacyLoadCommandTest extends TestCase
         $output = Artisan::output();
 
         $this->assertEquals(0, $exitCode);
-        $this->assertTrue(str_contains($output, "Privacy policy already existing, nothing to do"));
+        $this->assertTrue(Str::contains($output, "Privacy policy already existing, nothing to do"));
         
         Storage::disk('app')->assertExists('pages/privacy-legal.en.md');
         Storage::disk('app')->assertExists('pages/privacy-summary.en.md');

--- a/tests/Unit/Commands/StatisticsCommandTest.php
+++ b/tests/Unit/Commands/StatisticsCommandTest.php
@@ -10,6 +10,7 @@ use KBox\Project;
 use KBox\Shared;
 use Carbon\Carbon;
 use Tests\TestCase;
+use Illuminate\Support\Str;
 use KBox\DocumentDescriptor;
 use Tests\Concerns\ClearDatabase;
 use KBox\Console\Commands\StatisticsCommand;
@@ -32,9 +33,9 @@ class StatisticsCommandTest extends TestCase
         $output = Artisan::output();
 
         $this->assertEquals(0, $exitCode);
-        $this->assertTrue(str_contains($output, "Documents (not considering versions) | ".(6 + $previous_documents)));
-        $this->assertTrue(str_contains($output, "Uploads                              | ".(6 + $previous_files)));
-        $this->assertTrue(str_contains($output, "Registered users                     | ".(6 + $previous_users)));
+        $this->assertTrue(Str::contains($output, "Documents (not considering versions) | ".(6 + $previous_documents)));
+        $this->assertTrue(Str::contains($output, "Uploads                              | ".(6 + $previous_files)));
+        $this->assertTrue(Str::contains($output, "Registered users                     | ".(6 + $previous_users)));
     }
     
     public function test_report_is_printed()
@@ -50,9 +51,9 @@ class StatisticsCommandTest extends TestCase
         $output = Artisan::output();
         
         $this->assertEquals(0, $exitCode);
-        $this->assertTrue(str_contains($output, "Documents (not considering versions) | ".(6 + $previous_documents)));
-        $this->assertTrue(str_contains($output, "Uploads                              | ".(6 + $previous_files)));
-        $this->assertTrue(str_contains($output, "Registered users                     | ".(6 + $previous_users)));
+        $this->assertTrue(Str::contains($output, "Documents (not considering versions) | ".(6 + $previous_documents)));
+        $this->assertTrue(Str::contains($output, "Uploads                              | ".(6 + $previous_files)));
+        $this->assertTrue(Str::contains($output, "Registered users                     | ".(6 + $previous_users)));
     }
 
     public function test_influx_report_is_printed()

--- a/tests/Unit/Commands/TermsLoadCommandTest.php
+++ b/tests/Unit/Commands/TermsLoadCommandTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Commands;
 use Artisan;
 use Tests\TestCase;
 use KBox\Pages\Page;
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
 
@@ -21,7 +22,7 @@ class TermsLoadCommandTest extends TestCase
         $output = Artisan::output();
 
         $this->assertEquals(0, $exitCode);
-        $this->assertTrue(str_contains($output, "Terms page loaded"));
+        $this->assertTrue(Str::contains($output, "Terms page loaded"));
         
         Storage::disk('app')->assertExists('pages/terms.en.md');
 
@@ -43,7 +44,7 @@ class TermsLoadCommandTest extends TestCase
         $output = Artisan::output();
 
         $this->assertEquals(0, $exitCode);
-        $this->assertTrue(str_contains($output, "Terms already existing, nothing to do"));
+        $this->assertTrue(Str::contains($output, "Terms already existing, nothing to do"));
         
         Storage::disk('app')->assertExists('pages/terms.en.md');
 

--- a/tests/Unit/FlagsHelpersTest.php
+++ b/tests/Unit/FlagsHelpersTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit;
 
 use KBox\Flags;
 use Tests\TestCase;
+use Illuminate\Support\Str;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class FlagsHelpersTest extends TestCase
@@ -36,7 +37,7 @@ class FlagsHelpersTest extends TestCase
      */
     public function test_automated_is_flag_enabled_method_can_be_invoked($flag_constant_name)
     {
-        $function_name = 'is'.studly_case($flag_constant_name).'Enabled';
+        $function_name = 'is'.Str::studly($flag_constant_name).'Enabled';
 
         $ret = flags()->{$function_name}();
 

--- a/tests/Unit/TusUploadCancelledListenerTest.php
+++ b/tests/Unit/TusUploadCancelledListenerTest.php
@@ -7,6 +7,7 @@ use KBox\File;
 use Carbon\Carbon;
 use Tests\TestCase;
 use KBox\Capability;
+use Illuminate\Support\Str;
 use KBox\DocumentDescriptor;
 use OneOffTech\TusUpload\TusUpload;
 use KBox\Listeners\TusUploadCancelledHandler;
@@ -28,7 +29,7 @@ class TusUploadCancelledListenerTest extends TestCase
 
     private function createEvent($user, $requestId = '14b1c4c77771671a8479bc0444bbc5ce')
     {
-        $path = storage_path(str_slug($requestId).'.bin');
+        $path = storage_path(Str::slug($requestId).'.bin');
 
         file_put_contents($path, 'Test File Content');
 
@@ -36,7 +37,7 @@ class TusUploadCancelledListenerTest extends TestCase
 
         $upload = TusUpload::forceCreate([
             'request_id' => $requestId,
-            'tus_id' => str_slug($requestId),
+            'tus_id' => Str::slug($requestId),
             'user_id' => $user->id,
             'filename' => basename($path).'.txt',
             'size' => $size,

--- a/tests/Unit/TusUploadCompletedListenerTest.php
+++ b/tests/Unit/TusUploadCompletedListenerTest.php
@@ -7,6 +7,7 @@ use KBox\File;
 use Carbon\Carbon;
 use Tests\TestCase;
 use KBox\Capability;
+use Illuminate\Support\Str;
 use KBox\DocumentDescriptor;
 use KBox\Events\UploadCompleted;
 use OneOffTech\TusUpload\TusUpload;
@@ -30,7 +31,7 @@ class TusUploadCompletedListenerTest extends TestCase
 
     private function createEvent($user, $requestId = '14b1c4c77771671a8479bc0444bbc5ce')
     {
-        $path = storage_path(str_slug($requestId).'.bin');
+        $path = storage_path(Str::slug($requestId).'.bin');
 
         file_put_contents($path, 'Test File Content');
 
@@ -38,7 +39,7 @@ class TusUploadCompletedListenerTest extends TestCase
 
         $upload = TusUpload::forceCreate([
             'request_id' => $requestId,
-            'tus_id' => str_slug($requestId),
+            'tus_id' => Str::slug($requestId),
             'user_id' => $user->id,
             'filename' => basename($path).'.txt',
             'size' => $size,

--- a/workbench/klink/dms-adapter/src/Klink/DmsAdapter/KlinkDocumentUtils.php
+++ b/workbench/klink/dms-adapter/src/Klink/DmsAdapter/KlinkDocumentUtils.php
@@ -2,6 +2,7 @@
 
 namespace Klink\DmsAdapter;
 
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 
 /**
@@ -267,7 +268,7 @@ class KlinkDocumentUtils
 	 */
 	public static function documentTypeFromMimeType( $mimeType ){
 
-		if(str_contains($mimeType, ';')){
+		if(Str::contains($mimeType, ';')){
 			$mimeType = substr($mimeType, 0, strpos($mimeType, ';'));
 		}
 

--- a/workbench/klink/dms-project-microsites/templates/form.blade.php
+++ b/workbench/klink/dms-project-microsites/templates/form.blade.php
@@ -16,7 +16,7 @@
     @if( $errors->has('slug') )
         <span class="field-error">{{ implode(",", $errors->get('slug'))  }}</span>
     @endif
-    <input class="form-input block" type="text" name="slug" value="{{ old('slug', isset($microsite) ? $microsite->slug : str_slug($project->name) ) }}" required />
+    <input class="form-input block" type="text" name="slug" value="{{ old('slug', isset($microsite) ? $microsite->slug : \Illuminate\Support\Str::slug($project->name) ) }}" required />
     <span class="description">{{ trans('microsites.hints.slug') }}</span>
 </div>
 

--- a/workbench/klink/dms-project-microsites/templates/partials/content_form.blade.php
+++ b/workbench/klink/dms-project-microsites/templates/partials/content_form.blade.php
@@ -8,7 +8,7 @@
         <input type="hidden" name="content[en][id]" value="{{ $en_entity->id }}">
         @endif
         <input type="hidden" name="content[en][title]" value="{{ old('content.en.title.', isset($en_entity) ? $en_entity->title : $project->name) }}" required />
-        <input type="hidden" name="content[en][slug]" readonly value="{{ old('content.en.slug', isset($en_entity) ? $en_entity->slug : str_slug($project->name)) }}" required />
+        <input type="hidden" name="content[en][slug]" readonly value="{{ old('content.en.slug', isset($en_entity) ? $en_entity->slug : \Illuminate\Support\Str::slug($project->name)) }}" required />
         
         <div class=" mb-4">
             
@@ -26,7 +26,7 @@
         <input type="hidden" name="content[ru][id]" value="{{ $ru_entity->id }}">
         @endif
         <input type="hidden" name="content[ru][title]" value="{{ old('content.ru.title', isset($ru_entity) ? $ru_entity->title : $project->name) }}" required />
-        <input type="hidden" name="content[ru][slug]" readonly value="{{ old('content.ru.slug', isset($ru_entity) ? $ru_entity->slug : str_slug($project->name)) }}" required />
+        <input type="hidden" name="content[ru][slug]" readonly value="{{ old('content.ru.slug', isset($ru_entity) ? $ru_entity->slug : \Illuminate\Support\Str::slug($project->name)) }}" required />
         
         <div class=" mb-4">
             


### PR DESCRIPTION
## What does this PR do?

Remove the usage of the deprecated [string helpers](https://laravel.com/docs/5.8/upgrade#string-and-array-helpers) in preparation of Laravel upgrade.


### Review checklist

* [x] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [x] Is history cleaned up? (or can be squashed on merge?)