### PR TITLE
Copy link to document, collection and project

### DIFF
--- a/changelogs/unreleased/copy-document-link.yml
+++ b/changelogs/unreleased/copy-document-link.yml
@@ -1,0 +1,5 @@
+title: "Quickly copy the link to a document, collection or project from the detail panel"
+issue: 73
+merge_request: 464
+author: ""
+type: added

--- a/resources/views/components/copy-button.blade.php
+++ b/resources/views/components/copy-button.blade.php
@@ -1,0 +1,13 @@
+@props(['links'])
+
+<button type="button" {{ $attributes->merge(['class' => 'button inline-flex items-center']) }} 
+    x-data="CopyToClipboard({links: '{{ implode('&#13;&#10;', $links) }}'})"
+    @click="copy" 
+    :class="{ 'bg-green-300 border-green-700': copied === true }" 
+    title="{{ trans('share.document_link_copy') }}">
+        <span class="" x-show="!copied">@materialicon('content', 'content_copy', '')</span>
+        <span class="" x-show="copied">@materialicon('action', 'done', '')</span>
+        <span class="hidden md:inline md:ml-1" x-show="!copied">{{ trans( count($links) == 1 ? 'share.document_link_copy' : 'share.document_link_copy_multiple') }}</span>
+        <span class="hidden md:inline md:ml-1" x-show="copied">{{ trans('actions.clipboard.copied_title') }}</span>
+        <span class="field-error" x-show="error">{{trans('actions.clipboard.not_copied_link_text')}}</span>
+</button>

--- a/resources/views/components/copy.blade.php
+++ b/resources/views/components/copy.blade.php
@@ -12,7 +12,7 @@
         </div>
         
         <div class="flex">
-            <button class="button inline-flex  items-center mr-2" @click="copy" :class="{ 'bg-green-300 border-green-700': copied === true }" title="{{ trans('share.document_link_copy') }}">
+            <button type="button" class="button inline-flex  items-center mr-2" @click="copy" :class="{ 'bg-green-300 border-green-700': copied === true }" title="{{ trans('share.document_link_copy') }}">
                 <span class="" x-show="!copied">@materialicon('content', 'content_copy', '')</span>
                 <span class="" x-show="copied">@materialicon('action', 'done', '')</span>
                 <span class="hidden md:inline md:ml-1" x-show="!copied">{{ trans( count($links) == 1 ? 'share.document_link_copy' : 'share.document_link_copy_multiple') }}</span>

--- a/resources/views/documents/edit.blade.php
+++ b/resources/views/documents/edit.blade.php
@@ -182,18 +182,20 @@
 
 			</div>
 
-			<div class=" mb-4">
+			<div class=" mb-4 flex items-center flex-wrap">
 				
 				@if(!$document->isRemoteWebPage())
 
 					@if($document->isFileUploadComplete())
 
-						<a href="{{DmsRouting::preview($document)}}" class="button">{!!trans('panels.open_btn')!!} </a>
+						<a href="{{DmsRouting::preview($document)}}" class="button mb-2 mr-2">{!!trans('panels.open_btn')!!} </a>
+
+						<x-copy-button :links="[DmsRouting::preview($document)]" class="mb-2" />
 
 					@endif
 
 					@if($document->isFileUploadComplete())
-						<a href="{{DmsRouting::download($document)}}" target="_blank" download="{{ $document->title }}" class="button">
+						<a href="{{DmsRouting::download($document)}}" target="_blank" download="{{ $document->title }}" class="button mb-2">
 							{{trans('panels.download_btn')}} 
 							({{KBox\Documents\Services\DocumentsService::extension_from_file($document->file)}}, {{KBox\Documents\Services\DocumentsService::human_filesize($document->file->size)}})
 						</a>

--- a/resources/views/documents/partials/preview_properties.blade.php
+++ b/resources/views/documents/partials/preview_properties.blade.php
@@ -21,6 +21,8 @@
 
 	@endif
 
+	<x-copy-button :links="[DmsRouting::preview($document, $version)]" class="my-4" />
+
 	<div class="js-license-details">
 		@include('documents.partials.license', ['license' => $document->copyright_usage, 'owner' => $document->copyright_owner])
 	</div>

--- a/resources/views/documents/projects/detail.blade.php
+++ b/resources/views/documents/projects/detail.blade.php
@@ -15,6 +15,8 @@
 <div class="c-panel__actions">
 	<a href="{{route('documents.groups.show', $project->collection->id)}}" class="button">{{ trans('projects.show_documents') }}</a>
 
+	<x-copy-button :links="[route('documents.groups.show', $project->collection->id)]" />
+
 	@if( flags('microsites') && !is_null( $project->microsite ) )
 		<a target="_blank" href="{{ route('projects.site', ['slug' => $project->microsite->slug]) }}" class="button">{{ trans('microsites.actions.view_site') }}</a>
 	@endif

--- a/resources/views/groups/detail.blade.php
+++ b/resources/views/groups/detail.blade.php
@@ -22,6 +22,8 @@
 </div>
 <div class="c-panel__actions">
 	<a href="{{route('documents.groups.show', $group->id)}}" class="button">{{ trans('projects.show_documents') }}</a>
+    
+    <x-copy-button :links="[route('documents.groups.show', $group->id)]" />
 </div>
 
 <div class="c-panel__data">

--- a/resources/views/panels/document.blade.php
+++ b/resources/views/panels/document.blade.php
@@ -55,8 +55,9 @@
 	
 			@if(!is_null($item->file) )
 	           <?php $real_preview_link = DmsRouting::preview($item); ?>
-				<a href="{{DmsRouting::preview($item)}}" class="button button--primary" target="_blank">{!!trans('panels.open_btn')!!} </a>
+				<a href="{{ $real_preview_link }}" class="button button--primary" target="_blank">{!!trans('panels.open_btn')!!} </a>
 	
+				<x-copy-button :links="[$real_preview_link]" />
 			@endif
 	       
            <?php $real_download_link = DmsRouting::download($item); ?>


### PR DESCRIPTION
## What does this PR do?

Add a "copy link" button to 

- document, project and collection detail panel
- document preview
- document edit page

### Related issues

Fixes #73

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)