### PR TITLE
Discard application/CDFV2-unknown mime type

### DIFF
--- a/packages/contentprocessing/src/DocumentType.php
+++ b/packages/contentprocessing/src/DocumentType.php
@@ -213,7 +213,6 @@ final class DocumentType
         'application/vnd.google-apps.form' => self::FORM,
 
         'application/octet-stream' => self::BINARY,
-        'application/octet-stream' => self::BINARY,
     ];
     
     /**

--- a/packages/contentprocessing/src/FileHelper.php
+++ b/packages/contentprocessing/src/FileHelper.php
@@ -196,6 +196,7 @@ final class FileHelper
     private static $discardMimeTypes = [
         'application/CDFV2-corrupt',
         'application/CDFV2-encrypted',
+        'application/CDFV2-unknown',
         'application/CDFV2',
         'inode/x-empty',
     ];


### PR DESCRIPTION
## What does this PR do?

Discard the `application/CDFV2-unknown` mime type as recognized by the OS in favor of extension based fallback.

### Related issues

Fixes #449 

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)