### PR TITLE
Ensure PDF read/write policy is present

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ RUN apt-get update -yqq && \
     && pecl channel-update pecl.php.net \
     && pecl install imagick \
     && docker-php-ext-enable imagick \
+    && sed -i -e 's/rights="none" pattern="PDF"/rights="read|write" pattern="PDF"/' /etc/ImageMagick-6/policy.xml \
     && docker-php-source delete \
     && apt-get clean \
     && rm -r /var/lib/apt/lists/*


### PR DESCRIPTION
## What does this PR do?

Ensure the produced Docker image has read/write specified in the Image Magick policy file for the PDF file type.

### Related issues

Fixes #403 

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)