### PR TITLE
Remove deprecated league/commonmark-ext-external-link

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,6 @@
 		"k-box/kbox-plugin-geo": "*",
 		"laravel/framework": "5.8.*",
 		"laravel/tinker": "^1.0",
-		"league/commonmark-ext-external-link": "^1.0",
 		"league/csv": "^9.0",
 		"oneofftech/geoserver-client-php": "0.2.*",
 		"oneofftech/k-link-streaming-upload-client": "^0.3.0@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b4e86d9969df487c6f36e4ca06fc36a0",
+    "content-hash": "742ef581a2337292e628c99dc990fc37",
     "packages": [
         {
             "name": "anahkiasen/underscore-php",
@@ -2453,16 +2453,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "fc33ca12575e98e57cdce7d5f38b2ca5335714b3"
+                "reference": "6d74caf6abeed5fd85d6ec20da23d7269cd0b46f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/fc33ca12575e98e57cdce7d5f38b2ca5335714b3",
-                "reference": "fc33ca12575e98e57cdce7d5f38b2ca5335714b3",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/6d74caf6abeed5fd85d6ec20da23d7269cd0b46f",
+                "reference": "6d74caf6abeed5fd85d6ec20da23d7269cd0b46f",
                 "shasum": ""
             },
             "require": {
@@ -2544,72 +2544,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-21T20:50:13+00:00"
-        },
-        {
-            "name": "league/commonmark-ext-external-link",
-            "version": "v1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/thephpleague/commonmark-ext-external-link.git",
-                "reference": "9bfb76b260c08b69a73e23a26b416fc16d23a39e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark-ext-external-link/zipball/9bfb76b260c08b69a73e23a26b416fc16d23a39e",
-                "reference": "9bfb76b260c08b69a73e23a26b416fc16d23a39e",
-                "shasum": ""
-            },
-            "require": {
-                "league/commonmark": "^1.3",
-                "php": "^7.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.5"
-            },
-            "type": "commonmark-extension",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "League\\CommonMark\\Ext\\ExternalLink\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Colin O'Dell",
-                    "email": "colinodell@gmail.com",
-                    "homepage": "https://www.colinodell.com",
-                    "role": "Lead Developer"
-                }
-            ],
-            "description": "Extension for league/commonmark which adds extra classes and HTML attributes to external links",
-            "homepage": "https://github.com/thephpleague/commonmark-ext-external-link",
-            "keywords": [
-                "commonmark",
-                "extension",
-                "links",
-                "markdown"
-            ],
-            "funding": [
-                {
-                    "url": "https://github.com/colinodell",
-                    "type": "github"
-                },
-                {
-                    "url": "https://www.patreon.com/colinodell",
-                    "type": "patreon"
-                }
-            ],
-            "abandoned": "league/commonmark",
-            "time": "2020-04-04T14:20:01+00:00"
+            "time": "2020-06-27T12:50:08+00:00"
         },
         {
             "name": "league/csv",

--- a/config/markdown.php
+++ b/config/markdown.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use League\CommonMark\Ext\ExternalLink\ExternalLinkExtension;
+use League\CommonMark\Extension\ExternalLink\ExternalLinkExtension;
 
 /*
  * This file is part of Laravel Markdown.


### PR DESCRIPTION
## What does this PR do?

Remove abandoned league/commonmark-ext-external-link in favor of the bundled extension already inside league/commonmark

### Related issues

Fixes ...

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)