### PR TITLE
Language selector under profile menu

### DIFF
--- a/app/Http/Controllers/ChangeUserLanguagePreferenceController.php
+++ b/app/Http/Controllers/ChangeUserLanguagePreferenceController.php
@@ -24,18 +24,16 @@ class ChangeUserLanguagePreferenceController extends Controller
 
         $user = $request->user();
 
-        if ($request->has(User::OPTION_LANGUAGE)) {
-            $user->setOption(User::OPTION_LANGUAGE, $request->get(User::OPTION_LANGUAGE));
-
-            $user->save();
-        }
+        $language = $request->get(User::OPTION_LANGUAGE);
+        $user->setOption(User::OPTION_LANGUAGE, $language);
+        $user->save();
 
         if ($request->wantsJson()) {
             return new JsonResponse(['status' => 'ok'], 200);
         }
-                
-        return redirect()->route('profile.index')->with([
-            'flash_message' => trans('profile.messages.language_changed')
+        
+        return redirect()->back()->with([
+            'flash_message' => trans('profile.messages.language_changed', [], $language)
         ]);
     }
 }

--- a/app/View/Components/LanguageSelector.php
+++ b/app/View/Components/LanguageSelector.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace KBox\View\Components;
+
+use Illuminate\View\Component;
+
+class LanguageSelector extends Component
+{
+    public const TYPE_FORM = 'form';
+
+    public const TYPE_DROPDOWN = 'dropdown';
+
+    /**
+     * Current language selected.
+     * Represented by the language code
+     *
+     * @var string
+     */
+    public $current;
+
+    /**
+     * Currently supported languages
+     *
+     * @var array
+     */
+    public $languages;
+
+    /**
+     * The type of the selector to show
+     *
+     * @var string available options 'form' or 'dropdown'
+     */
+    public $type;
+
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct($current = null, $type = 'form')
+    {
+        $this->current = $current ?? app()->getLocale();
+
+        $this->type = $type;
+
+        $this->languages = [
+            // sort is based on the alphabetical order
+            // of the ISO 639-1 language code, as seen in Wikipedia
+            "de",
+            "en",
+            "fr",
+            "ky",
+            "ru",
+            "tg",
+        ];
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\View\View|string
+     */
+    public function render()
+    {
+        return view('components.language-selector');
+    }
+
+    public function isDropdown()
+    {
+        return $this->type == self::TYPE_DROPDOWN;
+    }
+}

--- a/changelogs/unreleased/language-selector-improve.yml
+++ b/changelogs/unreleased/language-selector-improve.yml
@@ -1,0 +1,5 @@
+title: "Language selector under the profile menu"
+issue: 30
+merge_request: 475
+author: ""
+type: added

--- a/resources/views/components/dropdown-link-item.blade.php
+++ b/resources/views/components/dropdown-link-item.blade.php
@@ -1,0 +1,5 @@
+@props(['label'])
+
+<a class="no-underline block p-2 -mx-2 mb-1 text-black hover:bg-blue-100 active:bg-blue-200 focus:bg-blue-100 focus:outline-none" {{ $attributes }}>
+    {{ $label }}
+</a>

--- a/resources/views/components/language-selector.blade.php
+++ b/resources/views/components/language-selector.blade.php
@@ -1,0 +1,64 @@
+@if ($isDropdown())
+
+
+    @component('components.dropdown', [
+        'classes' => $attributes->whereStartsWith('class')->first() ?? '',
+        'button_classes' => 'button',
+        'title' => trans('profile.labels.language')
+    ])
+
+        <div class="">
+            <span class="font-mono inline-block mr-2">{{ $current }}</span> {{trans("languages.$current", [], $current)}}
+        </div>
+
+        @materialicon('navigation', 'arrow_drop_down', ['class' => 'inline fill-current arrow', ':class' => "{ 'rotate-180': open }"])
+
+        @slot('panel')
+
+            <form method="post" id="language-selector-dropdown" class="" action="{{route('profile.language.update')}}">
+
+                @csrf
+                
+                @method('PUT')
+
+                @foreach ($languages as $language)
+                    <label class="no-underline block p-2 -mx-2 mb-1 text-black hover:bg-blue-100 active:bg-blue-200 focus:bg-blue-100 focus:outline-none" title="{{trans("languages.$language")}}">
+                        <input onclick="document.getElementById('language-selector-dropdown').submit()" type="radio" name="language" value="{{$language}}" id="" @if($current==$language) checked @endif>
+                        {{trans("languages.$language", [], $language)}}
+                    </label>
+                @endforeach
+
+                <div class="mt-2 hidden">
+                    <button type="submit" class="button hidden">{{trans('profile.change_language_btn')}}</button>
+                </div>
+            </form>
+            
+        @endslot
+        
+    @endcomponent
+
+@else
+
+    <form method="post" class="" action="{{route('profile.language.update')}}">
+
+        @csrf
+        
+        @method('PUT')
+
+        <select class="form-select block mt-1" name="language" autocomplete="off">
+            {{-- 
+                autocomplete="off" force Firefox to not cache the selected value and use always the latest
+                https://stackoverflow.com/questions/10870567/firefox-not-refreshing-select-tag-on-page-refresh
+            --}}
+            
+            @foreach ($languages as $language)
+                <option value="{{$language}}" @if($current==$language) selected @endif>{{trans("languages.$language", [], $language)}}</option>
+            @endforeach
+
+        </select>
+
+        <div class="mt-2">
+            <button type="submit" class="button">{{trans('profile.change_language_btn')}}</button>
+        </div>
+    </form>
+@endif

--- a/resources/views/headers/header.blade.php
+++ b/resources/views/headers/header.blade.php
@@ -39,12 +39,14 @@
 					@slot('panel')
 
 						<div class="mb-4">
-							<a class="no-underline font-bold block p-2 -mx-2 mb-1 text-black hover:bg-blue-100 active:bg-blue-200 focus:bg-blue-100 focus:outline-none" href="{{ $profile_url ?? route('profile.index') }}">{{$current_user_name}}</a>
+							<x-dropdown-link-item :label="$current_user_name" href="{{ $profile_url ?? route('profile.index') }}" />
 						</div>
 						<ul class="">
-							<li><a class="no-underline block p-2 -mx-2 mb-1 text-black hover:bg-blue-100 active:bg-blue-200 focus:bg-blue-100 focus:outline-none" href="{{ $profile_url ?? route('profile.index') }}">{{trans('profile.go_to_profile')}}</a></li>							
 							<li>
-								<a href="#" class="no-underline block p-2 -mx-2 mb-1 text-black hover:bg-blue-100 active:bg-blue-200 focus:bg-blue-100 focus:outline-none" onclick="event.preventDefault();document.getElementById('logout-form').submit();">{{trans('auth.logout')}}</a>
+								<x-dropdown-link-item label="{{trans('profile.go_to_profile')}}" href="{{ $profile_url ?? route('profile.index') }}" />
+							</li>
+							<li>
+								<x-dropdown-link-item label="{{trans('auth.logout')}}" href="#" onclick="event.preventDefault();document.getElementById('logout-form').submit();" />
 								<form class="hidden" id="logout-form" action="{{ route('logout') }}" method="POST">
 									{{ csrf_field() }}
 								</form>

--- a/resources/views/headers/header.blade.php
+++ b/resources/views/headers/header.blade.php
@@ -41,6 +41,9 @@
 						<div class="mb-4">
 							<x-dropdown-link-item :label="$current_user_name" href="{{ $profile_url ?? route('profile.index') }}" />
 						</div>
+
+						<x-language-selector type="dropdown" class="mb-4 w-full" />
+
 						<ul class="">
 							<li>
 								<x-dropdown-link-item label="{{trans('profile.go_to_profile')}}" href="{{ $profile_url ?? route('profile.index') }}" />

--- a/resources/views/profile/user.blade.php
+++ b/resources/views/profile/user.blade.php
@@ -73,10 +73,7 @@
 
 	</form>
 
-	<form method="post"  class="" action="{{route('profile.language.update')}}">
-		
-		{{ csrf_field() }}
-		{{ method_field('PUT') }}
+	<div>
 
 		<h4>{{trans('profile.language_section')}}</h4>
 
@@ -86,30 +83,14 @@
 			@if( $errors->has('language') )
 				<span class="field-error">{{ implode(",", $errors->get('language'))  }}</span>
 			@endif
+
+			<x-language-selector :current="$language" />
+
 			
-			<select class="form-select block mt-1" name="language" autocomplete="off">
-				{{-- 
-					autocomplete="off" force Firefox to not cache the selected value and use always the latest
-					https://stackoverflow.com/questions/10870567/firefox-not-refreshing-select-tag-on-page-refresh
-				--}}
-				<option value="en" @if($language=='en') selected @endif>{{trans('languages.en')}}</option>
-				<option value="ru" @if($language=='ru') selected @endif>{{trans('languages.ru')}}</option>
-				<option value="tg" @if($language=='tg') selected @endif>{{trans('languages.tg')}}</option>
-				<option value="fr" @if($language=='fr') selected @endif>{{trans('languages.fr')}}</option>
-				<option value="de" @if($language=='de') selected @endif>{{trans('languages.de')}}</option>
-				<option value="ky" @if($language=='ky') selected @endif>{{trans('languages.ky')}}</option>
-			</select>
-		</div>
-		
-		
-		<div class=" mb-4">
-			
-			<button type="submit" class="button">{{trans('profile.change_language_btn')}}</button>
 		</div>
 
 
-	</form>
+	</div>
 
-	
 
 @stop

--- a/tests/Feature/ChangeUserLanguagePreferenceControllerTest.php
+++ b/tests/Feature/ChangeUserLanguagePreferenceControllerTest.php
@@ -30,16 +30,38 @@ class ChangeUserLanguagePreferenceControllerTest extends TestCase
             $u->addCapabilities($capabilities);
         });
         
-        $response = $this->actingAs($user)->put(route('profile.language.update'), [
-            User::OPTION_LANGUAGE => $value,
-            '_token' => csrf_token()
-        ]);
-            
+        $response = $this->actingAs($user)
+            ->from(route('profile.index'))
+            ->put(route('profile.language.update'), [
+                User::OPTION_LANGUAGE => $value,
+                '_token' => csrf_token()
+            ]);
+        
         $response->assertRedirect(route('profile.index'));
 
-        $response->assertSessionHas('flash_message', trans('profile.messages.language_changed'));
+        $response->assertSessionHas('flash_message', trans('profile.messages.language_changed', [], $value));
 
         $this->assertEquals($user->getOption(User::OPTION_LANGUAGE)->value, $value);
+    }
+
+    public function test_language_preference_redirect_to_previous_page()
+    {
+        $user = tap(factory(User::class)->create(), function ($u) {
+            $u->addCapabilities(Capability::$PARTNER);
+        });
+        
+        $response = $this->actingAs($user)
+            ->from(route('documents.index'))
+            ->put(route('profile.language.update'), [
+                User::OPTION_LANGUAGE => 'ru',
+                '_token' => csrf_token()
+            ]);
+            
+        $response->assertRedirect(route('documents.index'));
+
+        $response->assertSessionHas('flash_message', trans('profile.messages.language_changed', [], 'ru'));
+
+        $this->assertEquals($user->getOption(User::OPTION_LANGUAGE)->value, 'ru');
     }
 
     public function test_language_preference_do_not_accept_invalid_language()

--- a/tests/Feature/Components/LanguageSelectorTest.php
+++ b/tests/Feature/Components/LanguageSelectorTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature\Components;
+
+use Tests\TestCase;
+
+class LanguageSelectorTest extends TestCase
+{
+    public function test_component_renders_form()
+    {
+        $view = $this->blade(
+            '<x-language-selector />'
+        );
+
+        $sorting_fields = [
+            trans("languages.de", [], 'de'),
+            trans("languages.en", [], 'en'),
+            trans("languages.fr", [], 'fr'),
+            trans("languages.ky", [], 'ky'),
+            trans("languages.ru", [], 'ru'),
+            trans("languages.tg", [], 'tg'),
+            trans('profile.change_language_btn'),
+        ];
+
+        $view->assertSeeTextInOrder($sorting_fields);
+    }
+
+    public function test_component_renders_dropdown()
+    {
+        $view = $this->blade(
+            '<x-language-selector type="dropdown" />'
+        );
+
+        $sorting_fields = [
+            trans("languages.de", [], 'de'),
+            trans("languages.en", [], 'en'),
+            trans("languages.fr", [], 'fr'),
+            trans("languages.ky", [], 'ky'),
+            trans("languages.ru", [], 'ru'),
+            trans("languages.tg", [], 'tg'),
+            trans('profile.change_language_btn'),
+        ];
+
+        $view->assertSeeTextInOrder($sorting_fields);
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Add the language selector to the profile menu. Languages are presented in the alphabetical order defined by the two digit language code (ISO 639-1), as Wikipedia does.

The language selection is still available under the profile page and the language order follows the same language code sorting.

| before | after |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/5672748/103302878-f1ae7900-4a04-11eb-8ac9-ffad55104e3f.png) | ![image](https://user-images.githubusercontent.com/5672748/103302899-fffc9500-4a04-11eb-8382-b9597184103f.png) |


### Related issues

Fixes #30 

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)