### PR TITLE
Update video cli to version 0.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
       
     - name: Prepare environment
       run: |
+        echo "::set-env name=CI_CACHE_DOMAIN::https://cache.oneofftech.xyz/"
         cp env.ci .env
         cp env.ci .env.testing
         mkdir ./storage/documents

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,12 @@ jobs:
       with:
         path: ~/.composer/cache/files
         key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+    
+    - name: Cache binaries
+      uses: actions/cache@v1
+      with:
+        path: bin
+        key: binaries-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
       
     - name: Prepare environment
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,12 +66,11 @@ jobs:
       
     - name: Prepare environment
       run: |
-        echo "::set-env name=CI_CACHE_DOMAIN::https://cache.oneofftech.xyz/"
         cp env.ci .env
         cp env.ci .env.testing
         mkdir ./storage/documents
         composer install --prefer-dist
-        composer run install-video-cli
+        composer run install-video-cli -- https://cache.oneofftech.xyz
         chmod +x ./bin/bin/packager-linux
         composer run install-content-cli
         composer run install-language-cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 ##
 
 ## Grabbing required binaries for the video processing part
-FROM docker.klink.asia/images/video-processing-cli:0.5.3 AS videocli
+FROM oneofftech/video-processing-cli:0.6.0 AS videocli
 ## .. we just need this image so we can copy from it
 
 FROM klinktech/k-box-ci-pipeline-php:7.2 AS builder

--- a/composer.json
+++ b/composer.json
@@ -140,7 +140,7 @@
 		"preferred-install": "dist",
 		"sort-packages": true, 
 		"optimize-autoloader": true,
-		"video-cli-download-url": "https://github.com/OneOffTech/video-processing-cli/releases/download/v0.5.3/video-processing-cli",
+		"video-cli-download-url": "https://github.com/OneOffTech/video-processing-cli/releases/download/v0.6.0/video-processing-cli",
 		"language-guesser-binary": "https://github.com/avvertix/franc-bin/releases/download/v1.0.0/franc-bin"
 	},
 	"minimum-stability": "dev",

--- a/packages/video-processing/src/ComposerScripts.php
+++ b/packages/video-processing/src/ComposerScripts.php
@@ -5,7 +5,6 @@ namespace OneOffTech\VideoProcessing;
 use Composer\Factory;
 use Composer\Script\Event;
 use Composer\Downloader\TransportException;
-use Composer\Util\ProcessExecutor;
 
 class ComposerScripts
 {
@@ -91,7 +90,9 @@ class ComposerScripts
                 $io->write('Installing the video-processing-cli and its dependencies...');
                 $io->write('');
 
-                $executor = new ProcessExecutor($io);
+                $executor = new ProcessExecutor($io, [
+                    'CI_CACHE_DOMAIN' => env('CI_CACHE_DOMAIN', null)
+                ]);
                 
                 $command_filename = $os!=='windows' ? './'.basename($fileName) : basename($fileName);
                 

--- a/packages/video-processing/src/ComposerScripts.php
+++ b/packages/video-processing/src/ComposerScripts.php
@@ -91,7 +91,7 @@ class ComposerScripts
                 $io->write('');
 
                 $executor = new ProcessExecutor($io, [
-                    'CI_CACHE_DOMAIN' => env('CI_CACHE_DOMAIN', null)
+                    'CI_CACHE_DOMAIN' => getenv('CI_CACHE_DOMAIN') ?? null
                 ]);
                 
                 $command_filename = $os!=='windows' ? './'.basename($fileName) : basename($fileName);

--- a/packages/video-processing/src/ComposerScripts.php
+++ b/packages/video-processing/src/ComposerScripts.php
@@ -41,6 +41,14 @@ class ComposerScripts
     {
         try {
             $io = $event->getIO();
+
+            $args = $event->getArguments();
+
+            $ci_cache_domain = null;
+
+            if (! empty($args)) {
+                $ci_cache_domain = rtrim($args[0], '/').'/';
+            }
             
             $rfs = Factory::createRemoteFilesystem($io, $event->getComposer()->getConfig());
             
@@ -91,7 +99,7 @@ class ComposerScripts
                 $io->write('');
 
                 $executor = new ProcessExecutor($io, [
-                    'CI_CACHE_DOMAIN' => getenv('CI_CACHE_DOMAIN') ?? null
+                    'CI_CACHE_DOMAIN' => $ci_cache_domain
                 ]);
                 
                 $command_filename = $os!=='windows' ? './'.basename($fileName) : basename($fileName);

--- a/packages/video-processing/src/ProcessExecutor.php
+++ b/packages/video-processing/src/ProcessExecutor.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace OneOffTech\VideoProcessing;
+
+use Composer\Util\Platform;
+use Composer\IO\IOInterface;
+use Symfony\Component\Process\Process;
+use Composer\Util\ProcessExecutor as BaseProcessExecutor;
+
+class ProcessExecutor extends BaseProcessExecutor
+{
+    protected $env;
+
+    public function __construct(IOInterface $io = null, $env = null)
+    {
+        $this->io = $io;
+        $this->env = $env;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute($command, &$output = null, $cwd = null)
+    {
+        if ($this->io && $this->io->isDebug()) {
+            $safeCommand = preg_replace_callback('{://(?P<user>[^:/\s]+):(?P<password>[^@\s/]+)@}i', function ($m) {
+                if (preg_match('{^[a-f0-9]{12,}$}', $m['user'])) {
+                    return '://***:***@';
+                }
+
+                return '://'.$m['user'].':***@';
+            }, $command);
+            $safeCommand = preg_replace("{--password (.*[^\\\\]\') }", '--password \'***\' ', $safeCommand);
+            $this->io->writeError('Executing command ('.($cwd ?: 'CWD').'): '.$safeCommand);
+        }
+
+        // make sure that null translate to the proper directory in case the dir is a symlink
+        // and we call a git command, because msysgit does not handle symlinks properly
+        if (null === $cwd && Platform::isWindows() && false !== strpos($command, 'git') && getcwd()) {
+            $cwd = realpath(getcwd());
+        }
+
+        $this->captureOutput = func_num_args() > 1;
+        $this->errorOutput = null;
+
+        if (method_exists('Symfony\Component\Process\Process', 'fromShellCommandline')) {
+            $process = Process::fromShellCommandline($command, $cwd, $this->env, null, static::getTimeout());
+        } else {
+            $process = new Process($command, $cwd, $this->env, null, static::getTimeout());
+        }
+
+        $callback = is_callable($output) ? $output : [$this, 'outputHandler'];
+        $process->run($callback);
+
+        if ($this->captureOutput && ! is_callable($output)) {
+            $output = $process->getOutput();
+        }
+
+        $this->errorOutput = $process->getErrorOutput();
+
+        return $process->getExitCode();
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Update the video-processing-cli to version 0.6.0 and fix the binary caching and the download of ffmpeg that is failing in GitHub Actions

### Related issues

Fixes #432 

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)