### PR TITLE
Export projects in zip archive

### DIFF
--- a/app/Console/Commands/ExportProjectCommand.php
+++ b/app/Console/Commands/ExportProjectCommand.php
@@ -90,9 +90,56 @@ class ExportProjectCommand extends Command
 
     private function addReadme()
     {
+        $text = <<<EOL
+This archive contain the export of the project "{$this->project->name}", i.e. the documents and collections, as folders and files. 
+
+You will find the following files and folders
+
+- "documents.csv" lists the documents contained in the export with the basic meta-data (title, folder, author, language,...).
+  The file is formatted according to the Comma Separated Value standard using the UTF-8 character encoding.
+- "project-abstract.txt" contain the description of the project, if added.
+- "{$this->project->name}" the folder containing the project files and sub-folders.
+
+### Opening documents.csv
+
+The file can be opened with Excel by double clicking it.
+Once open you will see all the text in the first column.
+
+For better viewing please consider to do the following actions:
+
+1. select the first column by clicking on the column header
+2. From the data menu choose the "Text to columns" action
+3. A wizard will be opened asking you some options
+4. On the first question choose "delimited" and press next
+5. The separator (or delimiter) is the comma, so check it and uncheck the others. You should see a preview below with two columns, one called id and the other title
+6. Press next until finish is the only action
+7. You should now see all the text correctly divided into columns
+8. From the data menu press "filter"
+9. This will add filters on the first row so you can quickly sort or find relevant information
+
+### The columns in documents.csv
+
+- "id": The unique identifier of the document
+- "title": The title of the document
+- "uploaded_at": When the document was added to the K-Box
+- "file": The location of the file inside the zip archive
+- "language": The recognized language of the document
+- "document_type": The format of the document, e.g. pdf-document, image, ...
+- "uploader": The user that uploaded the document
+- "authors": The authors, if added
+- "license": The license of the document
+- "projects": The project that contained the document
+- "collections": The collection under which the document was added
+- "hash": An alphanumeric string that can be used to verify that the content of the document was not altered
+- "url": The url of the document inside the K-Box
+
+The file might contain duplicates in the "id" column as the same document can be added to multiple collections.
+Each document is represented based on the folders it is added.
+EOL;
+        
         $this->archiveHandle->addFromString(
             'readme.txt',
-            'This archive contain the export of the documents and collections contained into "'.$this->project->name.'". The included CSV lists the documents and the available information. The CSV file is UTF-8 encoded.'
+            $text
         );
     }
 
@@ -125,12 +172,6 @@ class ExportProjectCommand extends Command
         $documents = $this->getDocuments();
 
         $graph = $this->generateReport();
-
-        // $graph[] = $this->getCsvHeaders();
-
-        // $documents->each(function ($d) use (&$graph) {
-        //     $graph[] = $this->convertDocumentDescritor($d);
-        // });
 
         $writer = Writer::createFromString();
 

--- a/app/Console/Commands/ExportProjectCommand.php
+++ b/app/Console/Commands/ExportProjectCommand.php
@@ -91,33 +91,33 @@ class ExportProjectCommand extends Command
     private function addReadme()
     {
         $text = <<<EOL
-This archive contain the export of the project "{$this->project->name}", i.e. the documents and collections, as folders and files. 
+This archive contains the export of the "{$this->project->name}" project, i.e. the records and collections, as folders and files. 
 
 You will find the following files and folders
 
-- "documents.csv" lists the documents contained in the export with the basic meta-data (title, folder, author, language,...).
-  The file is formatted according to the Comma Separated Value standard using the UTF-8 character encoding.
-- "project-abstract.txt" contain the description of the project, if added.
-- "{$this->project->name}" the folder containing the project files and sub-folders.
+- "documents.csv" lists the documents contained in the export with the basic metadata (title, folder, author, language, ...).
+The file is formatted according to the Comma Separated Value standard using 8-character UTF encoding.
+- "project-abstract.txt" contains the description of the project, if added.
+- "{$this->project->name}" the folder containing the project files and subfolders.
 
-### Opening documents.csv
+### Open documents.csv
 
-The file can be opened with Excel by double clicking it.
-Once open you will see all the text in the first column.
+The file can be opened with Excel with a double click.
+Once opened you will see all the text in the first column.
 
-For better viewing please consider to do the following actions:
+For better viewing please consider doing the following actions:
 
-1. select the first column by clicking on the column header
-2. From the data menu choose the "Text to columns" action
-3. A wizard will be opened asking you some options
-4. On the first question choose "delimited" and press next
-5. The separator (or delimiter) is the comma, so check it and uncheck the others. You should see a preview below with two columns, one called id and the other title
-6. Press next until finish is the only action
-7. You should now see all the text correctly divided into columns
-8. From the data menu press "filter"
-9. This will add filters on the first row so you can quickly sort or find relevant information
+1. Select the first column by clicking on the column header
+2. From the data menu choose the action "Text to columns"
+3. A wizard will open that will ask you some options
+4. At the first question choose "delimited" and press "next"
+5. The separator (or delimiter) is the comma, so check it and deselect the others. You should see a preview below with two columns, one called "id" and the other "title"
+6. Press the "next" button until the only action is to finish
+7. Now you should see all the text correctly divided into columns
+8. From the data menu press "filter".
+9. This will add filters on the first line so that you can quickly sort or find the relevant information
 
-### The columns in documents.csv
+### Columns in documents.csv
 
 - "id": The unique identifier of the document
 - "title": The title of the document
@@ -125,16 +125,16 @@ For better viewing please consider to do the following actions:
 - "file": The location of the file inside the zip archive
 - "language": The recognized language of the document
 - "document_type": The format of the document, e.g. pdf-document, image, ...
-- "uploader": The user that uploaded the document
-- "authors": The authors, if added
+- "uploader": The user who uploaded the document
+- "authors": The document's author(s), if added
 - "license": The license of the document
 - "projects": The project that contained the document
-- "collections": The collection under which the document was added
-- "hash": An alphanumeric string that can be used to verify that the content of the document was not altered
+- "collections": The collection where the document was added
+- "hash": An alphanumeric string that can be used to verify that the content of the document has not been altered
 - "url": The url of the document inside the K-Box
 
-The file might contain duplicates in the "id" column as the same document can be added to multiple collections.
-Each document is represented based on the folders it is added.
+The file may contain duplicates in the "id" column, as the same document can be added to multiple collections.
+Each document is represented according to the folders that are added.
 EOL;
         
         $this->archiveHandle->addFromString(

--- a/app/Console/Commands/ExportProjectCommand.php
+++ b/app/Console/Commands/ExportProjectCommand.php
@@ -149,7 +149,7 @@ class ExportProjectCommand extends Command
                 );
                 $this->archiveHandle->addFromString(
                     $f.'/'.$this->filePathForZip($doc->file, 'json'),
-                    $doc->toJson(),
+                    $doc->toJson()
                 );
             });
         }

--- a/app/Console/Commands/ExportProjectCommand.php
+++ b/app/Console/Commands/ExportProjectCommand.php
@@ -100,7 +100,7 @@ class ExportProjectCommand extends Command
     {
         $this->archiveHandle->addFromString(
             'project-abstract.txt',
-            $this->project->abstract
+            $this->project->description
         );
     }
 
@@ -227,8 +227,8 @@ class ExportProjectCommand extends Command
             $d->owner->name,
             $d->authors,
             optional($d->copyright_usage)->name ?? 'Copyright',
-            $d->projects()->pluck('name')->join('.'),
-            $d->groups()->public()->pluck('name')->join('.'),
+            $d->projects()->pluck('name')->unique()->join('/'),
+            $d->groups()->public()->pluck('name')->join('/'),
             $d->hash,
             RoutingHelpers::download($d),
         ];

--- a/app/Console/Commands/ExportProjectCommand.php
+++ b/app/Console/Commands/ExportProjectCommand.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace KBox\Console\Commands;
+
+use League\Csv\Writer;
+use KBox\DocumentDescriptor;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+use KBox\Documents\Facades\Files;
+use KBox\File;
+use KBox\Project;
+use KBox\RoutingHelpers;
+use ZipArchive;
+
+class ExportProjectCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'export:project {project} {--only-list : Export only the list of documents and collections}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Export project documents\' and collections\' to zip file or export a CSV file with the list of documents and collections';
+
+    private $archiveHandle;
+
+    /**
+     * @var \App\Project
+     */
+    private $project;
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $onlyReport = $this->option('only-list');
+        
+        $this->project = Project::findOrFail($this->argument('project'));
+
+        $this->info("Generating export...");
+
+        if ($onlyReport) {
+            $path = $this->getPath($this->getExportName('csv'));
+
+            $this->generateCsv($path);
+
+            $this->info("Document list saved [{$path}].");
+
+            return 0;
+        }
+
+        $path = $this->getPath($this->getExportName('zip'));
+
+        $this->generateDataPackage($path);
+
+        $this->info("Export saved [{$path}].");
+
+        return 0;
+    }
+
+    protected function getExportName($extension = 'zip')
+    {
+        $date = today()->toDateString();
+        return "export-{$this->project->id}-{$this->project->title_slug}-{$date}.$extension";
+    }
+
+    protected function getPath($name = null)
+    {
+        return Storage::disk('app')->path($name ?? $this->getExportName());
+    }
+
+    private function addReadme()
+    {
+        $this->archiveHandle->addFromString(
+            'readme.txt',
+            'This archive contain the export of the documents and collections contained into "'.$this->project->name.'". The included CSV lists the documents and the available information. The CSV file is UTF-8 encoded.'
+        );
+    }
+
+    private function addAbstract()
+    {
+        $this->archiveHandle->addFromString(
+            'project-abstract.txt',
+            $this->project->abstract
+        );
+    }
+
+    private function generateDataPackage($path)
+    {
+        $this->archiveHandle = new ZipArchive();
+        $this->archiveHandle->open($path, ZipArchive::CREATE);
+
+        try {
+            $this->addReadme();
+            $this->addAbstract();
+            $this->addDocuments();
+        } finally {
+            if ($this->archiveHandle) {
+                $this->archiveHandle->close();
+            }
+        }
+    }
+
+    private function addDocuments()
+    {
+        $documents = $this->getDocuments();
+
+        $graph = [];
+
+        $graph[] = $this->getCsvHeaders();
+
+        $documents->each(function ($d) use (&$graph) {
+            $graph[] = $this->convertDocumentDescritor($d);
+        });
+
+        $writer = Writer::createFromString();
+
+        $writer->insertAll($graph);
+
+        $this->archiveHandle->addFromString(
+            'documents.csv',
+            $writer->getContent()
+        );
+
+        foreach ($documents as $doc) {
+            $this->getFolders($doc)->each(function ($f) use ($doc) {
+                $this->archiveHandle->addFile(
+                    $doc->file->absolute_path,
+                    $f.'/'.$this->filePathForZip($doc->file)
+                );
+                $this->archiveHandle->addFromString(
+                    $f.'/'.$this->filePathForZip($doc->file, 'json'),
+                    $doc->toJson(),
+                );
+            });
+        }
+    }
+
+    private function getFolders(DocumentDescriptor $doc)
+    {
+        return $doc->groups->map(function ($g) {
+            return $g->ancestors()->get()->pluck('name')->merge($g->name)->join('/');
+        });
+    }
+
+    private function filePathForZip(File $file, $extension = null)
+    {
+        if (! is_null($extension)) {
+            return $file->uuid.'.'.$extension;
+        }
+        return $file->uuid.'.'.Files::extensionFromType($file->mime_type);
+    }
+
+    private function getDocuments()
+    {
+        return DocumentDescriptor::with(['owner', 'file'])->orderBy('id')->get();
+    }
+
+    private function generateReport()
+    {
+        $public = $this->getDocuments();
+
+        $graph = [];
+        $graph[] = $this->getCsvHeaders();
+
+        $public->each(function ($d) use (&$graph) {
+            $graph[] = $this->convertDocumentDescritor($d);
+        });
+
+        return $graph;
+    }
+
+    private function generateCsv($path)
+    {
+        $csv = Writer::createFromPath($path, 'w');
+
+        $csv->insertAll($this->generateReport());
+    }
+
+    private function getCsvHeaders()
+    {
+        return [
+            'id',
+            'title',
+            'uploaded_at',
+            'file',
+            'language',
+            'document_type',
+            'uploader',
+            'authors',
+            'license',
+            'projects',
+            'collections',
+            'hash',
+            'url',
+        ];
+    }
+
+    private function convertDocumentDescritor(DocumentDescriptor $d)
+    {
+        return [
+            $d->uuid,
+            $d->title,
+            optional($d->created_at)->toDateTimeString(),
+            $d->file->path,
+            $d->language,
+            $d->document_type,
+            $d->owner->name,
+            $d->authors,
+            optional($d->copyright_usage)->name ?? 'Copyright',
+            $d->projects()->pluck('name')->join('.'),
+            $d->groups()->public()->pluck('name')->join('.'),
+            $d->hash,
+            RoutingHelpers::download($d),
+        ];
+    }
+}

--- a/app/Console/Commands/ExportProjectCommand.php
+++ b/app/Console/Commands/ExportProjectCommand.php
@@ -91,7 +91,7 @@ class ExportProjectCommand extends Command
     private function addReadme()
     {
         $text = <<<EOL
-This archive contains the export of the "{$this->project->name}" project, i.e. the records and collections, as folders and files. 
+This archive contains the export of the "{$this->project->name}" project, i.e. the documents and collections, as folders and files. 
 
 You will find the following files and folders
 

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 use KBox\Console\Commands\AppearanceDownloadPictureCommand;
 use KBox\Console\Commands\ExportPublicDocumentsCommand;
+use KBox\Console\Commands\ExportProjectCommand;
 use KBox\Console\Commands\PurgeInvitesCommand;
 use KBox\Console\Commands\QuotaCheckCommand;
 use KBox\Console\Commands\RetryFailedPublicationsCommand;
@@ -48,6 +49,7 @@ class Kernel extends ConsoleKernel
         \KBox\Console\Commands\PurgeInvitesCommand::class,
         AppearanceDownloadPictureCommand::class,
         ExportPublicDocumentsCommand::class,
+        ExportProjectCommand::class,
         RetryFailedPublicationsCommand::class,
     ];
 

--- a/app/Project.php
+++ b/app/Project.php
@@ -7,6 +7,7 @@ use KBox\Traits\LocalizableDateFields;
 use Illuminate\Database\Eloquent\Model;
 use Dyrynda\Database\Support\GeneratesUuid;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Str;
 use KBox\Events\ProjectCreated;
 use KBox\Events\ProjectMembersAdded;
 use KBox\Events\ProjectMembersRemoved;
@@ -141,6 +142,11 @@ class Project extends Model
     public function documents()
     {
         return DocumentDescriptor::whereIn('id', $this->getDocumentsQuery());
+    }
+
+    public function getTitleSlugAttribute()
+    {
+        return Str::slug($this->title);
     }
 
     /**

--- a/docs/developer/commands/export-project.md
+++ b/docs/developer/commands/export-project.md
@@ -1,0 +1,42 @@
+# `export:project` command
+
+Export a project content as folders and files in a ZIP archive.
+
+## Usage
+
+```
+php artisan export:project {id}
+```
+
+The `{id}` argument is mandatory and must be the identifier of the project. You can find it in the URL 
+when editing the project.
+
+A zip file will be generated with the content of the project plus some additional files
+
+- `documents.csv` lists the documents contained in the export with the basic metadata (title, folder, author, language, ...).
+The file is formatted according to the Comma Separated Value standard using 8-character UTF encoding.
+- `project-abstract.txt` contains the description of the project, if added.
+- `readme.txt` contains some useful information on the content of the zip and how to deal with it.
+- `a folder`, named as the project title, containing the project files and subfolders.
+
+
+### documents.csv
+
+The documents.csv file has the following columns
+
+- `id`: The unique identifier of the document
+- `title`: The title of the document
+- `uploaded_at`: When the document was added to the K-Box
+- `file`: The location of the file inside the zip archive
+- `language`: The recognized language of the document
+- `document_type`: The format of the document, e.g. pdf-document, image, ...
+- `uploader`: The user who uploaded the document
+- `authors`: The document's author(s), if added
+- `license`: The license of the document
+- `projects`: The project that contained the document
+- `collections`: The collection where the document was added
+- `hash`: An alphanumeric string that can be used to verify that the content of the document has not been altered
+- `url`: The url of the document inside the K-Box
+
+The file may contain duplicates in the `id` column, as the same document can be added to multiple collections.
+Each document is represented according to the folders that are added.

--- a/docs/developer/commands/index.md
+++ b/docs/developer/commands/index.md
@@ -20,6 +20,7 @@ Here are only listed the specific commands added by the K-Box:
 - `dms:sync`: Performs a synchronization of the documents from the DMS that do not 
   exists on the Core.
 - `dms:lang-publish`: Publish Javascript language files for RequireJS i18n plugin
+- [`export:project`](./export-project.md): Export a project as a zip archive
 - [`users:import`](./user-import-command.md): Import users from a CSV file
 - [`documents:check-latest-version`](./documents-check-latest-version.md): Check if 
   the latest version details of a Document are correctly reported in a document descriptor

--- a/tests/Feature/ExportProjectCommandTest.php
+++ b/tests/Feature/ExportProjectCommandTest.php
@@ -7,6 +7,7 @@ use Tests\TestCase;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use KBox\DocumentDescriptor;
 use KBox\Documents\Facades\Files;
 use KBox\Group;
@@ -52,6 +53,13 @@ class ExportProjectCommandTest extends TestCase
         return $project;
     }
 
+    private function getFolders(DocumentDescriptor $doc)
+    {
+        return $doc->groups->map(function ($g) {
+            return $g->ancestors()->get()->pluck('name')->merge($g->name)->join('/');
+        });
+    }
+
     public function test_csv_with_document_listing_is_generated()
     {
         Storage::fake('app');
@@ -94,23 +102,28 @@ class ExportProjectCommandTest extends TestCase
             'url',
         ], $headers);
 
-        $this->assertEquals($project->documents()->orderBy('id')->get()->map(function ($d) {
-            return [
-                'id' => $d->uuid,
-                'title' => $d->title,
-                'uploaded_at' => $d->created_at->toDateTimeString(),
-                'file' => $d->file->path,
-                'language' => $d->language,
-                'document_type' => $d->document_type,
-                'uploader' => $d->owner->name,
-                'authors' => $d->authors,
-                'license' => optional($d->copyright_usage)->name ?? 'Copyright',
-                'projects' => $d->projects()->pluck('name')->unique()->join('/'),
-                'collections' => $d->groups()->public()->pluck('name')->join('/'),
-                'hash' => $d->hash,
-                'url' => RoutingHelpers::download($d),
-            ];
-        })->toArray(), $records);
+        $expectedList = [];
+        $project->documents()->orderBy('id')->get()->each(function ($d) use (&$expectedList) {
+            $this->getFolders($d)->each(function ($f) use ($d, &$expectedList) {
+                $expectedList[] = [
+                    'id' => $d->uuid,
+                    'title' => $d->title,
+                    'uploaded_at' => $d->created_at->toDateTimeString(),
+                    'file' => $f.'/'.Str::slug($d->title).'.'.Files::extensionFromType($d->file->mime_type),
+                    'language' => $d->language,
+                    'document_type' => $d->document_type,
+                    'uploader' => $d->owner->name,
+                    'authors' => $d->authors,
+                    'license' => optional($d->copyright_usage)->name ?? 'Copyright',
+                    'projects' => $d->projects()->pluck('name')->unique()->join('/'),
+                    'collections' => $f,
+                    'hash' => $d->hash,
+                    'url' => RoutingHelpers::download($d),
+                ];
+            });
+        });
+
+        $this->assertEquals($expectedList, $records);
     }
 
     public function test_project_export_include_files_and_folders()
@@ -128,8 +141,8 @@ class ExportProjectCommandTest extends TestCase
 
             return $collections->map(function ($c) use ($d) {
                 return [
-                    $c.'/'.$d->file->uuid.'.'.Files::extensionFromType($d->file->mime_type),
-                    $c.'/'.$d->file->uuid.'.json',
+                    $c.'/'.Str::slug($d->title).'.'.Files::extensionFromType($d->file->mime_type),
+                    $c.'/'.Str::slug($d->title).'.json',
                 ];
             });
         })->flatten();
@@ -197,22 +210,27 @@ class ExportProjectCommandTest extends TestCase
             'url',
         ], $headers);
 
-        $this->assertEquals($project->documents()->orderBy('id')->get()->map(function ($d) {
-            return [
-                'id' => $d->uuid,
-                'title' => $d->title,
-                'uploaded_at' => $d->created_at->toDateTimeString(),
-                'file' => $d->file->path,
-                'language' => $d->language,
-                'document_type' => $d->document_type,
-                'uploader' => $d->owner->name,
-                'authors' => $d->authors,
-                'license' => optional($d->copyright_usage)->name ?? 'Copyright',
-                'projects' => $d->projects()->pluck('name')->unique()->join('/'),
-                'collections' => $d->groups()->public()->pluck('name')->join('/'),
-                'hash' => $d->hash,
-                'url' => RoutingHelpers::download($d),
-            ];
-        })->toArray(), $records);
+        $expectedList = [];
+        $project->documents()->orderBy('id')->get()->each(function ($d) use (&$expectedList) {
+            $this->getFolders($d)->each(function ($f) use ($d, &$expectedList) {
+                $expectedList[] = [
+                    'id' => $d->uuid,
+                    'title' => $d->title,
+                    'uploaded_at' => $d->created_at->toDateTimeString(),
+                    'file' => $f.'/'.Str::slug($d->title).'.'.Files::extensionFromType($d->file->mime_type),
+                    'language' => $d->language,
+                    'document_type' => $d->document_type,
+                    'uploader' => $d->owner->name,
+                    'authors' => $d->authors,
+                    'license' => optional($d->copyright_usage)->name ?? 'Copyright',
+                    'projects' => $d->projects()->pluck('name')->unique()->join('/'),
+                    'collections' => $f,
+                    'hash' => $d->hash,
+                    'url' => RoutingHelpers::download($d),
+                ];
+            });
+        });
+
+        $this->assertEquals($expectedList, $records);
     }
 }

--- a/tests/Feature/ExportProjectCommandTest.php
+++ b/tests/Feature/ExportProjectCommandTest.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Tests\Feature;
+
+use Carbon\Carbon;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Storage;
+use KBox\DocumentDescriptor;
+use KBox\Documents\Facades\Files;
+use KBox\Group;
+use KBox\Project;
+use KBox\RoutingHelpers;
+use League\Csv\Reader;
+use ZipArchive;
+
+class ExportProjectCommandTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private function createProject()
+    {
+        $project = factory(Project::class)->create();
+
+        $project->collection->documents()->save(factory(DocumentDescriptor::class)->create());
+
+        $first_level = tap(factory(Group::class, 2)->create([
+            'parent_id' => $project->collection->getKey()
+        ]), function ($s) {
+            $s->each(function ($g) {
+                $g->documents()->save(factory(DocumentDescriptor::class)->create());
+            });
+        });
+
+        $parent = $first_level->first()->getKey();
+
+        $second_level = tap(factory(Group::class, 2)->create([
+            'parent_id' => $parent
+        ]), function ($s) {
+            $s->each(function ($g) {
+                $g->documents()->save(factory(DocumentDescriptor::class)->create());
+            });
+        });
+
+        return $project;
+    }
+
+    public function test_csv_with_document_listing_is_generated()
+    {
+        Storage::fake('app');
+
+        $project = $this->createProject();
+
+        $date = Carbon::today()->toDateString();
+
+        $exitCode = Artisan::call('export:project', [
+            'project' => $project->getKey(),
+            '--only-list' => true
+        ]);
+
+        $this->assertEquals(0, $exitCode);
+
+        $expectedFile = "export-{$project->id}-{$project->title_slug}-{$date}.csv";
+        
+        Storage::disk('app')->assertExists($expectedFile);
+
+        $csv = Reader::createFromPath(Storage::disk('app')->path($expectedFile), 'r');
+        $csv->setHeaderOffset(0); //set the CSV header offset
+
+        $headers = $csv->getHeader();
+
+        $records = collect($csv->getRecords())->values()->toArray();
+
+        $this->assertEquals([
+            'id',
+            'title',
+            'uploaded_at',
+            'file',
+            'language',
+            'document_type',
+            'uploader',
+            'authors',
+            'license',
+            'projects',
+            'collections',
+            'hash',
+            'url',
+        ], $headers);
+
+        $this->assertEquals($project->documents()->orderBy('id')->get()->map(function ($d) {
+            return [
+                'id' => $d->uuid,
+                'title' => $d->title,
+                'uploaded_at' => $d->created_at->toDateTimeString(),
+                'file' => $d->file->path,
+                'language' => $d->language,
+                'document_type' => $d->document_type,
+                'uploader' => $d->owner->name,
+                'authors' => $d->authors,
+                'license' => optional($d->copyright_usage)->name ?? 'Copyright',
+                'projects' => $d->projects()->pluck('name')->join('.'),
+                'collections' => $d->groups()->public()->pluck('name')->join('.'),
+                'hash' => $d->hash,
+                'url' => RoutingHelpers::download($d),
+            ];
+        })->toArray(), $records);
+    }
+
+    public function test_project_export_include_files_and_folders()
+    {
+        Storage::fake('app');
+
+        $project = $this->createProject();
+
+        $documents = $project->documents()->get();
+
+        $files_map = $documents->map(function ($d) {
+            $collections = $d->groups->map(function ($g) {
+                return $g->ancestors()->get()->pluck('name')->merge($g->name)->join('/');
+            })->join('/').'/';
+
+            return [
+                $collections.$d->file->uuid.'.'.Files::extensionFromType($d->file->mime_type),
+                $collections.$d->file->uuid.'.json',
+            ];
+        })->flatten();
+
+        $date = Carbon::today()->toDateString();
+
+        $exitCode = Artisan::call('export:project', [
+            'project' => $project->getKey()
+        ]);
+
+        $this->assertEquals(0, $exitCode);
+
+        $expectedFile = "export-{$project->id}-{$project->title_slug}-{$date}.zip";
+        
+        Storage::disk('app')->assertExists($expectedFile);
+        
+        $entries = [];
+
+        $zip = tap(new ZipArchive(), function ($z) use ($expectedFile) {
+            $z->open(Storage::disk('app')->path($expectedFile));
+        });
+
+        $csv_content = $zip->getFromName("documents.csv");
+
+        $elementsInZipFile = $zip->count();
+
+        for ($i=0; $i < $elementsInZipFile; $i++) {
+            $entry = $zip->statIndex($i);
+            $entries[] = $entry['name'];
+        }
+
+        $zip->close();
+
+        $files = collect([
+            'readme.txt',
+            "project-abstract.txt",
+            "documents.csv",
+        ])->merge($files_map);
+
+        $this->assertEquals($files->toArray(), $entries);
+
+        $csv = Reader::createFromString($csv_content);
+        $csv->setHeaderOffset(0); //set the CSV header offset
+
+        $headers = $csv->getHeader();
+
+        $records = collect($csv->getRecords())->values()->toArray();
+
+        $this->assertEquals([
+            'id',
+            'title',
+            'uploaded_at',
+            'file',
+            'language',
+            'document_type',
+            'uploader',
+            'authors',
+            'license',
+            'projects',
+            'collections',
+            'hash',
+            'url',
+        ], $headers);
+
+        $this->assertEquals($project->documents()->orderBy('id')->get()->map(function ($d) {
+            return [
+                'id' => $d->uuid,
+                'title' => $d->title,
+                'uploaded_at' => $d->created_at->toDateTimeString(),
+                'file' => $d->file->path,
+                'language' => $d->language,
+                'document_type' => $d->document_type,
+                'uploader' => $d->owner->name,
+                'authors' => $d->authors,
+                'license' => optional($d->copyright_usage)->name ?? 'Copyright',
+                'projects' => $d->projects()->pluck('name')->join('.'),
+                'collections' => $d->groups()->public()->pluck('name')->join('.'),
+                'hash' => $d->hash,
+                'url' => RoutingHelpers::download($d),
+            ];
+        })->toArray(), $records);
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Add a `export:project` command to generate a zip of all the documents and collections present in a project. Inside the zip file the collections are represented as folders.

### Related issues

Fixes ...

### Review checklist

* [x] Are unit tests required?
* [x] Are Documentation changes needed?

**Before merging**

* [x] Is history cleaned up? (or can be squashed on merge?)