### PR TITLE
Retry failed publication

### DIFF
--- a/app/Console/Commands/RetryFailedPublicationsCommand.php
+++ b/app/Console/Commands/RetryFailedPublicationsCommand.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace KBox\Console\Commands;
+
+use Illuminate\Console\Command;
+use KBox\Jobs\PublishDocumentJob;
+use KBox\Publication;
+
+class RetryFailedPublicationsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'publication:retry 
+                                {publication? : the publication to retry. Default retry all}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Retry a failed publication on K-Link';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $id = $this->argument('publication') ?? null;
+        
+        if ($id) {
+            // retry single publication if identifier set
+
+            $this->info("Retrying publication [$id]...");
+            
+            $this->publish(Publication::findOrFail($id));
+
+            return 0;
+        }
+
+        $this->info("Retrying failed publications...");
+
+        Publication::whereNotNull('failed_at')->chunk(30, function ($chunk) {
+            $chunk->each(function ($p) {
+                $this->publish($p);
+            });
+        });
+
+        return 0;
+    }
+    
+    protected function publish(Publication $p)
+    {
+        dispatch_now(new PublishDocumentJob($p));
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -8,6 +8,7 @@ use KBox\Console\Commands\AppearanceDownloadPictureCommand;
 use KBox\Console\Commands\ExportPublicDocumentsCommand;
 use KBox\Console\Commands\PurgeInvitesCommand;
 use KBox\Console\Commands\QuotaCheckCommand;
+use KBox\Console\Commands\RetryFailedPublicationsCommand;
 
 class Kernel extends ConsoleKernel
 {
@@ -47,6 +48,7 @@ class Kernel extends ConsoleKernel
         \KBox\Console\Commands\PurgeInvitesCommand::class,
         AppearanceDownloadPictureCommand::class,
         ExportPublicDocumentsCommand::class,
+        RetryFailedPublicationsCommand::class,
     ];
 
     /**

--- a/app/Jobs/PublishDocumentJob.php
+++ b/app/Jobs/PublishDocumentJob.php
@@ -17,16 +17,25 @@ class PublishDocumentJob implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    /**
+     * @var \KBox\Publication
+     */
     public $publication;
+
+    /**
+     * @var bool
+     */
+    public $force;
 
     /**
      * Create a new job instance.
      *
      * @return void
      */
-    public function __construct(Publication $publication)
+    public function __construct(Publication $publication, $force = false)
     {
         $this->publication = $publication;
+        $this->force = $force;
     }
 
     /**
@@ -40,8 +49,8 @@ class PublishDocumentJob implements ShouldQueue
 
         \Log::info("Publish Job handling for {$this->publication->id}: $document->uuid");
 
-        if ($this->publication->published && $this->publication->hasPendingPublications()) {
-            // Abort as publication is already happened or is in the process
+        if ($this->publication->published && ! $this->force) {
+            // Abort as publication is already happened
             return true;
         }
 

--- a/app/Publication.php
+++ b/app/Publication.php
@@ -29,6 +29,7 @@ class Publication extends Model
     protected $fillable = [
         'published_by',
         'published_at',
+        'failed_at',
         'unpublished_by',
         'published_at',
         'unpublished_at',

--- a/tests/Feature/PublishDocumentJobTest.php
+++ b/tests/Feature/PublishDocumentJobTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+use KBox\DocumentDescriptor;
+use KBox\Documents\Services\DocumentsService;
+use KBox\Jobs\PublishDocumentJob;
+use KBox\Publication;
+use KBox\User;
+use Tests\TestCase;
+
+class PublishDocumentJobTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_failed_publications_can_be_retried()
+    {
+        $this->withKlinkAdapterFake();
+
+        $user = factory(User::class)->create();
+
+        $document = factory(DocumentDescriptor::class)->create([
+            'is_public' => true
+        ]);
+            
+        $failedPublication = $document->publications()->save(new Publication([
+            'published_by' => $user->getKey(),
+            'published_at' => null,
+            'failed_at' => now(),
+            'pending' => false,
+        ]));
+
+        (new PublishDocumentJob($failedPublication))->handle(app()->make(DocumentsService::class));
+        
+        $publication = $failedPublication->fresh();
+
+        $this->assertNotNull($publication->published_at);
+    }
+
+    public function test_publish_and_already_published_document()
+    {
+        $this->withKlinkAdapterFake();
+
+        $user = factory(User::class)->create();
+
+        $document = factory(DocumentDescriptor::class)->create([
+            'is_public' => true
+        ]);
+
+        $originalPublicationDate = now()->subDays(2);
+            
+        $publication = $document->publications()->save(new Publication([
+            'published_by' => $user->getKey(),
+            'published_at' => $originalPublicationDate,
+            'failed_at' => null,
+            'pending' => false,
+        ]));
+
+        (new PublishDocumentJob($publication))->handle(app()->make(DocumentsService::class));
+        
+        $expectedPublication = $publication->fresh();
+
+        $this->assertNotNull($expectedPublication->published_at);
+        $this->assertNotEquals($originalPublicationDate, $expectedPublication->published_at);
+    }
+
+    public function test_pending_publications_can_be_processed()
+    {
+        $this->withKlinkAdapterFake();
+
+        $user = factory(User::class)->create();
+
+        $document = factory(DocumentDescriptor::class)->create([
+            'is_public' => false
+        ]);
+            
+        $publication = $document->publications()->save(new Publication([
+            'published_by' => $user->getKey(),
+            'published_at' => null,
+            'failed_at' => null,
+            'pending' => true,
+        ]));
+
+        (new PublishDocumentJob($publication))->handle(app()->make(DocumentsService::class));
+        
+        $expectedPublication = $publication->fresh();
+
+        $this->assertNotNull($expectedPublication->published_at);
+        $this->assertFalse($expectedPublication->pending);
+    }
+}

--- a/tests/Feature/RetryFailedPublicationCommandTest.php
+++ b/tests/Feature/RetryFailedPublicationCommandTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Artisan;
+use KBox\DocumentDescriptor;
+use KBox\Publication;
+use KBox\User;
+use Tests\TestCase;
+
+class RetryFailedPublicationCommandTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_failed_publications_can_be_retried()
+    {
+        $this->withKlinkAdapterFake();
+
+        $user = factory(User::class)->create();
+
+        $document = factory(DocumentDescriptor::class)->create([
+            'is_public' => true
+        ]);
+            
+        $failedPublication = $document->publications()->save(new Publication([
+            'published_by' => $user->getKey(),
+            'published_at' => null,
+            'failed_at' => now(),
+            'pending' => false,
+        ]));
+
+        $exitCode = Artisan::call('publication:retry', [
+            'publication' => $failedPublication->getKey()
+        ]);
+
+        $this->assertEquals(0, $exitCode);
+
+        $publication = $failedPublication->fresh();
+
+        $this->assertNotNull($publication->published_at);
+    }
+
+    public function test_all_failed_publications_are_retried()
+    {
+        $this->withKlinkAdapterFake();
+
+        $user = factory(User::class)->create();
+
+        $document = factory(DocumentDescriptor::class)->create([
+            'is_public' => true
+        ]);
+            
+        $failedPublication = $document->publications()->save(new Publication([
+            'published_by' => $user->getKey(),
+            'published_at' => null,
+            'failed_at' => now(),
+            'pending' => false,
+        ]));
+
+        $exitCode = Artisan::call('publication:retry');
+
+        $this->assertEquals(0, $exitCode);
+        
+        $publication = $failedPublication->fresh();
+
+        $this->assertNotNull($publication->published_at);
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Ensure that failed publications on K-Link can be retrieved

### Related issues

Fixes ...

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)