### PR TITLE
Changelog entries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,3 +25,7 @@ bin/
 php-cs-fixer.phar
 _ide_helper.php
 .phpstorm.meta.php
+changelogs/*
+readme.md
+contributing.md
+changelog.md

--- a/.php_cs
+++ b/.php_cs
@@ -23,6 +23,7 @@ $finder = PhpCsFixer\Finder::create()
     ->in([
         __DIR__.'/app',
         __DIR__.'/config',
+        __DIR__.'/changelogs/src',
         __DIR__.'/packages',
         __DIR__.'/routes',
         __DIR__.'/tests',

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Response;
 use KBox\DocumentsElaboration\DocumentElaborationManager;
 use KBox\Services\Quota;
 use Jenssegers\Date\Date as LocalizedDate;
+use KBox\Changelog\ChangelogCommand;
 use KBox\Pages\Page;
 use Oneofftech\Identities\Facades\Identity;
 
@@ -108,6 +109,8 @@ class AppServiceProvider extends ServiceProvider
 
             return $this->asLocalizableDate()->format($format).($withTime ? ' (UTC)' : '');
         });
+
+        $this->registerDevelopmentCommand();
     }
 
     /**
@@ -138,6 +141,15 @@ class AppServiceProvider extends ServiceProvider
 
         if ($this->app->runningInConsole() && $this->app->environment('development')) {
             $this->app->register(\Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class);
+        }
+    }
+
+    protected function registerDevelopmentCommand()
+    {
+        if ($this->app->runningInConsole() && $this->app->environment('local', 'testing')) {
+            $this->commands([
+                ChangelogCommand::class,
+            ]);
         }
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -13,6 +13,7 @@ use KBox\DocumentsElaboration\DocumentElaborationManager;
 use KBox\Services\Quota;
 use Jenssegers\Date\Date as LocalizedDate;
 use KBox\Changelog\ChangelogCommand;
+use KBox\Changelog\ReleaseCommand;
 use KBox\Pages\Page;
 use Oneofftech\Identities\Facades\Identity;
 
@@ -149,6 +150,7 @@ class AppServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole() && $this->app->environment('local', 'testing')) {
             $this->commands([
                 ChangelogCommand::class,
+                ReleaseCommand::class,
             ]);
         }
     }

--- a/changelog.md
+++ b/changelog.md
@@ -1,17 +1,16 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+Lists all notable changes to the K-Box for each version.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+**Note**: Changes for the unreleased section are handled via entries under 
+[changelogs/unreleased](./changelogs/unreleased). Please see the 
+[developer documentation](./docs/developer/changelog.md) for 
+instructions on adding your own entry.
 
-### Added
-### Changed
-### Fixed
-### Deprecated
-### Removed
+## [Unreleased]
 
 ## [0.31.6] - 2020-10-15
 

--- a/changelogs/README.md
+++ b/changelogs/README.md
@@ -1,0 +1,9 @@
+## Generating changelog entries
+
+To generate and validate your changelog entries run:
+
+```bash
+php artisan changelog
+```
+
+See [docs/developer/changelog.md](../docs/developer/changelog.md) documentation for detailed usage.

--- a/changelogs/src/ChangelogCommand.php
+++ b/changelogs/src/ChangelogCommand.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace KBox\Changelog;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+
+class ChangelogCommand extends Command
+{
+    protected $signature = 'changelog {title?}
+                                {--f|force : Overwrite entry if already exists}
+                                {--dry-run : Don\'t actually write anything, just print }
+                                {--i|issue= : Set the issue number}
+                                {--m|merge-request= : Set the merge request number}
+                                {--u|author= : Set the author}
+                                {--t|type= : Set the entry type}';
+
+    protected $description = 'Generate a changelog entry file';
+
+    protected static $types = [
+        'added',
+        'fixed',
+        'changed',
+        'deprecated',
+        'removed',
+        'security',
+    ];
+
+    protected static $categories = [
+        'New feature' => 'added',
+        'Bug fix' => 'fixed',
+        'Feature change' => 'changed',
+        'New deprecation' => 'deprecated',
+        'Feature removal' => 'removed',
+        'Security fix' => 'security',
+    ];
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function handle()
+    {
+        $git = $this->laravel->make(Git::class);
+
+        $branch = Str::slug($git->branch());
+
+        $path = "changelogs/unreleased/$branch.yml";
+        $file = base_path($path);
+
+        $force = $this->option('force') ?? false;
+
+        if (is_file($file) && ! $force) {
+            $this->error("error $path already exists! Use `--force` to overwrite.");
+            return 127;
+        }
+
+        $commit = $git->commit();
+
+        $title = $this->argument('title') ?? $this->ask('Please specify a title for the changelog entry', $commit) ?? $commit;
+        $type = $this->ensureIsType($this->option('type') ?? $this->choice('Please specify the category of your change', array_keys(self::$categories)));
+        $mergeRequest = $this->option('merge-request') ?? $this->ask('The merge request identifier', $this->getMergeFromCommit($commit)) ?? $this->getMergeFromCommit($commit);
+
+        $defaultIssueNumber = $this->getIssueNumberFromBranch($branch) ?? $this->getIssueFromCommit($commit);
+
+        $issue = $this->option('issue') ?? $this->ask('The issue number', $defaultIssueNumber) ?? $defaultIssueNumber;
+        $author = $this->ensureAuthorStartsWithAt($this->option('author') ?? $this->ask('Please specify the GitHub username of the author'));
+
+        $yaml = <<<"yaml"
+        title: $title
+        issue: $issue
+        merge_request: $mergeRequest
+        author: $author
+        type: $type
+        yaml;
+
+        $this->info("create $path");
+        $this->info('---');
+        $this->info($yaml);
+
+        if ($this->option('dry-run')) {
+            return 0;
+        }
+
+        file_put_contents($file, $yaml);
+
+        return 0;
+    }
+
+    protected function ensureIsType($value)
+    {
+        if (in_array($value, array_keys(self::$categories))) {
+            return self::$categories[$value];
+        }
+
+        if (! in_array($value, self::$types)) {
+            throw new InvalidArgumentException("Unexpected type. Found [$value], expected one of [].");
+        }
+
+        return $value;
+    }
+
+    protected function getIssueNumberFromBranch($branch)
+    {
+        preg_match('/^(\d+)-/', $branch, $matches);
+
+        return $matches[1] ?? null;
+    }
+
+    protected function getIssueFromCommit($commit)
+    {
+        preg_match('/#(\d+)/', $commit, $matches);
+
+        return $matches[1] ?? null;
+    }
+
+    protected function getMergeFromCommit($commit)
+    {
+        preg_match('/!(\d+)/', $commit, $matches);
+
+        return $matches[1] ?? null;
+    }
+
+    protected function ensureAuthorStartsWithAt($author)
+    {
+        if (empty($author)) {
+            return null;
+        }
+        return '@'.ltrim($author, '@');
+    }
+}

--- a/changelogs/src/ChangelogCommand.php
+++ b/changelogs/src/ChangelogCommand.php
@@ -69,10 +69,10 @@ class ChangelogCommand extends Command
         $author = $this->ensureAuthorStartsWithAt($this->option('author') ?? $this->ask('Please specify the GitHub username of the author'));
 
         $yaml = <<<"yaml"
-        title: $title
+        title: "$title"
         issue: $issue
         merge_request: $mergeRequest
-        author: $author
+        author: "$author"
         type: $type
         yaml;
 

--- a/changelogs/src/EntriesFinder.php
+++ b/changelogs/src/EntriesFinder.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace KBox\Changelog;
+
+use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Yaml\Parser;
+
+class EntriesFinder
+{
+    protected $filesystem;
+
+    public function __construct(Filesystem $filesystem)
+    {
+        $this->filesystem = $filesystem;
+    }
+
+    protected function files()
+    {
+        return $this->filesystem->glob(base_path('changelogs/unreleased/*.yml'));
+    }
+
+    public function all()
+    {
+        $yamlParser = new Parser();
+
+        $files = collect($this->files())->map(function ($file) use ($yamlParser) {
+            return $yamlParser->parse($this->filesystem->get($file));
+        });
+
+        return $files;
+    }
+
+    public function delete()
+    {
+        $this->filesystem->delete($this->files());
+    }
+}

--- a/changelogs/src/Git.php
+++ b/changelogs/src/Git.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace KBox\Changelog;
+
+class Git
+{
+    /**
+     * Get current branch
+     *
+     * @return string
+     */
+    public function branch()
+    {
+        exec('git symbolic-ref --short HEAD', $output);
+
+        return $output[0] ?? null;
+    }
+    
+    /**
+     * Get current commit message
+     *
+     * @return string
+     */
+    public function commit()
+    {
+        exec('git log --format=%s -1', $output);
+
+        return $output[0] ?? null;
+    }
+}

--- a/changelogs/src/ReleaseCommand.php
+++ b/changelogs/src/ReleaseCommand.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace KBox\Changelog;
+
+use Illuminate\Console\Command;
+
+class ReleaseCommand extends Command
+{
+    protected $signature = 'release {version}
+                                {--dry-run : Don\'t actually write anything, just print }';
+
+    protected $description = 'Consolidate a release changelog';
+
+    protected static $types = [
+        'added' => '### Added',
+        'changed' => '### Changed',
+        'fixed' => '### Fixed',
+        'security' => '### Security',
+        'deprecated' => '### Deprecated',
+        'removed' => '### Removed',
+    ];
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function handle()
+    {
+        $finder = $this->laravel->make(EntriesFinder::class);
+
+        $entries = $finder->all();
+
+        $sections = $entries->groupBy('type')->mapWithKeys(function ($entries, $group) {
+            $items = $entries->map(function ($entry) {
+                return $this->formatEntry($entry);
+            })->filter();
+
+            return [$group => $items];
+        })->filter();
+
+        $formattedSections = collect(self::$types)->map(function ($title, $key) use ($sections) {
+            $content = $sections->get($key);
+
+            if (empty($content)) {
+                return null;
+            }
+
+            return $title."\n\n".$content->join("\n");
+        })->filter()->join("\n\n");
+
+        $version = ltrim($this->argument('version'), 'v');
+
+        $releaseDate = today()->toDateString();
+
+        $releaseMarkdown = <<<"markdown"
+        ## [$version] - $releaseDate
+
+        $formattedSections
+
+        markdown;
+
+        $this->info("update changelog.md");
+        $this->info('---');
+        $this->info($releaseMarkdown);
+
+        if ($this->option('dry-run')) {
+            return 0;
+        }
+        
+        $changelog = file_get_contents(base_path('changelog.md'));
+        
+        $changelog = str_replace('## [Unreleased]', "## [Unreleased]\n\n".$releaseMarkdown, $changelog);
+
+        file_put_contents(base_path('changelog.md'), $changelog);
+
+        $finder->delete();
+        
+        return 0;
+    }
+
+    protected function formatEntry(array $entry)
+    {
+        $links = array_filter([
+            $this->link('issues', $entry['issue'] ?? null),
+            $this->link('pull', $entry['merge_request'] ?? null),
+        ]);
+
+        $pieces = [
+            trim($entry['title']),
+            $this->author($entry['author']),
+            ! empty($links) ? '('.implode(", ", $links).')' : null,
+        ];
+
+        return sprintf('- %1$s', implode(' ', $pieces));
+    }
+
+    protected function link($type, $entry)
+    {
+        if (empty($entry)) {
+            return null;
+        }
+
+        return "[#$entry](https://github.com/k-box/k-box/$type/$entry)";
+    }
+
+    protected function author($value)
+    {
+        if (empty($value)) {
+            return null;
+        }
+
+        return "by $value";
+    }
+}

--- a/changelogs/unreleased/422-login-with-third-party-services.yml
+++ b/changelogs/unreleased/422-login-with-third-party-services.yml
@@ -1,0 +1,5 @@
+title: "Log in and registration via external identity providers (e.g. Gitlab and Dropbox)"
+issue: 422
+merge_request: 437
+authors: 
+type: added

--- a/changelogs/unreleased/422-login-with-third-party-services.yml
+++ b/changelogs/unreleased/422-login-with-third-party-services.yml
@@ -1,5 +1,5 @@
 title: "Log in and registration via external identity providers (e.g. Gitlab and Dropbox)"
 issue: 422
 merge_request: 437
-authors: 
+author: 
 type: added

--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,8 @@
 	},
 	"autoload-dev": {
 		"psr-4": {
-            "Tests\\": "tests/"
+			"Tests\\": "tests/",
+			"KBox\\Changelog\\": "changelogs/src/"
         },
 		"classmap": [
 			"tests/TestCase.php"

--- a/docs/developer/changelog.md
+++ b/docs/developer/changelog.md
@@ -137,7 +137,7 @@ type:
 
 #### `--merge-request` or `-m`
 
-Use the **`--merge-request`** or **`-m`** argument to provide the
+Use the **`--merge-request`** or **`-m`** option to provide the
 `merge_request` value:
 
 ```plaintext
@@ -153,7 +153,7 @@ type:
 
 #### `--issue` or `-i`
 
-Use the **`--issue`** or **`-i`** argument to provide the
+Use the **`--issue`** or **`-i`** option to provide the
 `issue` value:
 
 ```plaintext
@@ -169,7 +169,7 @@ type:
 
 #### `--dry-run`
 
-Use the **`--dry-run`** argument to prevent actually writing anything:
+Use the **`--dry-run`** option to prevent actually writing anything:
 
 ```plaintext
 $ php artisan changelog --dry-run
@@ -184,7 +184,7 @@ type:
 
 #### `--author` or `-u`
 
-Use the **`--author`** or **`-u`** argument to fill in the `author` value:
+Use the **`--author`** or **`-u`** option to fill in the `author` value:
 
 ```plaintext
 $ php artisan changelog -u "octocat" 'Hey Jo, I added a feature to the K-Box!'
@@ -199,7 +199,7 @@ type:
 
 #### `--type` or `-t`
 
-Use the **`--type`** or **`-t`** argument to provide the `type` value:
+Use the **`--type`** or **`-t`** option to provide the `type` value:
 
 ```plaintext
 $ php artisan changelog 'Hey Jo, I added a feature to the K-Box!' -t added

--- a/docs/developer/changelog.md
+++ b/docs/developer/changelog.md
@@ -4,8 +4,10 @@ The [`CHANGELOG.md`](../../changelog.md) file track notable changes to
 the K-Box. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 Each entry, or bullet point, in the Changelog file is generated from a single 
-data file in the `changelogs/unreleased` folder.
-The file is expected to be a YAML file in the following format:
+data file in the `changelogs/unreleased` folder while the 
+release is generated with the [`release` command](#generate-a-release-entry).
+
+Each entry file is expected to be a YAML file in the following format:
 
 ```yaml
 title: "A new important feature"
@@ -224,3 +226,35 @@ we [started brainstorming](https://github.com/k-box/k-box/issues/435).
 The discussion lead to the current solution of one file per entry,
 and then compiling the entries into the overall `CHANGELOG.md` file during the
 release process.
+
+## Generate a release entry
+
+Consolidating the changelog for a release can be done via the Artisan `release`
+command.
+
+Its simplest usage is to provide the value for the `version` number.
+
+```bash
+php artisan release 0.32.0
+```
+
+### Options
+
+| Option      | Shorthand | Purpose                                   |
+| ----------- | --------- | ----------------------------------------- |
+| `--dry-run` |           | Don't actually write anything, just print |
+
+#### `--dry-run`
+
+Use the **`--dry-run`** option to prevent actually writing anything:
+
+```plaintext
+$ php artisan release 0.32.0 --dry-run
+update changelog.md
+---
+## [0.32.0] - 2020-11-22
+
+### Added
+
+- Entry for added by @octocat ([#100](https://github.com/k-box/k-box/issues/100), [#2100](https://github.com/k-box/k-box/pull/2100))
+```

--- a/docs/developer/changelog.md
+++ b/docs/developer/changelog.md
@@ -1,0 +1,226 @@
+# Changelog entries
+
+The [`CHANGELOG.md`](../../changelog.md) file track notable changes to
+the K-Box. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+
+Each entry, or bullet point, in the Changelog file is generated from a single 
+data file in the `changelogs/unreleased` folder.
+The file is expected to be a YAML file in the following format:
+
+```yaml
+title: "A new important feature"
+issue: 100
+merge_request: 101
+author: @octocat
+type: added
+```
+
+The `merge_request` value is a reference to a merge request that adds this entry, and the `author` key 
+(format: `<GitHub username>`) is used to give attribution to community contributors. 
+The `issue` field is the reference to the issue under which the change might have been discussed.
+`author`, `issue` and `merge_request` are optional. 
+The `type` field maps the [category of the change](https://keepachangelog.com/en/1.0.0/#how), 
+valid options are: `added`, `fixed`, `changed`, `deprecated`, `removed`, `security`. Type field is mandatory.
+
+Community contributors and core team members are encouraged to add their name to the author field. 
+
+## What can be added as changelog entry?
+
+- Any change that introduces a database migration **must** have a changelog entry;
+- Security fixes **must** have a changelog entry, without `merge_request` value
+  and with `type` set to `security`;
+- Any user-facing change **must** have a changelog entry. This includes both visual changes 
+  (regardless of how minor);
+- Performance improvements **should** have a changelog entry;
+- _Any_ contribution from a community member, no matter how small, **may** have
+  a changelog entry regardless of these guidelines if the contributor wants one
+  Example: "Fixed a typo on the search results page";
+- Any docs-only changes **should not** have a changelog entry;
+- Any change behind feature flag **may** have a changelog entry;
+- Any developer-facing change (e.g., refactoring, technical debt remediation,
+  test suite changes) **can** have a changelog entry. Examples: "Refactor to 
+  use model factories", "Update to Laravel v7.x".
+
+## Writing good changelog entries
+
+A good changelog entry should be descriptive and concise. It should explain the
+change to a reader who has _zero context_ about the change. If you have trouble
+making it both concise and descriptive, err on the side of descriptive.
+
+Use your best judgement and try to put yourself in the mindset of someone
+reading the compiled changelog. Does this entry add value? Does it offer context
+about _where_ and _why_ the change was made? Is the _end benefit_ to the user clear?
+
+| **Bad** | **Good**|
+|---------|---------|
+| Starred documents order | Show a user's starred documents at the top of the "My Uploads" section |
+| Copy (some text) to clipboard | Update the "Copy to clipboard" tooltip to indicate what's being copied |
+| Improves CSS and HTML problems in details panel | Fix layout spacing in document's detail panel |
+| Remove `null`s from version array | Fix 500 errors caused by trashed file in version list |
+
+
+## How to generate a changelog entry
+
+An Artisan command, `changelog`, is available to generate the changelog entry file
+automatically.
+
+Its simplest usage is to provide the value for `title`:
+
+```bash
+php artisan changelog 'Hey Jo, I added a feature to the K-Box!'
+```
+
+At this point the command would ask you to select the category of the change 
+(mapped to the `type` field in the entry):
+
+```plaintext
+>> Please specify the category of your change:
+1. New feature
+2. Bug fix
+3. Feature change
+4. New deprecation
+5. Feature removal
+6. Security fix
+```
+
+The entry filename is based on the name of the current Git branch. If you run
+the command above on a branch called `feature-hey-jo`, it will generate a
+`changelogs/unreleased/feature-hey-jo.yml` file.
+
+The command will output the path of the generated file and its contents:
+
+```plaintext
+create changelogs/unreleased/feature-hey-jo.yml
+---
+title: Hey Jo, I added a feature to the K-Box!
+issue:
+merge_request:
+author:
+type:
+```
+
+
+### Options
+
+| Option            | Shorthand | Purpose                                                    |
+| ------------------| --------- | -----------------------------------------------------------|
+| `--force`         | `-f`      | Overwrite an existing entry                                |
+| `--dry-run`       |           | Don't actually write anything, just print                  |
+| `--issue`         | `-i`      | Set the issue number                                       |
+| `--merge-request` | `-m`      | Set merge request ID                                       |
+| `--author`        | `-u`      | Specify the author                                         |
+| `--type`          | `-t`      | The category of the change, valid options are: `added`, `fixed`, `changed`, `deprecated`, `removed`, `security` |
+| `--help`          | `-h`      | Print help message                                         |
+
+
+
+#### `--force` or `-f`
+
+Use **`--force`** or **`-f`** to overwrite an existing changelog entry if it
+already exists.
+
+```plaintext
+$ php artisan changelog 'Hey Jo, I added a feature to the K-Box!'
+error changelogs/unreleased/feature-hey-jo.yml already exists! Use `--force` to overwrite.
+
+$ php artisan changelog 'Hey Jo, I added a feature to the K-Box!' --force
+create changelogs/unreleased/feature-hey-jo.yml
+---
+title: Hey Jo, I added a feature to the K-Box!
+issue: 2020
+merge_request: 2021
+author:
+type:
+```
+
+#### `--merge-request` or `-m`
+
+Use the **`--merge-request`** or **`-m`** argument to provide the
+`merge_request` value:
+
+```plaintext
+$ php artisan changelog 'Hey Jo, I added a feature to the K-Box!' -m 2021
+create changelogs/unreleased/feature-hey-jo.yml
+---
+title: Hey Jo, I added a feature to the K-Box!
+issue:
+merge_request: 2021
+author:
+type:
+```
+
+#### `--issue` or `-i`
+
+Use the **`--issue`** or **`-i`** argument to provide the
+`issue` value:
+
+```plaintext
+$ php artisan changelog 'Hey Jo, I added a feature to the K-Box!' -i 2020
+create changelogs/unreleased/feature-hey-jo.yml
+---
+title: Hey Jo, I added a feature to the K-Box!
+issue: 2020
+merge_request: 
+author:
+type:
+```
+
+#### `--dry-run`
+
+Use the **`--dry-run`** argument to prevent actually writing anything:
+
+```plaintext
+$ php artisan changelog --dry-run
+create changelogs/unreleased/feature-hey-jo.yml
+---
+title: Added an awesome new feature to the K-Box
+issue:
+merge_request:
+author:
+type:
+```
+
+#### `--author` or `-u`
+
+Use the **`--author`** or **`-u`** argument to fill in the `author` value:
+
+```plaintext
+$ php artisan changelog -u "octocat" 'Hey Jo, I added a feature to the K-Box!'
+create changelogs/unreleased/feature-hey-jo.yml
+---
+title: Hey Jo, I added a feature to the K-Box!
+issue:
+merge_request:
+author: @octocat
+type:
+```
+
+#### `--type` or `-t`
+
+Use the **`--type`** or **`-t`** argument to provide the `type` value:
+
+```plaintext
+$ php artisan changelog 'Hey Jo, I added a feature to the K-Box!' -t added
+create changelogs/unreleased/feature-hey-jo.yml
+---
+title: Hey Jo, I added a feature to the K-Box!
+issue:
+merge_request:
+author:
+type: added
+```
+
+### History and Reasoning
+
+Our `CHANGELOG` file was previously updated manually by each contributor that
+felt their change warranted an entry. When two merge requests added their own
+entries at the same spot in the list, it created a merge conflict in one as soon
+as the other was merged. To reduce the merge conflicts not updating the 
+changelog quickly became a practice. Creating a release then became a slow
+process.
+
+To reduce the impact on contributors, reviewers and on the release process
+we [started brainstorming](https://github.com/k-box/k-box/issues/435).
+The discussion lead to the current solution of one file per entry,
+and then compiling the entries into the overall `CHANGELOG.md` file during the
+release process.

--- a/tests/Feature/Changelogs/ChangelogCommandTest.php
+++ b/tests/Feature/Changelogs/ChangelogCommandTest.php
@@ -36,10 +36,10 @@ class ChangelogCommandTest extends TestCase
         $this->path = base_path('changelogs/unreleased/100-test-branch.yml');
 
         $expectedYaml = <<<'yaml'
-        title: Test add entry!
+        title: "Test add entry!"
         issue: 100
         merge_request: 
-        author: @octocat
+        author: "@octocat"
         type: changed
         yaml;
 
@@ -81,10 +81,10 @@ class ChangelogCommandTest extends TestCase
         file_put_contents($this->path, 'test');
 
         $expectedYaml = <<<'yaml'
-        title: Test add entry!
+        title: "Test add entry!"
         issue: 100
         merge_request: 
-        author: @octocat
+        author: "@octocat"
         type: changed
         yaml;
 
@@ -112,10 +112,10 @@ class ChangelogCommandTest extends TestCase
         $this->path = base_path('changelogs/unreleased/100-test-branch.yml');
 
         $expectedYaml = <<<'yaml'
-        title: Test add entry!
+        title: "Test add entry!"
         issue: 100
         merge_request: 
-        author: @octocat
+        author: "@octocat"
         type: changed
         yaml;
 
@@ -141,10 +141,10 @@ class ChangelogCommandTest extends TestCase
         $this->path = base_path('changelogs/unreleased/100-test-branch.yml');
 
         $expectedYaml = <<<'yaml'
-        title: Commit description (#161) (!162)
+        title: "Commit description (#161) (!162)"
         issue: 100
         merge_request: 162
-        author: 
+        author: ""
         type: changed
         yaml;
 
@@ -169,10 +169,10 @@ class ChangelogCommandTest extends TestCase
         $this->path = base_path('changelogs/unreleased/test-branch.yml');
 
         $expectedYaml = <<<'yaml'
-        title: Commit description (#161) (!162)
+        title: "Commit description (#161) (!162)"
         issue: 161
         merge_request: 162
-        author: 
+        author: ""
         type: changed
         yaml;
 
@@ -197,10 +197,10 @@ class ChangelogCommandTest extends TestCase
         $this->path = base_path('changelogs/unreleased/100-test-branch.yml');
 
         $expectedYaml = <<<'yaml'
-        title: A title
+        title: "A title"
         issue: 101
         merge_request: 102
-        author: @octocat
+        author: "@octocat"
         type: changed
         yaml;
 

--- a/tests/Feature/Changelogs/ChangelogCommandTest.php
+++ b/tests/Feature/Changelogs/ChangelogCommandTest.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace Tests\Feature\Changelogs;
+
+use KBox\Changelog\Git;
+use Mockery;
+use Tests\TestCase;
+
+class ChangelogCommandTest extends TestCase
+{
+    protected $path = null;
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        if (! is_null($this->path) && is_file($this->path)) {
+            unlink($this->path);
+        }
+    }
+
+    protected function mockGit($branch, $commit)
+    {
+        $mock = Mockery::mock(Git::class);
+
+        $mock->shouldReceive('branch')->andReturn($branch);
+        $mock->shouldReceive('commit')->andReturn($commit);
+
+        $this->app->instance(Git::class, $mock);
+    }
+    
+    public function test_changelog_entry_written()
+    {
+        $this->mockGit('100-test-branch', 'Commit description');
+
+        $this->path = base_path('changelogs/unreleased/100-test-branch.yml');
+
+        $expectedYaml = <<<'yaml'
+        title: Test add entry!
+        issue: 100
+        merge_request: 
+        author: @octocat
+        type: changed
+        yaml;
+
+        $this->artisan('changelog', [
+                'title' => 'Test add entry!'
+            ])
+            ->expectsQuestion('Please specify the category of your change', 'Feature change')
+            ->expectsQuestion('The merge request identifier', '')
+            ->expectsQuestion('The issue number', '100')
+            ->expectsQuestion('Please specify the GitHub username of the author', 'octocat')
+            ->expectsOutput('create changelogs/unreleased/100-test-branch.yml')
+            ->expectsOutput($expectedYaml)
+            ->assertExitCode(0);
+
+        $this->assertFileExists($this->path);
+
+        $this->assertEquals($expectedYaml, file_get_contents($this->path));
+    }
+
+    public function test_changelog_entry_overwrite_denied_without_force()
+    {
+        $this->mockGit('100-test-branch', 'Commit description');
+
+        $this->path = base_path('changelogs/unreleased/100-test-branch.yml');
+        file_put_contents($this->path, 'test');
+
+        $this->artisan('changelog', [
+                'title' => 'Test add entry!'
+            ])
+            ->expectsOutput('error changelogs/unreleased/100-test-branch.yml already exists! Use `--force` to overwrite.')
+            ->assertExitCode(127);
+    }
+
+    public function test_changelog_entry_overwritten()
+    {
+        $this->mockGit('100-test-branch', 'Commit description');
+
+        $this->path = base_path('changelogs/unreleased/100-test-branch.yml');
+        file_put_contents($this->path, 'test');
+
+        $expectedYaml = <<<'yaml'
+        title: Test add entry!
+        issue: 100
+        merge_request: 
+        author: @octocat
+        type: changed
+        yaml;
+
+        $this->artisan('changelog', [
+                'title' => 'Test add entry!',
+                '--force' => true,
+            ])
+            ->expectsQuestion('Please specify the category of your change', 'Feature change')
+            ->expectsQuestion('The merge request identifier', '')
+            ->expectsQuestion('The issue number', '100')
+            ->expectsQuestion('Please specify the GitHub username of the author', 'octocat')
+            ->expectsOutput('create changelogs/unreleased/100-test-branch.yml')
+            ->expectsOutput($expectedYaml)
+            ->assertExitCode(0);
+
+        $this->assertFileExists($this->path);
+
+        $this->assertEquals($expectedYaml, file_get_contents($this->path));
+    }
+    
+    public function test_title_asked_when_not_specified()
+    {
+        $this->mockGit('100-test-branch', 'Commit description');
+
+        $this->path = base_path('changelogs/unreleased/100-test-branch.yml');
+
+        $expectedYaml = <<<'yaml'
+        title: Test add entry!
+        issue: 100
+        merge_request: 
+        author: @octocat
+        type: changed
+        yaml;
+
+        $this->artisan('changelog')
+            ->expectsQuestion('Please specify a title for the changelog entry', 'Test add entry!')
+            ->expectsQuestion('Please specify the category of your change', 'Feature change')
+            ->expectsQuestion('The merge request identifier', '')
+            ->expectsQuestion('The issue number', '100')
+            ->expectsQuestion('Please specify the GitHub username of the author', 'octocat')
+            ->expectsOutput('create changelogs/unreleased/100-test-branch.yml')
+            ->expectsOutput($expectedYaml)
+            ->assertExitCode(0);
+
+        $this->assertFileExists($this->path);
+
+        $this->assertEquals($expectedYaml, file_get_contents($this->path));
+    }
+
+    public function test_default_values_used_without_answers()
+    {
+        $this->mockGit('100-test-branch', 'Commit description (#161) (!162)');
+
+        $this->path = base_path('changelogs/unreleased/100-test-branch.yml');
+
+        $expectedYaml = <<<'yaml'
+        title: Commit description (#161) (!162)
+        issue: 100
+        merge_request: 162
+        author: 
+        type: changed
+        yaml;
+
+        $this->artisan('changelog', ['--type' => 'changed'])
+            ->expectsQuestion('Please specify a title for the changelog entry', null)
+            ->expectsQuestion('The merge request identifier', null)
+            ->expectsQuestion('The issue number', null)
+            ->expectsQuestion('Please specify the GitHub username of the author', null)
+            ->expectsOutput('create changelogs/unreleased/100-test-branch.yml')
+            ->expectsOutput($expectedYaml)
+            ->assertExitCode(0);
+
+        $this->assertFileExists($this->path);
+
+        $this->assertEquals($expectedYaml, file_get_contents($this->path));
+    }
+
+    public function test_issue_number_read_from_commit_message()
+    {
+        $this->mockGit('test-branch', 'Commit description (#161) (!162)');
+
+        $this->path = base_path('changelogs/unreleased/test-branch.yml');
+
+        $expectedYaml = <<<'yaml'
+        title: Commit description (#161) (!162)
+        issue: 161
+        merge_request: 162
+        author: 
+        type: changed
+        yaml;
+
+        $this->artisan('changelog', ['--type' => 'changed'])
+            ->expectsQuestion('Please specify a title for the changelog entry', null)
+            ->expectsQuestion('The merge request identifier', null)
+            ->expectsQuestion('The issue number', null)
+            ->expectsQuestion('Please specify the GitHub username of the author', null)
+            ->expectsOutput('create changelogs/unreleased/test-branch.yml')
+            ->expectsOutput($expectedYaml)
+            ->assertExitCode(0);
+
+        $this->assertFileExists($this->path);
+
+        $this->assertEquals($expectedYaml, file_get_contents($this->path));
+    }
+
+    public function test_changelog_accept_options()
+    {
+        $this->mockGit('100-test-branch', 'Commit description');
+
+        $this->path = base_path('changelogs/unreleased/100-test-branch.yml');
+
+        $expectedYaml = <<<'yaml'
+        title: A title
+        issue: 101
+        merge_request: 102
+        author: @octocat
+        type: changed
+        yaml;
+
+        $this->artisan('changelog', [
+            'title' => 'A title',
+            '--type' => 'changed',
+            '-i' => '101',
+            '-m' => '102',
+            '-u' => 'octocat',
+            ])
+            ->expectsOutput('create changelogs/unreleased/100-test-branch.yml')
+            ->expectsOutput($expectedYaml)
+            ->assertExitCode(0);
+
+        $this->assertFileExists($this->path);
+
+        $this->assertEquals($expectedYaml, file_get_contents($this->path));
+    }
+}

--- a/tests/Feature/Changelogs/ReleaseCommandTest.php
+++ b/tests/Feature/Changelogs/ReleaseCommandTest.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Tests\Feature\Changelogs;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+use KBox\Changelog\EntriesFinder;
+use Mockery;
+use Tests\TestCase;
+
+class ReleaseCommandTest extends TestCase
+{
+    protected $paths = null;
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        if (! is_null($this->paths)) {
+            foreach ($this->paths as $path) {
+                if (is_file($path)) {
+                    unlink($path);
+                }
+            }
+        }
+    }
+
+    protected function mockEntries($files)
+    {
+        $mock = Mockery::mock(Filesystem::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial();
+
+        $mock->shouldReceive('glob')->andReturn($files);
+
+        $this->app->instance(Filesystem::class, $mock);
+
+        $this->app->instance(EntriesFinder::class, new EntriesFinder($mock));
+
+        return $mock;
+    }
+
+    protected function generateTestingEntries()
+    {
+        $base = base_path('changelogs/unreleased/');
+
+        return [
+            $this->generateEntry("$base/100-added.yml", 'added'),
+            $this->generateEntry("$base/101-fixed.yml", 'fixed'),
+            $this->generateEntry("$base/102-changed.yml", 'changed'),
+            $this->generateEntry("$base/103-removed.yml", 'removed'),
+            $this->generateEntry("$base/104-deprecated.yml", 'deprecated'),
+            $this->generateEntry("$base/105-security.yml", 'security'),
+        ];
+    }
+
+    protected function generateEntry($path, $type = null)
+    {
+        $issue = Str::before(basename($path), '-');
+
+        $yaml = <<<"yaml"
+        title: "Entry for $type"
+        issue: $issue
+        merge_request: 2$issue
+        author: "@octocat"
+        type: $type
+        yaml;
+
+        file_put_contents($path, $yaml);
+
+        return $path;
+    }
+    
+    public function test_release_changelog_dry_run()
+    {
+        $this->paths = $this->generateTestingEntries();
+
+        $this->mockEntries($this->paths);
+
+        $releaseDate = today()->toDateString();
+
+        $expectedMarkdown = <<<"markdown"
+        ## [0.32.0] - $releaseDate
+        
+        ### Added
+
+        - Entry for added by @octocat ([#100](https://github.com/k-box/k-box/issues/100), [#2100](https://github.com/k-box/k-box/pull/2100))
+        
+        ### Changed
+
+        - Entry for changed by @octocat ([#102](https://github.com/k-box/k-box/issues/102), [#2102](https://github.com/k-box/k-box/pull/2102))
+        
+        ### Fixed
+
+        - Entry for fixed by @octocat ([#101](https://github.com/k-box/k-box/issues/101), [#2101](https://github.com/k-box/k-box/pull/2101))
+        
+        ### Security
+
+        - Entry for security by @octocat ([#105](https://github.com/k-box/k-box/issues/105), [#2105](https://github.com/k-box/k-box/pull/2105))
+        
+        ### Deprecated
+
+        - Entry for deprecated by @octocat ([#104](https://github.com/k-box/k-box/issues/104), [#2104](https://github.com/k-box/k-box/pull/2104))
+        
+        ### Removed
+
+        - Entry for removed by @octocat ([#103](https://github.com/k-box/k-box/issues/103), [#2103](https://github.com/k-box/k-box/pull/2103))
+        
+        markdown;
+
+        $this->artisan('release', [
+                'version' => 'v0.32.0',
+                '--dry-run' => true
+            ])
+            ->expectsOutput('update changelog.md')
+            ->expectsOutput($expectedMarkdown)
+            ->assertExitCode(0);
+
+        $this->assertFileExists($this->paths[0]);
+    }
+    
+    public function test_release_changelog_updated()
+    {
+        $this->paths = $this->generateTestingEntries();
+
+        $this->mockEntries($this->paths);
+
+        $releaseDate = today()->toDateString();
+
+        $expectedMarkdown = <<<"markdown"
+        ## [0.32.0] - $releaseDate
+        
+        ### Added
+
+        - Entry for added by @octocat ([#100](https://github.com/k-box/k-box/issues/100), [#2100](https://github.com/k-box/k-box/pull/2100))
+        
+        ### Changed
+
+        - Entry for changed by @octocat ([#102](https://github.com/k-box/k-box/issues/102), [#2102](https://github.com/k-box/k-box/pull/2102))
+        
+        ### Fixed
+
+        - Entry for fixed by @octocat ([#101](https://github.com/k-box/k-box/issues/101), [#2101](https://github.com/k-box/k-box/pull/2101))
+        
+        ### Security
+
+        - Entry for security by @octocat ([#105](https://github.com/k-box/k-box/issues/105), [#2105](https://github.com/k-box/k-box/pull/2105))
+        
+        ### Deprecated
+
+        - Entry for deprecated by @octocat ([#104](https://github.com/k-box/k-box/issues/104), [#2104](https://github.com/k-box/k-box/pull/2104))
+        
+        ### Removed
+
+        - Entry for removed by @octocat ([#103](https://github.com/k-box/k-box/issues/103), [#2103](https://github.com/k-box/k-box/pull/2103))
+        
+        markdown;
+
+        $this->artisan('release', [
+                'version' => 'v0.32.0',
+            ])
+            ->expectsOutput('update changelog.md')
+            ->expectsOutput($expectedMarkdown)
+            ->assertExitCode(0);
+
+        $this->assertStringContainsString($expectedMarkdown, file_get_contents(base_path('changelog.md')));
+
+        $this->assertFileNotExists($this->paths[0]);
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Introduce the new workflow for editing unrelease changelog entries using single separate files under the `changelogs/unreleased` folder. Add a `changelog` command to generate those entries and a `release` command to consolidate the changelog entries for a release.

### Related issues

Fixes #435 

### Review checklist

* [x] Are unit tests required?
* [x] Are Documentation changes needed?

**Before merging**

* [x] Is history cleaned up? (or can be squashed on merge?)