### PR TITLE
Markdown view component and project description

### DIFF
--- a/app/Http/Controllers/PrivacyConsentDialogController.php
+++ b/app/Http/Controllers/PrivacyConsentDialogController.php
@@ -40,8 +40,8 @@ class PrivacyConsentDialogController extends Controller
 
         return view('consents.privacy', [
             'pagetitle' => trans('consent.privacy.dialog_title'),
-            'privacy_content' => $legal->html,
-            'summary_content' => $summary ? $summary->html : null
+            'privacy_content' => $legal->content,
+            'summary_content' => $summary ? $summary->content : null
         ]);
     }
 

--- a/app/Http/Controllers/SupportPagesController.php
+++ b/app/Http/Controllers/SupportPagesController.php
@@ -14,11 +14,9 @@ class SupportPagesController extends Controller
         
         $help_file_content = file_get_contents(@is_file($path) ? $path : $fallback);
 
-        $page_text = \Markdown::convertToHtml($help_file_content);
-
         return view('static.page', [
             'pagetitle' => trans('pages.help'),
-            'page_content' => $page_text]);
+            'page_content' => $help_file_content]);
     }
 
     /**

--- a/app/View/Components/Markdown.php
+++ b/app/View/Components/Markdown.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace KBox\View\Components;
+
+use Illuminate\View\Component;
+use League\CommonMark\MarkdownConverterInterface;
+
+class Markdown extends Component
+{
+    /**
+     * Value attribute
+     *
+     * @var string
+     */
+    public $value;
+
+    protected $converter;
+    
+    public function __construct(MarkdownConverterInterface $converter, $value = null)
+    {
+        $this->value = $value;
+        $this->converter = $converter;
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\View\View|string
+     */
+    public function render()
+    {
+        return view('components.markdown');
+    }
+
+    /**
+     * Convert markdown content to html
+     *
+     * @param string $text the markdown content
+     * @return string html
+     */
+    public function convert($text)
+    {
+        return $this->converter->convertToHtml($text);
+    }
+}

--- a/changelogs/unreleased/markdown-project-description.yml
+++ b/changelogs/unreleased/markdown-project-description.yml
@@ -1,0 +1,5 @@
+title: "Support markdown in project description"
+issue: 474
+merge_request: 476
+author: ""
+type: fixed

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
 		"fideloper/proxy": "^4.2",
 		"franzose/closure-table": "^6.0",
 		"fruitcake/laravel-cors": "^2.0",
-		"graham-campbell/markdown": "^11.0",
+		"graham-campbell/markdown": "^13.0",
 		"guzzlehttp/guzzle": "^6.3",
 		"intervention/image": "^2.4",
 		"jenssegers/agent": "^2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "740bfea654d1fb908ddf22b5c2e1e62d",
+    "content-hash": "96dbbd9b518ab0d57e635f8dcddbab18",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1308,36 +1308,34 @@
         },
         {
             "name": "graham-campbell/markdown",
-            "version": "v11.2.1",
+            "version": "v13.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/GrahamCampbell/Laravel-Markdown.git",
-                "reference": "7ead48c43098b562707a30650843d4279786b0d9"
+                "reference": "d25b873e5c5870edc4de7d980808f1a8e092a9c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GrahamCampbell/Laravel-Markdown/zipball/7ead48c43098b562707a30650843d4279786b0d9",
-                "reference": "7ead48c43098b562707a30650843d4279786b0d9",
+                "url": "https://api.github.com/repos/GrahamCampbell/Laravel-Markdown/zipball/d25b873e5c5870edc4de7d980808f1a8e092a9c7",
+                "reference": "d25b873e5c5870edc4de7d980808f1a8e092a9c7",
                 "shasum": ""
             },
             "require": {
-                "illuminate/contracts": "^5.5|^6.0|^7.0",
-                "illuminate/support": "^5.5|^6.0|^7.0",
-                "illuminate/view": "^5.5|^6.0|^7.0",
-                "league/commonmark": "^1.3",
-                "php": "^7.1.3"
+                "illuminate/contracts": "^6.0 || ^7.0 || ^8.0",
+                "illuminate/filesystem": "^6.0 || ^7.0 || ^8.0",
+                "illuminate/support": "^6.0 || ^7.0 || ^8.0",
+                "illuminate/view": "^6.0 || ^7.0 || ^8.0",
+                "league/commonmark": "^1.5",
+                "php": "^7.2.5 || ^8.0"
             },
             "require-dev": {
-                "graham-campbell/analyzer": "^2.4",
+                "graham-campbell/analyzer": "^3.0",
                 "graham-campbell/testbench": "^5.4",
                 "mockery/mockery": "^1.3.1",
-                "phpunit/phpunit": "^6.5|^7.0|^8.0"
+                "phpunit/phpunit": "^8.5.8 || ^9.3.7"
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "11.2-dev"
-                },
                 "laravel": {
                     "providers": [
                         "GrahamCampbell\\Markdown\\MarkdownServiceProvider"
@@ -1377,15 +1375,11 @@
                     "type": "github"
                 },
                 {
-                    "url": "https://www.patreon.com/GrahamJCampbell",
-                    "type": "patreon"
-                },
-                {
                     "url": "https://tidelift.com/funding/github/packagist/graham-campbell/markdown",
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-04-14T14:11:12+00:00"
+            "time": "2020-08-22T14:18:21+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/composer.lock
+++ b/composer.lock
@@ -2649,16 +2649,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "1.5.1",
+            "version": "1.5.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "6d74caf6abeed5fd85d6ec20da23d7269cd0b46f"
+                "reference": "11df9b36fd4f1d2b727a73bf14931d81373b9a54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/6d74caf6abeed5fd85d6ec20da23d7269cd0b46f",
-                "reference": "6d74caf6abeed5fd85d6ec20da23d7269cd0b46f",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/11df9b36fd4f1d2b727a73bf14931d81373b9a54",
+                "reference": "11df9b36fd4f1d2b727a73bf14931d81373b9a54",
                 "shasum": ""
             },
             "require": {
@@ -2670,14 +2670,14 @@
             },
             "require-dev": {
                 "cebe/markdown": "~1.0",
-                "commonmark/commonmark.js": "0.29.1",
+                "commonmark/commonmark.js": "0.29.2",
                 "erusev/parsedown": "~1.0",
                 "ext-json": "*",
                 "github/gfm": "0.29.0",
                 "michelf/php-markdown": "~1.4",
                 "mikehaertl/php-shellcommand": "^1.4",
                 "phpstan/phpstan": "^0.12",
-                "phpunit/phpunit": "^7.5",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.2",
                 "scrutinizer/ocular": "^1.5",
                 "symfony/finder": "^4.2"
             },
@@ -2740,7 +2740,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-27T12:50:08+00:00"
+            "time": "2020-10-31T13:49:32+00:00"
         },
         {
             "name": "league/csv",

--- a/config/markdown.php
+++ b/config/markdown.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use League\CommonMark\Extension\ExternalLink\ExternalLinkExtension;
+use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
+use League\CommonMark\Extension\DisallowedRawHTML\DisallowedRawHTMLExtension;
 
 /*
  * This file is part of Laravel Markdown.
@@ -45,6 +47,8 @@ return [
 
     'extensions' => [
         ExternalLinkExtension::class,
+        HeadingPermalinkExtension::class,
+        DisallowedRawHTMLExtension::class,
     ],
 
     /*
@@ -152,5 +156,11 @@ return [
     'external_link' => [
         'internal_hosts' => '', // is empty as we would like to have all links marked as external
         'open_in_new_window' => true,
+    ],
+
+    'heading_permalink' => [
+        'html_class' => 'markdown-header-link',
+        'id_prefix' => 'uc-',
+        'insert' => 'after',
     ],
 ];

--- a/config/markdown.php
+++ b/config/markdown.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 use League\CommonMark\Extension\ExternalLink\ExternalLinkExtension;
 use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
 use League\CommonMark\Extension\DisallowedRawHTML\DisallowedRawHTMLExtension;

--- a/config/markdown.php
+++ b/config/markdown.php
@@ -2,7 +2,6 @@
 
 use League\CommonMark\Extension\ExternalLink\ExternalLinkExtension;
 use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
-use League\CommonMark\Extension\DisallowedRawHTML\DisallowedRawHTMLExtension;
 
 /*
  * This file is part of Laravel Markdown.
@@ -46,7 +45,6 @@ return [
     'extensions' => [
         ExternalLinkExtension::class,
         HeadingPermalinkExtension::class,
-        // DisallowedRawHTMLExtension::class,
     ],
 
     /*

--- a/config/markdown.php
+++ b/config/markdown.php
@@ -46,7 +46,7 @@ return [
     'extensions' => [
         ExternalLinkExtension::class,
         HeadingPermalinkExtension::class,
-        DisallowedRawHTMLExtension::class,
+        // DisallowedRawHTMLExtension::class,
     ],
 
     /*

--- a/resources/assets/css/app-evolution.css
+++ b/resources/assets/css/app-evolution.css
@@ -204,6 +204,15 @@ h6 {
         @apply text-gray-900;
         @apply p-1;
     }
+
+    .markdown-header-link {
+        @apply opacity-0 transition-opacity ease-in-out duration-150;
+    }
+
+    h1:hover .markdown-header-link, h2:hover .markdown-header-link, h3:hover .markdown-header-link,
+    h4:hover .markdown-header-link, h5:hover .markdown-header-link, h6:hover .markdown-header-link {
+        @apply opacity-100;
+    }
 }
 
 

--- a/resources/views/components/markdown.blade.php
+++ b/resources/views/components/markdown.blade.php
@@ -1,3 +1,3 @@
-<div class="markdown {{ $class ?? '' }}">
-    {!! $slot !!}
+<div {{ $attributes->merge(['class' => 'markdown']) }}>
+    {!! trim($convert($slot ?? $value)) !!}
 </div>

--- a/resources/views/consents/privacy.blade.php
+++ b/resources/views/consents/privacy.blade.php
@@ -29,9 +29,7 @@
 
             @if(!is_null($summary_content))
 
-                @component('components.markdown', ['class' => 'markdown--within bg-gray-100 p-2'])
-                    {!! $summary_content !!}
-                @endcomponent
+                <x-markdown class="markdown--within bg-gray-100 p-2">{!! $summary_content !!}</x-markdown>
 
                 <p class="mt-4">
                     <a href="{{ route('privacy.legal') }}" target="_blank" rel="noopener noreferrer">{{ trans('consent.privacy.show_full_text') }}</a>
@@ -39,9 +37,7 @@
 
             @else 
 
-                @component('components.markdown', ['class' => 'markdown--within bg-gray-100 p-2'])
-                    {!! $privacy_content !!}
-                @endcomponent
+                <x-markdown class="markdown--within bg-gray-100 p-2">{!! $privacy_content !!}</x-markdown>
 
             @endif
 

--- a/resources/views/documents/partials/preview_properties.blade.php
+++ b/resources/views/documents/partials/preview_properties.blade.php
@@ -46,10 +46,9 @@
 
 		<div class="meta abstract">
 			<h4 class="c-panel__section">{{trans('panels.abstract_section_title')}}</h4>
+
+			<x-markdown class="markdown--within bg-gray-100 p-2">{!! $document->abstract !!}</x-markdown>
 			
-			@component('components.markdown', ['class' => 'markdown--within bg-gray-100 p-1'])
-				{!! $document->abstract_html !!}
-			@endcomponent
 		</div>
 
 	@endif

--- a/resources/views/documents/projects/detail.blade.php
+++ b/resources/views/documents/projects/detail.blade.php
@@ -26,8 +26,8 @@
 <div class="c-panel__data">
 
 	@if($project->description)
-		<div class="c-panel__meta">
-			{{$project->description}}
+		<div class="meta abstract">
+			<x-markdown class="markdown--within my-4">{!! $project->description !!}</x-markdown>
 		</div>
 	@endif
 

--- a/resources/views/panels/document.blade.php
+++ b/resources/views/panels/document.blade.php
@@ -132,9 +132,8 @@
 <div class="meta abstract">
 	<h4 class="c-panel__section">{{trans('panels.abstract_section_title')}}</h4>
 
-	@component('components.markdown', ['class' => 'markdown--within bg-gray-100 p-1'])
-		{!! $item->abstract_html !!}
-	@endcomponent
+	<x-markdown class="markdown--within bg-gray-100 p-1">{!! $item->abstract !!}</x-markdown>
+	
 </div>
 
 @endif

--- a/resources/views/panels/licensehelp.blade.php
+++ b/resources/views/panels/licensehelp.blade.php
@@ -20,10 +20,7 @@
 						<div style="flex-basis:160px;text-align:right">{!! $license->icon ?? '' !!}</div>
 					</div>
 
-
-					@component('components.markdown', ['class' => ''])
-						{!! Markdown::convertToHtml($license->description) !!}
-					@endcomponent
+					<x-markdown>{!! $license->description !!}</x-markdown>
 						
 					@if($license->license)
 						<div><a href="{{ $license->license }}" target="_blank" rel="noopener noreferrer nofollow">{{ trans('administration.documentlicenses.view_license') }}</a></div>

--- a/resources/views/static/licenseshelp.blade.php
+++ b/resources/views/static/licenseshelp.blade.php
@@ -23,9 +23,8 @@
 						
 						<div style="flex-basis:160px;text-align:right">{!! $license->icon ?? '' !!}</div>
 					</div>
-					@component('components.markdown', ['class' => ''])
-						{!! Markdown::convertToHtml($license->description) !!}
-					@endcomponent
+					
+					<x-markdown>{!! $license->description !!}</x-markdown>
 						
 					@if($license->license)
 						<div><a href="{{ $license->license }}" target="_blank" rel="noopener noreferrer nofollow">{{ trans('administration.documentlicenses.view_license') }}</a></div>

--- a/resources/views/static/page.blade.php
+++ b/resources/views/static/page.blade.php
@@ -17,9 +17,7 @@
 
 	<div class="max-w-4xl md:mx-auto px-2 lg:px-0">
 
-		@component('components.markdown', ['class' => ''])
-			{!!$page_content!!}
-		@endcomponent
+		<x-markdown>{!! $page_content !!}</x-markdown>
 
 	</div>
 @stop

--- a/tests/Feature/Components/MarkdownComponentTest.php
+++ b/tests/Feature/Components/MarkdownComponentTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature\Components;
+
+use Tests\TestCase;
+
+class MarkdownComponentTest extends TestCase
+{
+    public function test_markdown_is_converted_to_html()
+    {
+        $view = $this->blade(
+            '<x-markdown>## a title</x-markdown>'
+        );
+
+        $expected = <<<'html'
+        <div class="markdown">
+            <h2>a title<a id="uc--a-title" href="#a-title" name="a-title" class="markdown-header-link" aria-hidden="true" title="Permalink">¶</a></h2>
+        </div>
+        html;
+
+        $this->assertEquals($expected, trim((string)$view));
+    }
+
+    public function test_class_attribute_is_honored()
+    {
+        $view = $this->blade(
+            '<x-markdown class="additional-class">## a title</x-markdown>'
+        );
+
+        $expected = <<<'html'
+        <div class="markdown additional-class">
+            <h2>a title<a id="uc--a-title" href="#a-title" name="a-title" class="markdown-header-link" aria-hidden="true" title="Permalink">¶</a></h2>
+        </div>
+        html;
+
+        $this->assertEquals($expected, trim((string)$view));
+    }
+    
+    public function test_html_is_stripped()
+    {
+        $view = $this->blade(
+            '<x-markdown><h2>a title</h2><a id="start">Hello</a></x-markdown>'
+        );
+
+        $expected = <<<'html'
+        <div class="markdown">
+            
+        </div>
+        html;
+
+        $this->assertEquals($expected, trim((string)$view));
+    }
+}

--- a/tests/Unit/Documents/PreviewDriver/MarkdownPreviewTest.php
+++ b/tests/Unit/Documents/PreviewDriver/MarkdownPreviewTest.php
@@ -34,7 +34,7 @@ class MarkdownPreviewTest extends TestCase
         $this->assertInstanceOf(Renderable::class, $preview);
         $this->assertNotNull($html);
         $this->assertNotEmpty($html);
-        $this->assertStringContainsString('<h1>This is</h1>', $html);
+        $this->assertStringContainsString('<h1>This is<a id="uc--this-is" href="#this-is" name="this-is" class="markdown-header-link" aria-hidden="true" title="Permalink">¶</a></h1>', $html);
         $this->assertStringContainsString('a <strong>Markdown</strong> file', $html);
         $this->assertStringContainsString('preview__render preview__render--text', $html);
     }


### PR DESCRIPTION
## What does this PR do?

- Update the Markdown library to require version 13
- Make the markdown component a proper Laravel Blade view component
- Ensure that project description is rendered via markdown component
- Fix heading links in help page

### Related issues

Fixes #474 

### Review checklist

* [x] Are unit tests required?
* [x] Are Documentation changes needed?

**Before merging**

* [x] Is history cleaned up? (or can be squashed on merge?)