### PR TITLE
Add configuration options to change picture on the login/registration pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ public/build
 public/mix-manifest.json
 public/js/*
 public/css/*
+public/storage/*
 storage/documents/*
 storage/framework/testing
 tests/data/**/thumbnails

--- a/app/Appearance/HeroPicture.php
+++ b/app/Appearance/HeroPicture.php
@@ -114,11 +114,14 @@ class HeroPicture
             $response = Http::sink($temp_file)->get($this->picture);
             
             if ($response->failed()) {
+                logs()->warning("Appearance picture failed to download [{$response->status()}: $this->picture].");
                 return null;
             }
 
             copy($temp_file, $this->path());
         } catch (Throwable $th) {
+            logs()->warning("Appearance picture failed to download [{$th->getMessage()}: $this->picture].");
+            return null;
         } finally {
             @unlink($temp_file);
         }

--- a/app/Appearance/HeroPicture.php
+++ b/app/Appearance/HeroPicture.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace KBox\Appearance;
+
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use Throwable;
+
+class HeroPicture
+{
+    private const DISK = 'public';
+    private const FOLDER = 'appearance';
+
+    private $picture;
+
+    private $filename;
+
+    /**
+     * @param string $picture
+     */
+    public function __construct($picture)
+    {
+        $this->picture = $picture;
+        $this->filename = hash('sha256', $picture).'.jpg';
+    }
+
+    /**
+     * @return bool
+     */
+    public function isLocal()
+    {
+        if (Str::startsWith($this->picture, url('')) || ! Str::startsWith($this->picture, 'http')) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @return string
+     */
+    public function name()
+    {
+        return static::FOLDER."/$this->filename";
+    }
+
+    /**
+     * Get the url of the picture
+     *
+     * @return string
+     */
+    public function url()
+    {
+        if ($this->isLocal()) {
+            return url($this->picture);
+        }
+
+        return url(Storage::disk(static::DISK)->url($this->name()));
+    }
+
+    /**
+     * Get the local file for the specified picture
+     *
+     * @return string
+     */
+    public function path()
+    {
+        if ($this->isLocal()) {
+            return $this->picture;
+        }
+
+        return Storage::disk(static::DISK)->path($this->name());
+    }
+
+    /**
+     * @return bool
+     */
+    public function exists()
+    {
+        if ($this->isLocal()) {
+            return true;
+        }
+
+        return Storage::disk(static::DISK)->exists($this->name());
+    }
+
+    /**
+     * @param bool $force
+     */
+    public function fetch($force = false)
+    {
+        if (is_null($this->picture)) {
+            return;
+        }
+
+        if ($this->isLocal()) {
+            return;
+        }
+
+        if ($this->exists() && ! $force) {
+            return;
+        }
+
+        $this->ensureAppearanceFolderExists();
+
+        $temp_file = tempnam(sys_get_temp_dir(), 'app');
+
+        try {
+            $response = Http::sink($temp_file)->get($this->picture);
+            
+            if ($response->failed()) {
+                return null;
+            }
+
+            copy($temp_file, $this->path());
+        } catch (Throwable $th) {
+        } finally {
+            @unlink($temp_file);
+        }
+    }
+
+    protected function ensureAppearanceFolderExists()
+    {
+        if (Storage::disk(static::DISK)->exists(static::FOLDER)) {
+            return true;
+        }
+
+        return Storage::disk(static::DISK)->makeDirectory(static::FOLDER);
+    }
+}

--- a/app/Appearance/HeroPicture.php
+++ b/app/Appearance/HeroPicture.php
@@ -48,10 +48,14 @@ class HeroPicture
     /**
      * Get the url of the picture
      *
-     * @return string
+     * @return string|null
      */
     public function url()
     {
+        if (is_null($this->picture)) {
+            return null;
+        }
+
         if ($this->isLocal()) {
             return url($this->picture);
         }

--- a/app/Console/Commands/AppearanceDownloadPictureCommand.php
+++ b/app/Console/Commands/AppearanceDownloadPictureCommand.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace KBox\Console\Commands;
+
+use Illuminate\Console\Command;
+use KBox\Jobs\DownloadAppearancePicture;
+
+class AppearanceDownloadPictureCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'appearance:downloadpicture {--now} {--p|picture=} {--f|force}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Caches locally the picture defined in the appearance';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $force = $this->option('force');
+        $now = $this->option('now');
+        $picture = $this->option('picture') ?? config('appearance.picture');
+
+        if ($now) {
+            dispatch_now(new DownloadAppearancePicture($picture, $force));
+        } else {
+            dispatch(new DownloadAppearancePicture($picture, $force));
+        }
+        
+        $this->line("Picture download dispatched");
+
+        return 0;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -4,6 +4,7 @@ namespace KBox\Console;
 
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+use KBox\Console\Commands\AppearanceDownloadPictureCommand;
 use KBox\Console\Commands\PurgeInvitesCommand;
 use KBox\Console\Commands\QuotaCheckCommand;
 
@@ -43,6 +44,7 @@ class Kernel extends ConsoleKernel
         \KBox\Console\Commands\PurgeExpiredPersonalDataExportsCommand::class,
         \KBox\Console\Commands\QuotaCheckCommand::class,
         \KBox\Console\Commands\PurgeInvitesCommand::class,
+        AppearanceDownloadPictureCommand::class,
     ];
 
     /**

--- a/app/Jobs/DownloadAppearancePicture.php
+++ b/app/Jobs/DownloadAppearancePicture.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace KBox\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use KBox\Appearance\HeroPicture;
+
+class DownloadAppearancePicture implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public $picture;
+    
+    public $force = false;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct($picture, $force = false)
+    {
+        $this->picture = $picture;
+        $this->force = $force;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        (new HeroPicture($this->picture))->fetch($this->force);
+    }
+}

--- a/app/View/Components/HeroImage.php
+++ b/app/View/Components/HeroImage.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace KBox\View\Components;
+
+use Illuminate\View\Component;
+use KBox\Appearance\HeroPicture;
+
+/**
+ * K-Box Hero image component.
+ *
+ * Show a picture that is suitable
+ * for login and registration screens
+ */
+class HeroImage extends Component
+{
+    private $pictureInstance;
+
+    /**
+     * The picture to show
+     *
+     * @var HeroPicture
+     */
+    public $picture = null;
+    
+    /**
+     * The background solid color
+     *
+     * @var string
+     */
+    public $fillColor = null;
+
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->pictureInstance = new HeroPicture(config('appearance.picture'));
+        $this->picture = $this->pictureInstance->url();
+        $this->fillColor = config('appearance.color');
+    }
+
+    public function hasPicture()
+    {
+        return ! is_null($this->picture) && $this->pictureInstance->exists();
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\View\View|string
+     */
+    public function render()
+    {
+        return view('components.hero-image');
+    }
+}

--- a/app/View/Components/HeroImage.php
+++ b/app/View/Components/HeroImage.php
@@ -4,6 +4,7 @@ namespace KBox\View\Components;
 
 use Illuminate\View\Component;
 use KBox\Appearance\HeroPicture;
+use Illuminate\Support\Facades\Validator;
 
 /**
  * K-Box Hero image component.
@@ -38,7 +39,32 @@ class HeroImage extends Component
     {
         $this->pictureInstance = new HeroPicture(config('appearance.picture'));
         $this->picture = $this->pictureInstance->url();
-        $this->fillColor = config('appearance.color');
+        $this->fillColor = $this->ensureColorIsValid(config('appearance.color'));
+    }
+
+    /**
+     * Check if a color is an expected value
+     *
+     * @param string $color
+     * @return string
+     */
+    private function ensureColorIsValid($color)
+    {
+        if (! $color) {
+            return null;
+        }
+
+        $validator = Validator::make(['color' => $color], [
+            'color' => 'required|regex:/#([a-f0-9]{3}){1,2}\b/i',
+        ]);
+
+        if ($validator->fails()) {
+            logs()->warning("Specified appearance color [$color] is not valid.");
+
+            return null;
+        }
+        
+        return $color;
     }
 
     public function hasPicture()

--- a/config/appearance.php
+++ b/config/appearance.php
@@ -1,0 +1,26 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Picture
+    |--------------------------------------------------------------------------
+    |
+    | This is the url of the picture to show on login and registration screen.
+    | It can be absolute or relative. If is a resource outside the K-Box
+    | application domain it will be downloaded and cached locally.
+    */
+
+    'picture' => env('KBOX_APPEARANCE_PICTURE', 'https://images.unsplash.com/photo-1563654727148-d7e9d1ed2a86?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2850&q=80'),
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Color
+    |--------------------------------------------------------------------------
+    |
+    | The color to show on login and registration screen instead of the picture.
+    */
+
+    'color' => env('KBOX_APPEARANCE_COLOR', null),
+];

--- a/config/appearance.php
+++ b/config/appearance.php
@@ -10,6 +10,7 @@ return [
     | This is the url of the picture to show on login and registration screen.
     | It can be absolute or relative. If is a resource outside the K-Box
     | application domain it will be downloaded and cached locally.
+    | Image format must be JPG
     */
 
     'picture' => env('KBOX_APPEARANCE_PICTURE', 'https://images.unsplash.com/photo-1563654727148-d7e9d1ed2a86?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2850&q=80'),

--- a/docker/configure.sh
+++ b/docker/configure.sh
@@ -92,6 +92,7 @@ function startup_config () {
     fi
 
     su -s /bin/sh -c "php artisan appearance:downloadpicture" $KBOX_SETUP_USER
+    su -s /bin/sh -c "php artisan storage:link" $KBOX_SETUP_USER
 }
 
 function write_config() {

--- a/docker/configure.sh
+++ b/docker/configure.sh
@@ -90,6 +90,8 @@ function startup_config () {
         echo "K-Box is creating the privacy policy from templates..."
         su -s /bin/sh -c "php artisan privacy:load" $KBOX_SETUP_USER
     fi
+
+    su -s /bin/sh -c "php artisan appearance:downloadpicture" $KBOX_SETUP_USER
 }
 
 function write_config() {

--- a/docs/administration/appearance.md
+++ b/docs/administration/appearance.md
@@ -1,0 +1,40 @@
+---
+Title: Appearance
+Description: personalize the look and feel of the K-Box
+---
+# Appearance
+
+You can personalize the look and feel of the K-Box based.
+
+The personalization is currently limited to:
+
+- the picture on the login and registration pages;
+- the background color, as replacement of the image, on the login and 
+  registration pages.
+
+## Configuration
+
+The configuration can be done only via static configuration (i.e. environment variables)
+and so require a K-Box restart.
+
+The two variables that control the configuration are:
+
+- `KBOX_APPEARANCE_PICTURE` the url of the image to show;
+- `KBOX_APPEARANCE_COLOR` the background color to use.
+
+The image and the background color appears only on large screens (i.e. above 
+1024px wide).
+
+The color must be specified in hex format, e.g. `#ff0000`. 
+
+The image can be a url of a JPEG picture hosted on a third party service or
+inside the K-Box (it must be public).
+At startup the picture, if hosted on third party services, will be downloaded
+and served directly by the K-Box to respect the user's privacy.
+
+For the picture to be effective the size must be at least 1920 x 1080 pixels.
+If configured the image has higher priority than the background color.
+
+## Downloading a new image
+
+Image download can be forced via the [`appearance:downloadpicture command`](../developer/commands/appearance-download-picture.md).

--- a/docs/developer/commands/appearance-download-picture.md
+++ b/docs/developer/commands/appearance-download-picture.md
@@ -1,0 +1,18 @@
+# `appearance:downloadpicture` command
+
+Download the [appearance](../../administration/appearance.md) picture, as defined in  defined in the `appearance.picture` configuration value.
+
+The file is downloaded in the public storage directory (`storage/public/appearance`).
+
+## Usage
+
+```
+$ php artisan appearacence:downloadpicture [--now] [--picture=file] [--force]
+```
+
+**options**
+
+- `--now` immediately download the specified picture
+- `--picture` the url of the picture to download, if not specified defaults to to the `appearance.picture` configuration value
+- `--force` use it to force the download of an already downloaded image
+

--- a/docs/developer/commands/index.md
+++ b/docs/developer/commands/index.md
@@ -34,6 +34,7 @@ Here are only listed the specific commands added by the K-Box:
 - [`privacy:load`](./privacy-load.md): create the privacy policy from the template
 - [`quote:check`](./quote-check.md): perform the calculation of each user storage quota and notify the user if over-quota
 - `invite:purge`: purge expired account creation invites for all users
+- [`appearance:downloadpicture`](./appearance-download-picture.md): Caches locally the picture defined in the appearance
 
 For a complete list of available commands execute
 

--- a/docs/developer/configuration.md
+++ b/docs/developer/configuration.md
@@ -51,6 +51,8 @@ The next table shows the K-Box specific configuration parameters:
 | `KBOX_SUPPORT_SERVICE`                |           | string  | null          | The support service to use. See [Configuring Support service](../administration/support.md) |
 | `KBOX_DEFAULT_USER_STORAGE_QUOTA`     |           | null|int  | null        | The available amount of storage to assign to a user in bytes. See [Storage](../administration/storage.md) |
 | `KBOX_DEFAULT_STORAGE_QUOTA_THRESHOLD_NOTIFICATION`     |           | int  | 80        | The used threshold after which the user will be notified on the amount of free storage space. See [Storage](../administration/storage.md) |
+| `KBOX_APPEARANCE_PICTURE`   |           | string  | [image from Unsplash](https://images.unsplash.com/photo-1563654727148-d7e9d1ed2a86?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2850&q=80) | The url of the image to show on login and registration pages. See [Appearance](../administration/appearance.md) |
+| `KBOX_APPEARANCE_COLOR`     |           | string  | null        | The background color of the picture area on login and registration pages. See [Appearance](../administration/appearance.md) |
 
 > `KBOX_MAIL_*` parameters can be configured from the User Interface, see [Configuring E-Mail](../administration/mail.md).
 

--- a/resources/views/components/hero-image.blade.php
+++ b/resources/views/components/hero-image.blade.php
@@ -1,4 +1,4 @@
-<div class="hidden lg:block lg:min-h-screen lg:fixed lg:inset-y-0 lg:right-0 lg:w-1/2 {{ $fillColor ?? 'bg-gray-900' }}">
+<div class="hidden lg:block lg:min-h-screen lg:fixed lg:inset-y-0 lg:right-0 lg:w-1/2 @unless($fillColor) bg-gray-900 @endunless" @if ($fillColor) style="background-color: {{ $fillColor }}" @endif>
     @if ($hasPicture())
         <img class="w-full object-cover lg:w-full h-full" src="{{ $picture }}" alt="">
     @endif

--- a/resources/views/components/hero-image.blade.php
+++ b/resources/views/components/hero-image.blade.php
@@ -1,10 +1,5 @@
-@props([
-    'hasPicture' => true,
-    'picture' => 'https://images.unsplash.com/photo-1563654727148-d7e9d1ed2a86?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2850&q=80',
-])
-
-<div class="hidden lg:block lg:min-h-screen lg:fixed bg-gray-900 lg:inset-y-0 lg:right-0 lg:w-1/2">
-    @if (!!$hasPicture)
+<div class="hidden lg:block lg:min-h-screen lg:fixed lg:inset-y-0 lg:right-0 lg:w-1/2 {{ $fillColor ?? 'bg-gray-900' }}">
+    @if ($hasPicture())
         <img class="w-full object-cover lg:w-full h-full" src="{{ $picture }}" alt="">
     @endif
 </div>

--- a/resources/views/layout/hero.blade.php
+++ b/resources/views/layout/hero.blade.php
@@ -20,7 +20,7 @@
 	    @include('footer')
     </div>
   </div>
-  <x-hero-image has-picture="1" />
+  <x-hero-image />
 </div>
 
 @endsection

--- a/tests/Feature/Appearance/AppearanceColorTest.php
+++ b/tests/Feature/Appearance/AppearanceColorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature\Appearance;
+
+use Tests\TestCase;
+
+class AppearanceColorTest extends TestCase
+{
+    public function test_default_color_used()
+    {
+        config([
+            'appearance.picture' => null,
+            'appearance.color' => null,
+        ]);
+
+        $response = $this->get(route('login'));
+
+        $response->assertSee('bg-gray-900');
+        $response->assertDontSee('object-cover');
+    }
+
+    public function test_color_is_honored()
+    {
+        config([
+            'appearance.picture' => null,
+            'appearance.color' => '#00ff00',
+        ]);
+
+        $response = $this->get(route('login'));
+
+        $response->assertSee('#00ff00');
+        $response->assertDontSee('object-cover');
+    }
+}

--- a/tests/Feature/Appearance/AppearanceColorTest.php
+++ b/tests/Feature/Appearance/AppearanceColorTest.php
@@ -16,6 +16,7 @@ class AppearanceColorTest extends TestCase
         $response = $this->get(route('login'));
 
         $response->assertSee('bg-gray-900');
+        $response->assertDontSee('background-color:');
         $response->assertDontSee('object-cover');
     }
 
@@ -28,7 +29,19 @@ class AppearanceColorTest extends TestCase
 
         $response = $this->get(route('login'));
 
-        $response->assertSee('#00ff00');
+        $response->assertSee('background-color: #00ff00');
         $response->assertDontSee('object-cover');
+    }
+
+    public function test_color_applied_only_if_valid_hex_value()
+    {
+        config([
+            'appearance.picture' => null,
+            'appearance.color' => 'blue',
+        ]);
+
+        $response = $this->get(route('login'));
+
+        $response->assertDontSee('background-color');
     }
 }

--- a/tests/Feature/Appearance/AppearancePictureTest.php
+++ b/tests/Feature/Appearance/AppearancePictureTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature\Appearance;
+
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class AppearancePictureTest extends TestCase
+{
+    public function test_external_image_url()
+    {
+        Storage::fake('public');
+
+        $pictureUrl = 'https://images.unsplash.com/photo-1563654727148-d7e9d1ed2a86?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2850&q=80';
+        $hash = hash('sha256', $pictureUrl);
+
+        Storage::disk('public')->makeDirectory('appearance');
+        Storage::disk('public')->put("appearance/$hash.jpg", file_get_contents(public_path('images/land-medium.jpg')));
+
+        config([
+            'appearance.picture' => $pictureUrl,
+            'appearance.color' => null,
+        ]);
+
+        $response = $this->get(route('login'));
+
+        $response->assertSee('bg-gray-900');
+        $response->assertSee('object-cover');
+        $pictureExpectedUrl = 'storage/appearance/'.$hash.'.jpg';
+        $response->assertSee(url($pictureExpectedUrl));
+    }
+
+    public function test_local_image_url()
+    {
+        $pictureUrl = 'http://localhost/images/land-large.jpg';
+        config([
+            'appearance.picture' => $pictureUrl,
+            'appearance.color' => null,
+        ]);
+
+        $response = $this->get(route('login'));
+
+        $response->assertSee('bg-gray-900');
+        $response->assertSee('object-cover');
+        $response->assertSee(url('images/land-large.jpg'));
+    }
+
+    public function test_relative_local_image_url()
+    {
+        $pictureUrl = 'images/land-large.jpg';
+        config([
+            'appearance.picture' => $pictureUrl,
+            'appearance.color' => null,
+        ]);
+
+        $response = $this->get(route('login'));
+
+        $response->assertSee('bg-gray-900');
+        $response->assertSee('object-cover');
+        $response->assertSee(url($pictureUrl));
+    }
+}

--- a/tests/Feature/Appearance/DownloadAppearancePictureCommandTest.php
+++ b/tests/Feature/Appearance/DownloadAppearancePictureCommandTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature\Appearance;
+
+use Illuminate\Support\Facades\Bus;
+use KBox\Jobs\DownloadAppearancePicture;
+use Queue;
+use Tests\TestCase;
+
+class DownloadAppearancePictureCommandTest extends TestCase
+{
+    public function test_command_dispatches_job()
+    {
+        Queue::fake();
+
+        $this->artisan('appearance:downloadpicture')
+            ->expectsOutput("Picture download dispatched")
+            ->assertExitCode(0);
+
+        Queue::assertPushed(DownloadAppearancePicture::class, function ($job) {
+            return $job->force === false && $job->picture == config('appearance.picture');
+        });
+    }
+
+    public function test_force_option_is_available()
+    {
+        Queue::fake();
+
+        $this->artisan('appearance:downloadpicture --force')
+            ->expectsOutput("Picture download dispatched")
+            ->assertExitCode(0);
+
+        Queue::assertPushed(DownloadAppearancePicture::class, function ($job) {
+            return $job->force === true && $job->picture == config('appearance.picture');
+        });
+    }
+
+    public function test_picture_option_is_available()
+    {
+        Queue::fake();
+        
+        $picture = 'https://images.unsplash.com/photo-1596618986211-c52f015773ae?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=80';
+
+        $this->artisan("appearance:downloadpicture --picture $picture")
+            ->expectsOutput("Picture download dispatched")
+            ->assertExitCode(0);
+
+        Queue::assertPushed(DownloadAppearancePicture::class, function ($job) use ($picture) {
+            return $job->force === false && $job->picture == $picture;
+        });
+    }
+
+    public function test_now_option_is_available()
+    {
+        Bus::fake();
+        
+        $this->artisan("appearance:downloadpicture --now")
+            ->expectsOutput("Picture download dispatched")
+            ->assertExitCode(0);
+
+        Bus::assertDispatched(DownloadAppearancePicture::class, function ($job) {
+            return $job->force === false && $job->picture == config('appearance.picture');
+        });
+    }
+}

--- a/tests/Feature/Appearance/DownloadAppearancePictureJobTest.php
+++ b/tests/Feature/Appearance/DownloadAppearancePictureJobTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Feature\Appearance;
+
+use Illuminate\Support\Facades\Storage;
+use KBox\Appearance\HeroPicture;
+use KBox\Jobs\DownloadAppearancePicture;
+use Tests\TestCase;
+
+class DownloadAppearancePictureJobTest extends TestCase
+{
+    public function test_image_can_be_fetched()
+    {
+        Storage::fake('public');
+        
+        (new DownloadAppearancePicture(config('appearance.picture')))->handle();
+
+        $name = hash('sha256', config('appearance.picture'));
+        Storage::disk('public')->assertExists("appearance/$name.jpg");
+    }
+    
+    public function test_image_fetch_honors_cache()
+    {
+        Storage::fake('public');
+        
+        $filename = (new HeroPicture(config('appearance.picture')))->name();
+        Storage::disk('public')->put($filename, 'test');
+        $sizeBefore = Storage::disk('public')->size($filename);
+        
+        (new DownloadAppearancePicture(config('appearance.picture')))->handle();
+
+        $sizeAfter = Storage::disk('public')->size($filename);
+
+        $this->assertEquals($sizeBefore, $sizeAfter);
+    }
+    
+    public function test_image_fetch_can_be_forced()
+    {
+        Storage::fake('public');
+        
+        $filename = (new HeroPicture(config('appearance.picture')))->name();
+        Storage::disk('public')->put($filename, 'test');
+        $sizeBefore = Storage::disk('public')->size($filename);
+        
+        (new DownloadAppearancePicture(config('appearance.picture'), true))->handle();
+
+        $sizeAfter = Storage::disk('public')->size($filename);
+
+        $this->assertNotEquals($sizeBefore, $sizeAfter);
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Allow to personalize the picture and background color used on the login and registration pages.

Additionally it fixes a privacy issue as the image was loaded from a third party service. Now the image is downloaded by the K-Box and served directly by it.

### Related issues

#420 

### Review checklist

* [x] Are unit tests required?
* [x] Are Documentation changes needed?

**Before merging**

* [x] Is history cleaned up? (or can be squashed on merge?)