### PR TITLE
Introduce reindex collection job

### DIFF
--- a/app/Jobs/ReindexCollection.php
+++ b/app/Jobs/ReindexCollection.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace KBox\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use KBox\Group;
+
+class ReindexCollection implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * @var KBox\Group
+     */
+    public $collection;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(Group $collection)
+    {
+        $this->collection = $collection;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        logs()->info('Reindex Job handling for collection '.$this->collection->getKey(), ['collection' => $this->collection]);
+
+        $this->collection->documents()->chunk(50, function ($documents) {
+            foreach ($documents as $doc) {
+                dispatch(new ReindexDocument($doc, $doc->visibility));
+            }
+        });
+    }
+}

--- a/changelogs/unreleased/fix-reindex-collection-move.yml
+++ b/changelogs/unreleased/fix-reindex-collection-move.yml
@@ -1,0 +1,5 @@
+title: "Fix documents in collection not reindex after move"
+issue: 
+merge_request: 472
+author: ""
+type: fixed

--- a/packages/contentprocessing/src/Services/DocumentsService.php
+++ b/packages/contentprocessing/src/Services/DocumentsService.php
@@ -32,6 +32,7 @@ use KBox\Jobs\ReindexDocument;
 use KBox\Documents\TrashContentResponse;
 use KBox\Events\DocumentsAddedToCollection;
 use KBox\Events\DocumentsRemovedFromCollection;
+use KBox\Jobs\ReindexCollection;
 
 class DocumentsService
 {
@@ -1220,12 +1221,16 @@ class DocumentsService
 
                 $group->makeRoot(0);
 
+                dispatch(new ReindexCollection($group));
+
                 return $group->fresh();
             }
 
             // move under a parent and no other child has the same name as the group I'm moving
             elseif (! $is_there_already && ! is_null($moveBelow)) {
                 $group->moveTo(0, $moveBelow);
+
+                dispatch(new ReindexCollection($group));
 
                 return $group->fresh();
             }


### PR DESCRIPTION
This job fetches all documents in a collection to reindex them.
Particularly suitable if the collection was moved under a different parent


### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)