### PR TITLE
Use environment files instead of set-env

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Define image version
       run: |
         export REF_SLUG=$(echo "$GITHUB_REF" | tr "[:upper:]" "[:lower:]" | sed -r 's#refs/[^\/]*/##;s/[~\^]+//g;s/[^a-zA-Z0-9.]+/-/g;s/^-+\|-+$//g;s/^-*//;s/-*$//' | cut -c1-63)
-        echo "::set-env name=IMAGE_VERSION::${REF_SLUG}"
+        echo "IMAGE_VERSION=${REF_SLUG}" >> $GITHUB_ENV
     - name: Build the Docker image 
       run: |
         echo ${{ env.IMAGE_VERSION }}


### PR DESCRIPTION
## What does this PR do?

Remove the usage of set-env in GitHub Action workflows. See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

### Related issues

Fixes ...

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)