### PR TITLE
Ensure mail settings page loads when log driver is used

### DIFF
--- a/app/Http/Controllers/Administration/MailAdministrationController.php
+++ b/app/Http/Controllers/Administration/MailAdministrationController.php
@@ -32,14 +32,10 @@ class MailAdministrationController extends Controller
     {
         $mail_config = config('mail');
 
-        $sections = Option::section('mail')->get(['key', 'value']);
-
-        $flat = $sections->toArray();
-
         return view('administration.mail', [
-        'pagetitle' => trans('administration.menu.mail'),
-        'config' => $mail_config,
-        'is_server_configurable' => $mail_config['driver'] !== 'log'
+            'pagetitle' => trans('administration.menu.mail'),
+            'config' => $mail_config,
+            'is_server_configurable' => $mail_config['default'] !== 'log'
         ]);
     }
 

--- a/resources/views/administration/mail.blade.php
+++ b/resources/views/administration/mail.blade.php
@@ -84,7 +84,7 @@
                     @if( $errors->has('host') )
                         <span class="field-error">{{ implode(",", $errors->get('host'))  }}</span>
                     @endif
-                    <input class="form-input block" type="text" name="host" @if($is_server_configurable) required @endif value="{{$config['host']}}" />
+                    <input class="form-input block" type="text" name="host" @if($is_server_configurable) required @endif value="{{$config['host'] ?? '' }}" />
                 </div>
                 
                 <div class=" mb-4  @if(!$is_server_configurable)  form-blocked @endif">
@@ -92,7 +92,7 @@
                     @if( $errors->has('port') )
                         <span class="field-error">{{ implode(",", $errors->get('port'))  }}</span>
                     @endif
-                    <input class="form-input block w-20" type="number" name="port" @if($is_server_configurable) required @endif value="{{$config['port']}}" />
+                    <input class="form-input block w-20" type="number" name="port" @if($is_server_configurable) required @endif value="{{$config['port'] ?? ''}}" />
                 </div>
                 
                 <div class=" mb-4  @if(!$is_server_configurable)  form-blocked @endif">
@@ -100,7 +100,7 @@
                     @if( $errors->has('smtp_u') )
                         <span class="field-error">{{ implode(",", $errors->get('smtp_u'))  }}</span>
                     @endif
-                    <input class="form-input block" type="text" name="smtp_u" value="{{$config['username']}}"  />
+                    <input class="form-input block" type="text" name="smtp_u" value="{{$config['username'] ?? ''}}"  />
                 </div>
 
                 <div class=" mb-4  @if(!$is_server_configurable)  form-blocked @endif">
@@ -108,7 +108,7 @@
                     @if( $errors->has('smtp_p') )
                         <span class="field-error">{{ implode(",", $errors->get('smtp_p'))  }}</span>
                     @endif
-                    <input class="form-input block" type="password" name="smtp_p" value="{{$config['password']}}"  />
+                    <input class="form-input block" type="password" name="smtp_p" value="{{$config['password'] ?? ''}}"  />
                 </div>
 
             </div>

--- a/tests/Feature/MailAdministrationControllerTest.php
+++ b/tests/Feature/MailAdministrationControllerTest.php
@@ -86,6 +86,36 @@ class MailAdministrationControllerTest extends TestCase
         $response->assertSee('465');
     }
 
+    public function testMailSettingsArePresentedWithLogDriver()
+    {
+        Option::remove('mail.host');
+        Option::remove('mail.port');
+        Option::remove('mail.from.address');
+        Option::remove('mail.from.name');
+        Option::remove('mail.username');
+        Option::remove('mail.password');
+
+        config([
+            'mail.default' => 'log',
+            'mail.from.address' => 'from@k-link.technology',
+            'mail.from.name' => 'Testing DMS',
+        ]);
+
+        $adapter = $this->withKlinkAdapterFake();
+
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$ADMIN);
+        });
+
+        $this->assertTrue(Option::isMailEnabled());
+
+        $response = $this->actingAs($user)->get(route('administration.mail.index'));
+
+        $response->assertSee(trans('administration.mail.log_driver_used'));
+        $response->assertSee('from@k-link.technology');
+        $response->assertSee('Testing DMS');
+    }
+
     public function testMailConfigurationSaved()
     {
         Option::remove('mail.host');


### PR DESCRIPTION
## What does this PR do?

Fixes an error that prevent the email configuration page to load if the log driver was set via environment variables

### Related issues

Fixes ...

### Review checklist

* [x] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)