### PR TITLE
Fix container height for document preview

### DIFF
--- a/packages/contentprocessing/assets/css/preview.css
+++ b/packages/contentprocessing/assets/css/preview.css
@@ -106,7 +106,12 @@
     align-items: center;
 }
 
-.preview__content, .preview__content video, .plyr {
+.preview__content {
+    
+    width: 100%;
+    max-width: 100%;
+}
+.preview__content video, .plyr {
     
     width: 100%;
     max-width: 100%;


### PR DESCRIPTION
## What does this PR do?

Fix container height for document preview that causes hidden text at the top of the document

### Related issues

Fixes ...

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)