### PR TITLE
removed checking of group context when private collection created

### DIFF
--- a/resources/views/groups/tree.blade.php
+++ b/resources/views/groups/tree.blade.php
@@ -31,7 +31,7 @@
 	
 		@if($user_can_edit_personal_groups || $user_can_see_private_groups)
 			<div class="navigation__actions" x-data="{}">
-				<button @click="$dispatch('dialog-show', { 'url': 'documents/groups/create', route: '{{ route('documents.groups.create') }}', 'params' : {isPrivate: true, group_context: {{$context_group ?? 'null' }}} })" class="navigation__action" title="{{trans('actions.create_collection_btn')}}">
+				<button @click="$dispatch('dialog-show', { 'url': 'documents/groups/create', route: '{{ route('documents.groups.create') }}', 'params' : {isPrivate: true} })" class="navigation__action" title="{{trans('actions.create_collection_btn')}}">
 					@materialicon('content', 'add_circle_outline', 'btn-icon')
 				</button>
 			</div>


### PR DESCRIPTION
## What does this PR do?

removed checking of group context when private collection created to avoid their nesting into public collections

### Related issues

Fixes ...

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)