### PR TITLE
Refactor mail settings page

### DIFF
--- a/app/Http/Controllers/Administration/MailAdministrationController.php
+++ b/app/Http/Controllers/Administration/MailAdministrationController.php
@@ -5,6 +5,7 @@ namespace KBox\Http\Controllers\Administration;
 use KBox\Http\Controllers\Controller;
 use KBox\Option;
 use Config;
+use Illuminate\Support\Arr;
 use KBox\Http\Requests\MailSettingsRequest;
 use Illuminate\Support\Facades\Mail;
 use KBox\Mail\TestingMail;
@@ -15,12 +16,20 @@ use Illuminate\Support\Facades\DB;
  */
 class MailAdministrationController extends Controller
 {
+    private $mappings = [
+        'mailers.smtp.port' => 'port',
+        'mailers.smtp.host' => 'host',
+        'mailers.smtp.username' => 'username',
+        'mailers.smtp.password' => 'password',
+        'from.address' => 'from.address',
+        'from.name' => 'from.name',
+    ];
 
-  /**
-   * Create a new controller instance.
-   *
-   * @return void
-   */
+    /**
+     * Create a new controller instance.
+     *
+     * @return void
+     */
     public function __construct()
     {
         $this->middleware('auth');
@@ -30,11 +39,17 @@ class MailAdministrationController extends Controller
 
     public function getIndex()
     {
-        $mail_config = config('mail');
+        $mail_config = Arr::dot(config('mail'));
+
+        $config = [];
+
+        foreach ($this->mappings as $configKey => $key) {
+            $config[$key] = $mail_config[$configKey];
+        }
 
         return view('administration.mail', [
             'pagetitle' => trans('administration.menu.mail'),
-            'config' => $mail_config,
+            'config' => $config,
             'is_server_configurable' => $mail_config['default'] !== 'log'
         ]);
     }

--- a/resources/views/administration/mail.blade.php
+++ b/resources/views/administration/mail.blade.php
@@ -49,7 +49,7 @@
                         <span class="field-error">{{ implode(",", $errors->get('from_address'))  }}</span>
                     @endif
                     
-                    <input class="form-input block" type="email" name="from_address" id="from_address" required value="@if(isset($config['from']['address'])){{$config['from']['address']}}@endif" placeholder="{{trans('administration.mail.from_address_placeholder')}}" />
+                    <input class="form-input block" type="email" name="from_address" id="from_address" required value="{{ $config['from.address'] ?? '' }}" placeholder="{{trans('administration.mail.from_address_placeholder')}}" />
                 
                 </div>
 
@@ -61,7 +61,7 @@
                     @if( $errors->has('from_name') )
                         <span class="field-error">{{ implode(",", $errors->get('from_name'))  }}</span>
                     @endif
-                    <input class="form-input block" type="text" name="from_name" id="from_name" value="@if(isset($config['from']['name'])){{$config['from']['name']}}@endif" placeholder="{{trans('administration.mail.from_name_placeholder')}}" />
+                    <input class="form-input block" type="text" name="from_name" id="from_name" value="{{ $config['from.name'] ?? '' }}" placeholder="{{trans('administration.mail.from_name_placeholder')}}" />
 
                 </div>
             </div>


### PR DESCRIPTION
## What does this PR do?

The Laravel email configuration changed layout, up until now it was not recognized a possible problem in showing the configuration values on the mail settings page.

This pull request tries to solve it by embracing the new configuration file change and create an intermediate data-transfer for visualization purposes.

### Related issues

Fixes ...

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)