### PR TITLE
Use collection type when scoping for personal and project collections.

### DIFF
--- a/app/Console/Commands/ExportProjectCommand.php
+++ b/app/Console/Commands/ExportProjectCommand.php
@@ -199,7 +199,7 @@ EOL;
     private function getFolders(DocumentDescriptor $doc)
     {
         return $doc->groups->map(function ($g) use ($doc) {
-            $ancestors = $g->ancestors()->public()->orderBy('depth', 'desc')->get();
+            $ancestors = $g->ancestors()->projectCollections()->orderBy('depth', 'desc')->get();
 
             if (! $ancestors->isEmpty() && ! $ancestors->first()->getProject()->is($this->project)) {
                 return null;

--- a/app/Console/Commands/ExportPublicDocumentsCommand.php
+++ b/app/Console/Commands/ExportPublicDocumentsCommand.php
@@ -118,7 +118,7 @@ class ExportPublicDocumentsCommand extends Command
                 optional($d->publication()->published_at)->toDateTimeString(),
                 optional($d->copyright_usage)->name ?? 'Copyright',
                 $d->projects()->pluck('name')->join('.'),
-                $d->groups()->public()->pluck('name')->join('.'),
+                $d->groups()->projectCollections()->pluck('name')->join('.'),
                 $d->hash,
                 RoutingHelpers::download($d),
             ];
@@ -169,7 +169,7 @@ class ExportPublicDocumentsCommand extends Command
                 optional($d->publication()->published_at)->toDateTimeString(),
                 optional($d->copyright_usage)->name ?? 'Copyright',
                 $d->projects()->pluck('name')->join('.'),
-                $d->groups()->public()->pluck('name')->join('.'),
+                $d->groups()->projectCollections()->pluck('name')->join('.'),
                 $d->hash,
                 RoutingHelpers::download($d),
             ];

--- a/app/Console/Commands/StatisticsCommand.php
+++ b/app/Console/Commands/StatisticsCommand.php
@@ -107,7 +107,7 @@ class StatisticsCommand extends Command
         $publication_made_per_day = Publication::where('created_at', '>=', $from)->where('created_at', '<=', $to)->select($date_field, $count_field)->groupBy('date')->orderBy('date')->get()->keyBy('date');
         $projects_created_per_day =  Project::where('created_at', '>=', $from)->where('created_at', '<=', $to)->select($date_field, $count_field)->groupBy('date')->orderBy('date')->get()->keyBy('date');
         $collections_created_per_day = Group::where('created_at', '>=', $from)->where('created_at', '<=', $to)->select($date_field, $count_field)->groupBy('date')->orderBy('date')->get()->keyBy('date');
-        $personal_collections_created_per_day = Group::where('is_private', true)->where('created_at', '>=', $from)->where('created_at', '<=', $to)->select($date_field, $count_field)->groupBy('date')->orderBy('date')->get()->keyBy('date');
+        $personal_collections_created_per_day = Group::type(Group::TYPE_PERSONAL)->where('created_at', '>=', $from)->where('created_at', '<=', $to)->select($date_field, $count_field)->groupBy('date')->orderBy('date')->get()->keyBy('date');
         $public_links_created_per_day = Shared::where('created_at', '>=', $from)->where('created_at', '<=', $to)->where('sharedwith_type', \KBox\PublicLink::class)->select($date_field, $count_field)->groupBy('date')->orderBy('date')->get()->keyBy('date');
         $shares_created_per_day = Shared::where('created_at', '>=', $from)->where('created_at', '<=', $to)->where('sharedwith_type', \KBox\User::class)->select($date_field, $count_field)->groupBy('date')->orderBy('date')->get()->keyBy('date');
 
@@ -156,7 +156,7 @@ class StatisticsCommand extends Command
             ['Registered users', User::count()],
             ['Projects', Project::count()],
             ['Collections', Group::count()],
-            ['Personal collections', Group::where('is_private', true)->count()],
+            ['Personal collections', Group::type(Group::TYPE_PERSONAL)->count()],
             ['Overall searches', RecentSearch::select(DB::raw('SUM(times + 1) as overall'))->first()->overall],
             ['Most used search keyword', $most_used_search ? "$most_used_search->terms, $most_used_search->total times" : ''],
         ];
@@ -175,7 +175,7 @@ class StatisticsCommand extends Command
             ['Registered users', User::where('created_at', '>=', $from)->where('created_at', '<=', $to)->count()],
             ['Projects', Project::where('created_at', '>=', $from)->where('created_at', '<=', $to)->count()],
             ['Collections', Group::where('created_at', '>=', $from)->where('created_at', '<=', $to)->count()],
-            ['Personal collections', Group::where('created_at', '>=', $from)->where('created_at', '<=', $to)->where('is_private', true)->count()],
+            ['Personal collections', Group::where('created_at', '>=', $from)->where('created_at', '<=', $to)->type(Group::TYPE_PERSONAL)->count()],
             ['Overall searches', RecentSearch::where('created_at', '>=', $from)->where('created_at', '<=', $to)->select(DB::raw('SUM(times + 1) as overall'))->first()->overall],
             ['Most used search keyword', $most_used_search ? "$most_used_search->terms, $most_used_search->total times" : ''],
         ];

--- a/app/DocumentDescriptor.php
+++ b/app/DocumentDescriptor.php
@@ -231,7 +231,7 @@ class DocumentDescriptor extends Model
      */
     public function projects()
     {
-        $projects = $this->groups()->public()->with('project')->get();
+        $projects = $this->groups()->projectCollections()->with('project')->get();
 
         $projects = $projects->map(function ($el) {
             if (! $el->project) {

--- a/app/Exceptions/FileAlreadyExistsException.php
+++ b/app/Exceptions/FileAlreadyExistsException.php
@@ -119,7 +119,7 @@ class FileAlreadyExistsException extends Exception
                 'title' => e($this->existing_descriptor->title)
             ]);
         } elseif (! is_null($this->existing_descriptor->owner_id)) {
-            $collection = $this->existing_descriptor->groups()->public()->first();
+            $collection = $this->existing_descriptor->groups()->projectCollections()->first();
             $owner = $this->existing_descriptor->owner;
 
             if (! is_null($collection)) {

--- a/app/Group.php
+++ b/app/Group.php
@@ -7,6 +7,7 @@ use KBox\Traits\LocalizableDateFields;
 use Franzose\ClosureTable\Models\Entity;
 use Dyrynda\Database\Support\GeneratesUuid;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Cache;
 use KBox\Events\CollectionCreated;
 use KBox\Events\CollectionTrashed;
 use KBox\Casts\UuidCast;
@@ -31,25 +32,23 @@ use KBox\Casts\UuidCast;
  * @property-read \KBox\Project $project
  * @property-read \Illuminate\Database\Eloquent\Collection|\KBox\Shared[] $shares
  * @property-read \KBox\User $user
- * @method static \Illuminate\Database\Query\Builder|\KBox\Group byName($name)
- * @method static \Illuminate\Database\Query\Builder|\KBox\Group ofType($type)
- * @method static \Illuminate\Database\Query\Builder|\KBox\Group orPrivate($user_id)
- * @method static \Illuminate\Database\Query\Builder|\KBox\Group orPublic()
- * @method static \Illuminate\Database\Query\Builder|\KBox\Group private($user_id)
- * @method static \Illuminate\Database\Query\Builder|\KBox\Group public()
- * @method static \Illuminate\Database\Query\Builder|\KBox\Group roots()
- * @method static \Illuminate\Database\Query\Builder|\KBox\Group whereColor($value)
- * @method static \Illuminate\Database\Query\Builder|\KBox\Group whereCreatedAt($value)
- * @method static \Illuminate\Database\Query\Builder|\KBox\Group whereDeletedAt($value)
- * @method static \Illuminate\Database\Query\Builder|\KBox\Group whereId($value)
- * @method static \Illuminate\Database\Query\Builder|\KBox\Group whereIsPrivate($value)
- * @method static \Illuminate\Database\Query\Builder|\KBox\Group whereName($value)
- * @method static \Illuminate\Database\Query\Builder|\KBox\Group whereParentId($value)
- * @method static \Illuminate\Database\Query\Builder|\KBox\Group wherePosition($value)
- * @method static \Illuminate\Database\Query\Builder|\KBox\Group whereRealDepth($value)
- * @method static \Illuminate\Database\Query\Builder|\KBox\Group whereUpdatedAt($value)
- * @method static \Illuminate\Database\Query\Builder|\KBox\Group whereUserId($value)
- * @method static \Illuminate\Database\Query\Builder|\KBox\Group withAllDescendants()
+ * @method static \Illuminate\Database\Query\Builder byName($name)
+ * @method static \Illuminate\Database\Query\Builder roots()
+ * @method static \Illuminate\Database\Query\Builder whereColor($value)
+ * @method static \Illuminate\Database\Query\Builder whereCreatedAt($value)
+ * @method static \Illuminate\Database\Query\Builder whereDeletedAt($value)
+ * @method static \Illuminate\Database\Query\Builder whereId($value)
+ * @method static \Illuminate\Database\Query\Builder whereIsPrivate($value)
+ * @method static \Illuminate\Database\Query\Builder whereName($value)
+ * @method static \Illuminate\Database\Query\Builder whereParentId($value)
+ * @method static \Illuminate\Database\Query\Builder wherePosition($value)
+ * @method static \Illuminate\Database\Query\Builder whereRealDepth($value)
+ * @method static \Illuminate\Database\Query\Builder whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Query\Builder whereUserId($value)
+ * @method static \Illuminate\Database\Query\Builder withAllDescendants()
+ * @method static \Illuminate\Database\Query\Builder personalCollections($user)
+ * @method static \Illuminate\Database\Query\Builder type($type)
+ * @method static \Illuminate\Database\Query\Builder projectCollections()
  * @mixin \Eloquent
  */
 class Group extends Entity
@@ -168,7 +167,14 @@ class Group extends Entity
         return $this->morphMany(\KBox\Shared::class, 'shareable');
     }
 
-    public function scopeOfType($query, $type)
+    /**
+     * Filter the collections of the specified type
+     *
+     * @param int $type the collection type
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function scopeType($query, $type)
     {
         return $query->whereType($type);
     }
@@ -178,57 +184,32 @@ class Group extends Entity
         return $query->whereName($name);
     }
 
-    public function scopePersonal($query, $user_id)
+    /**
+     * Filter only personal collections of a specific user
+     *
+     * @param int $user_id
+     */
+    public function scopePersonalCollections($query, $user_id)
     {
         return $query->where(function ($query) use ($user_id) {
-            $query->where('is_private', true)
-                      ->where('user_id', $user_id);
+            $query->type(self::TYPE_PERSONAL)
+                  ->where('user_id', $user_id);
         });
     }
 
-    public function scopeProject($query)
+    /**
+     * Filter only project collections
+     *
+     * Equal to {@see type} with Group::TYPE_PROJECT as value
+     */
+    public function scopeProjectCollections($query)
     {
-        return $query->where('is_private', false);
+        return $query->type(self::TYPE_PROJECT);
     }
 
     /**
-     * @deprecated use scopeProject
+     * Filter root collections (i.e. without parents)
      */
-    public function scopePublic($query)
-    {
-        return $query->where('is_private', false);
-    }
-    
-    /**
-     * @deprecated use scopeProject
-     */
-    public function scopeOrPublic($query)
-    {
-        return $query->orWhere('is_private', false);
-    }
-
-    /**
-     * @deprecated use scopePersonal
-     */
-    public function scopePrivate($query, $user_id)
-    {
-        return $query->where(function ($query) use ($user_id) {
-            $query->where('is_private', true)
-                      ->where('user_id', $user_id);
-        });
-    }
-    
-    /**
-     * @deprecated use scopePersonal
-     */
-    public function scopeOrPrivate($query, $user_id)
-    {
-        return $query->orWhere(function ($query) use ($user_id) {
-            $query->where('is_private', true)
-                      ->where('user_id', $user_id);
-        });
-    }
-
     public function scopeRoots($query)
     {
         return $query->whereNull('parent_id');
@@ -243,8 +224,7 @@ class Group extends Entity
         $columns = $instance->prepareTreeQueryColumns($columns);
 
         return $instance
-            ->where('is_private', '=', true)
-            ->where('user_id', '=', $user_id)
+            ->personalCollections($user_id)
             ->orderBy('name', 'asc')
             ->get($columns)->toTree();
     }
@@ -258,7 +238,7 @@ class Group extends Entity
         $columns = $instance->prepareTreeQueryColumns($columns);
 
         return $instance
-            ->where('is_private', '=', false)
+            ->projectCollections()
             ->orderBy('name', 'asc')
             ->get($columns)->toTree();
     }
@@ -282,7 +262,50 @@ class Group extends Entity
      */
     public function getIsPrivateAttribute($value)
     {
-        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+        if ($value) {
+            return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+        }
+        return $this->type === self::TYPE_PERSONAL;
+    }
+
+    public function getIsProjectCollectionAttribute($value)
+    {
+        return $this->type === self::TYPE_PROJECT;
+    }
+
+    public function getIsPersonalCollectionAttribute($value)
+    {
+        return $this->type === self::TYPE_PERSONAL;
+    }
+
+    /**
+     * Transform the current collection into a project collection
+     *
+     * @return self
+     */
+    public function transformToProjectCollection()
+    {
+        $this->is_private = false;
+        $this->type = Group::TYPE_PROJECT;
+        $this->color = 'f1c40f';
+        $this->save();
+
+        return $this;
+    }
+
+    /**
+     * Transform the current project collection into a personal collection
+     *
+     * @return self
+     */
+    public function transformToPersonalCollection()
+    {
+        $this->is_private = true;
+        $this->type = Group::TYPE_PERSONAL;
+        $this->color = '16a085';
+        $this->save();
+
+        return $this;
     }
     
     public function isSharedWith($user)
@@ -292,7 +315,6 @@ class Group extends Entity
 
     public function getNameAttribute($value)
     {
-
         // some values can be escaped, like the single quote char ' to #039; and needs to be escaped
         return htmlspecialchars_decode($value, ENT_QUOTES);
     }
@@ -348,7 +370,7 @@ class Group extends Entity
             // we need to merge the childrens and permanently trash this collection instead of
             // simply move it to the trash, as it will fail due to the uniqueness constraint
 
-            $alreadyTrashed = $parent->getTrashedChildren()->where('name', $this->name)->where('is_private', $this->is_private)->first();
+            $alreadyTrashed = $parent->getTrashedChildren()->where('name', $this->name)->where('type', $this->type)->first();
             
             if ($alreadyTrashed) {
                 // what if $alreadyTrashed is personal, but of another user
@@ -384,7 +406,7 @@ class Group extends Entity
             // if the parent has children and within those there is one with the same name
             // we need to merge the childrens and permanently trash this collection instead of
             // restore it from the trash
-            $alreadyExisting = $parent->children(['*'])->where('name', $this->name)->where('is_private', $this->is_private)->first();
+            $alreadyExisting = $parent->children(['*'])->where('name', $this->name)->type($this->type)->first();
             
             if ($alreadyExisting) {
                 // what if $alreadyExisting is personal, but of another user
@@ -416,21 +438,17 @@ class Group extends Entity
         parent::boot();
 
         static::created(function ($group) {
-            if ($group->is_private) {
-                \Cache::forget('dms_personal_collections'.$group->user_id);
-            } else {
-                \Cache::forget('dms_project_collections-'.$group->user_id);
-            }
+            $prefix = $group->type === self::TYPE_PERSONAL ? 'dms_personal_collections' : 'dms_project_collections-';
+
+            Cache::forget("{$prefix}{$group->user_id}");
             
             return $group;
         });
         
         static::updated(function ($group) {
-            if ($group->is_private) {
-                \Cache::forget('dms_personal_collections'.$group->user_id);
-            } else {
-                \Cache::forget('dms_project_collections-'.$group->user_id);
-            }
+            $prefix = $group->type === self::TYPE_PERSONAL ? 'dms_personal_collections' : 'dms_project_collections-';
+
+            Cache::forget("{$prefix}{$group->user_id}");
             
             return $group;
         });

--- a/app/Http/Controllers/FindSharingTargetsController.php
+++ b/app/Http/Controllers/FindSharingTargetsController.php
@@ -55,7 +55,7 @@ class FindSharingTargetsController extends Controller
 
         $is_multiple_selection = ! empty($documents_input) && ! empty($groups_input);
 
-        if ($groups->where('is_private', false)->isNotEmpty()) {
+        if ($groups->where('type', Group::TYPE_PROJECT)->isNotEmpty()) {
             // if there is at least a project collection in the selection
             // return an empty list. See
             // https://github.com/k-box/k-box/pull/355#issuecomment-551448888

--- a/app/Http/Controllers/SharingController.php
+++ b/app/Http/Controllers/SharingController.php
@@ -264,7 +264,7 @@ class SharingController extends Controller
             'publication' => $publication,
             'publication_status' => $publication ? $publication->status : null,
             'is_collection' => $first instanceof Group,
-            'can_add_users' => $groups->isEmpty() || ($groups->isNotEmpty() && $groups->where('is_private', false)->isEmpty()),
+            'can_add_users' => $groups->isEmpty() || ($groups->isNotEmpty() && $groups->where('type', Group::TYPE_PROJECT)->isEmpty()),
             'can_edit_project' => $groups->count() === 1 ? (optional($groups->first()->getProject())->isManagedBy($me) ?? false) : false,
             'project' => $groups->count() === 1 ? optional($groups->first()->getProject())->getKey() : null,
         ]);

--- a/app/Http/Requests/CreateShareRequest.php
+++ b/app/Http/Requests/CreateShareRequest.php
@@ -4,6 +4,7 @@ namespace KBox\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest as Request;
 use Illuminate\Validation\Rule;
+use KBox\Group;
 
 class CreateShareRequest extends Request
 {
@@ -32,7 +33,7 @@ class CreateShareRequest extends Request
                 Rule::exists('groups', 'id')->where(function ($query) {
                     // limiting the allowed collections to be personal only
                     // https://github.com/k-box/k-box/issues/356
-                    $query->where('is_private', true);
+                    $query->whereType(Group::TYPE_PERSONAL);
                 }),
             ],
             'documents' => 'required_without:groups|exists:document_descriptors,id'

--- a/app/Jobs/PreparePersonalExportJob.php
+++ b/app/Jobs/PreparePersonalExportJob.php
@@ -107,7 +107,7 @@ class PreparePersonalExportJob implements ShouldQueue
     private function addCollections()
     {
         $collection_json = CollectionDump::collection(
-            Group::private($this->export->user_id)
+            Group::personalCollections($this->export->user_id)
                 ->get()
         )->toJson();
 

--- a/database/factories/GroupFactory.php
+++ b/database/factories/GroupFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+use KBox\User;
+use KBox\Group;
+use Faker\Generator as Faker;
+
+$factory->define(Group::class, function (Faker $faker, $arguments = []) {
+    return [
+        'user_id' => function () {
+            return factory(User::class)->create()->id;
+        },
+        'name' => $faker->sentence,
+        'color' => 'f1c40f',
+        'type' => Group::TYPE_PERSONAL,
+        'is_private' => true
+    ];
+});
+
+$factory->state(Group::class, 'project', function (Faker $faker) { 
+    return [
+        'type' => Group::TYPE_PROJECT,
+        'is_private' => false
+    ];
+});

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -152,20 +152,6 @@ $factory->state(KBox\Shared::class, 'publiclink', function (Faker\Generator $fak
     ];
 });
 
-
-$factory->define(KBox\Group::class, function (Faker\Generator $faker, $arguments = []) {
-    
-    return [
-        'user_id' => function () {
-            return factory(KBox\User::class)->create()->id;
-        },
-        'name' => $faker->sentence,
-        'color' => 'f1c40f',
-        'type' => KBox\Group::TYPE_PERSONAL,
-        'is_private' => false
-    ];
-});
-
 $factory->define(KBox\DuplicateDocument::class, function (Faker\Generator $faker, $arguments = []) {
     
     // $hash = $faker->sha256.''.$faker->sha256;

--- a/tests/Feature/DocumentDescriptorPolicyTest.php
+++ b/tests/Feature/DocumentDescriptorPolicyTest.php
@@ -177,7 +177,6 @@ class DocumentDescriptorPolicyTest extends TestCase
 
         $collection = factory(Group::class)->create([
             'user_id' => $owner->id,
-            'is_private' => true
         ]);
         
         $descr = factory(DocumentDescriptor::class)->create([

--- a/tests/Feature/DocumentsControllerTest.php
+++ b/tests/Feature/DocumentsControllerTest.php
@@ -83,7 +83,6 @@ class DocumentsControllerTest extends TestCase
 
         $collection = factory(Group::class)->create([
             'user_id' => $user->id,
-            'is_private' => true,
         ]);
 
         $response = $this->actingAs($user)->json('POST', '/documents', [

--- a/tests/Feature/DocumentsServiceTest.php
+++ b/tests/Feature/DocumentsServiceTest.php
@@ -179,7 +179,6 @@ class DocumentsServiceTest extends TestCase
 
         $collection = factory(Group::class)->create([
             'user_id' => $user->id,
-            'is_private' => true,
         ]);
 
         Event::fake([
@@ -224,7 +223,6 @@ class DocumentsServiceTest extends TestCase
 
         $collection = factory(Group::class)->create([
             'user_id' => $user->id,
-            'is_private' => true,
         ]);
 
         Event::fake([
@@ -266,7 +264,6 @@ class DocumentsServiceTest extends TestCase
 
         $collection = factory(Group::class)->create([
             'user_id' => $user->id,
-            'is_private' => true,
         ]);
 
         $collection->documents()->save($document, ['added_by' => $user->getKey()]);
@@ -306,7 +303,6 @@ class DocumentsServiceTest extends TestCase
 
         $collection = factory(Group::class)->create([
             'user_id' => $user->id,
-            'is_private' => true,
         ]);
 
         $documents->each(function ($document) use ($collection, $user) {
@@ -351,13 +347,11 @@ class DocumentsServiceTest extends TestCase
         
         $single_root_collection = factory(Group::class)->create([
             'user_id' => $collection_creator->getKey(),
-            'is_private' => true,
             'name' => 'root',
         ]);
         
         $root_collection = factory(Group::class)->create([
             'user_id' => $collection_creator->getKey(),
-            'is_private' => true,
             'name' => 'root',
         ]);
 
@@ -365,7 +359,6 @@ class DocumentsServiceTest extends TestCase
         
         $hierarchy_root_collection = factory(Group::class)->create([
             'user_id' => $collection_creator->getKey(),
-            'is_private' => true,
             'name' => 'root',
         ]);
 
@@ -423,13 +416,11 @@ class DocumentsServiceTest extends TestCase
         
         $single_root_collection = factory(Group::class)->create([
             'user_id' => $collection_creator->getKey(),
-            'is_private' => true,
             'name' => 'root',
         ]);
         
         $root_collection = factory(Group::class)->create([
             'user_id' => $collection_creator->getKey(),
-            'is_private' => true,
             'name' => 'root',
         ]);
 
@@ -437,7 +428,6 @@ class DocumentsServiceTest extends TestCase
         
         $hierarchy_root_collection = factory(Group::class)->create([
             'user_id' => $collection_creator->getKey(),
-            'is_private' => true,
             'name' => 'root',
         ]);
 

--- a/tests/Feature/DuplicateDocumentsControllerTest.php
+++ b/tests/Feature/DuplicateDocumentsControllerTest.php
@@ -164,7 +164,7 @@ class DuplicateDocumentsControllerTest extends TestCase
 
         $collection = factory(Group::class)->create([
             'user_id' => $user->id,
-            'is_private' => true,
+            // 'is_private' => true,
         ]);
 
         $existing_document = factory(DocumentDescriptor::class)->create([
@@ -203,12 +203,12 @@ class DuplicateDocumentsControllerTest extends TestCase
 
         $collection_for_existing = factory(Group::class)->create([
             'user_id' => $user->id,
-            'is_private' => true,
+            // 'is_private' => true,
         ]);
         
         $collection_for_duplicate = factory(Group::class)->create([
             'user_id' => $user->id,
-            'is_private' => true,
+            // 'is_private' => true,
         ]);
 
         $existing_document = factory(DocumentDescriptor::class)->create([

--- a/tests/Feature/ExportProjectCommandTest.php
+++ b/tests/Feature/ExportProjectCommandTest.php
@@ -42,7 +42,7 @@ class ExportProjectCommandTest extends TestCase
         $project->collection->documents()->save($documents[0]);
         $project->collection->documents()->save($documents[1]);
 
-        $collection_a = factory(Group::class)->create([
+        $collection_a = factory(Group::class)->state('project')->create([
             'name' => 'level 1 - 1',
             'parent_id' => $project->collection->getKey()
         ]);
@@ -50,7 +50,7 @@ class ExportProjectCommandTest extends TestCase
         $collection_a->documents()->save($documents[2]);
         $collection_a->documents()->save($documents[0]);
 
-        $collection_c = factory(Group::class)->create([
+        $collection_c = factory(Group::class)->state('project')->create([
             'name' => 'level 2 - 1',
             'parent_id' => $collection_a->getKey()
         ]);
@@ -58,14 +58,14 @@ class ExportProjectCommandTest extends TestCase
         $collection_c->documents()->save($documents[0]);
         $collection_c->documents()->save($documents[7]);
         
-        $collection_d = factory(Group::class)->create([
+        $collection_d = factory(Group::class)->state('project')->create([
             'name' => 'level 2 - 2',
             'parent_id' => $collection_a->getKey()
         ]);
         $collection_d->documents()->save($documents[4]);
         $collection_d->documents()->save($documents[0]);
 
-        $collection_b = factory(Group::class)->create([
+        $collection_b = factory(Group::class)->state('project')->create([
             'name' => 'level 1 - 2',
             'parent_id' => $project->collection->getKey()
         ]);
@@ -100,7 +100,7 @@ class ExportProjectCommandTest extends TestCase
     private function getFolders(DocumentDescriptor $doc, Project $project)
     {
         return $doc->groups->map(function ($g) use ($project) {
-            $ancestors = $g->ancestors()->public()->orderBy('depth', 'desc')->get();
+            $ancestors = $g->ancestors()->projectCollections()->orderBy('depth', 'desc')->get();
 
             if (! $ancestors->isEmpty() && ! $ancestors->first()->getProject()->is($project)) {
                 return null;

--- a/tests/Feature/ExportPublicDocumentsCommandTest.php
+++ b/tests/Feature/ExportPublicDocumentsCommandTest.php
@@ -155,7 +155,7 @@ class ExportPublicDocumentsCommandTest extends TestCase
                 'publication_date' => $d->publication()->published_at->toDateTimeString(),
                 'license' => optional($d->copyright_usage)->name ?? 'Copyright',
                 'projects' => $d->projects()->pluck('name')->join('.'),
-                'collections' => $d->groups()->public()->pluck('name')->join('.'),
+                'collections' => $d->groups()->projectCollections()->pluck('name')->join('.'),
                 'hash' => $d->hash,
                 'url' => RoutingHelpers::download($d),
             ];

--- a/tests/Feature/FindSharingTargetsControllerTest.php
+++ b/tests/Feature/FindSharingTargetsControllerTest.php
@@ -384,7 +384,7 @@ class FindSharingTargetsControllerTest extends TestCase
 
         $collection = factory(Group::class)->create([
             'user_id' => $user->getKey(),
-            'is_private' => true
+            // 'is_private' => true
         ]);
 
         $targets = collect([
@@ -438,9 +438,8 @@ class FindSharingTargetsControllerTest extends TestCase
             $u->addCapabilities(Capability::$PARTNER);
         });
 
-        $collection = factory(Group::class)->create([
+        $collection = factory(Group::class)->state('project')->create([
             'user_id' => $user->getKey(),
-            'is_private' => false
         ]);
 
         $targets = collect([
@@ -474,7 +473,7 @@ class FindSharingTargetsControllerTest extends TestCase
 
         $collection = factory(Group::class)->create([
             'user_id' => $user->getKey(),
-            'is_private' => true
+            // 'is_private' => true
         ]);
 
         $targets = collect([
@@ -528,9 +527,8 @@ class FindSharingTargetsControllerTest extends TestCase
             'owner_id' => $user->getKey()
         ]);
 
-        $collection = factory(Group::class)->create([
+        $collection = factory(Group::class)->state('project')->create([
             'user_id' => $user->getKey(),
-            'is_private' => false
         ]);
 
         $targets = collect([

--- a/tests/Feature/GroupDetailsControllerTest.php
+++ b/tests/Feature/GroupDetailsControllerTest.php
@@ -23,7 +23,6 @@ class GroupDetailsControllerTest extends TestCase
 
         $collection = factory(Group::class)->create([
             'user_id' => $user->getKey(),
-            'is_private' => true
         ]);
 
         $response = $this->actingAs($user)
@@ -45,9 +44,7 @@ class GroupDetailsControllerTest extends TestCase
             $u->addCapabilities(Capability::$PARTNER);
         });
 
-        $collection = factory(Group::class)->create([
-            'is_private' => true
-        ]);
+        $collection = factory(Group::class)->create();
 
         $response = $this->actingAs($user)
             ->get(route('groups.detail', $collection->getKey()));
@@ -94,7 +91,6 @@ class GroupDetailsControllerTest extends TestCase
 
         $collection = factory(Group::class)->create([
             'user_id' => $user->getKey(),
-            'is_private' => true
         ]);
 
         $share = factory(Shared::class)->create([

--- a/tests/Feature/PersonalExportTest.php
+++ b/tests/Feature/PersonalExportTest.php
@@ -47,7 +47,7 @@ class PersonalExportTest extends TestCase
 
         $collection = factory(Group::class)->create([
             'user_id' => $user->id,
-            'is_private' => true
+            // 'is_private' => true
         ]);
 
         return [

--- a/tests/Feature/SharedWithMePageTest.php
+++ b/tests/Feature/SharedWithMePageTest.php
@@ -33,13 +33,11 @@ class SharedWithMePageTest extends TestCase
         
         $single_root_collection = factory(Group::class)->create([
             'user_id' => $collection_creator->getKey(),
-            'is_private' => true,
             'name' => 'root',
         ]);
         
         $root_collection = factory(Group::class)->create([
             'user_id' => $collection_creator->getKey(),
-            'is_private' => true,
             'name' => 'root',
         ]);
 
@@ -47,7 +45,6 @@ class SharedWithMePageTest extends TestCase
         
         $hierarchy_root_collection = factory(Group::class)->create([
             'user_id' => $collection_creator->getKey(),
-            'is_private' => true,
             'name' => 'root',
         ]);
 

--- a/tests/Feature/SharingControllerTest.php
+++ b/tests/Feature/SharingControllerTest.php
@@ -170,7 +170,7 @@ class SharingControllerTest extends TestCase
 
         $to_be_shared = factory(Group::class)->create([
             'user_id' => $user->getKey(),
-            'is_private' => true,
+            // 'is_private' => true,
         ]);
 
         $share = factory(Shared::class)->create([
@@ -199,9 +199,8 @@ class SharingControllerTest extends TestCase
             $u->addCapabilities(Capability::$PARTNER);
         });
 
-        $to_be_shared = factory(Group::class)->create([
+        $to_be_shared = factory(Group::class)->state('project')->create([
             'user_id' => $user->getKey(),
-            'is_private' => false,
         ]);
 
         $data = [
@@ -370,7 +369,7 @@ class SharingControllerTest extends TestCase
 
         $collection = factory(Group::class)->create([
             'user_id' => $user->getKey(),
-            'is_private' => true,
+            // 'is_private' => true,
         ]);
 
         $response = $this->actingAs($user)->get(route('shares.create', [
@@ -458,13 +457,13 @@ class SharingControllerTest extends TestCase
             'owner_id' => $user->getKey()
         ]);
 
-        $collection1 = $collection = factory(Group::class)->create([
+        $collection1 = factory(Group::class)->create([
             'user_id' => $user->getKey(),
-            'is_private' => true,
+            // 'is_private' => true,
         ]);
-        $collection2 = $collection = factory(Group::class)->create([
+        $collection2 = factory(Group::class)->create([
             'user_id' => $user->getKey(),
-            'is_private' => true,
+            // 'is_private' => true,
         ]);
 
         $response = $this->actingAs($user)->get(route('shares.create', [
@@ -511,9 +510,9 @@ class SharingControllerTest extends TestCase
             'owner_id' => $user->getKey()
         ]);
 
-        $collection1 = $collection = factory(Group::class)->create([
+        $collection1 = factory(Group::class)->create([
             'user_id' => $user->getKey(),
-            'is_private' => true,
+            // 'is_private' => true,
         ]);
 
         $project = factory(Project::class)->create([

--- a/tests/Unit/Commands/StatisticsCommandTest.php
+++ b/tests/Unit/Commands/StatisticsCommandTest.php
@@ -63,7 +63,7 @@ class StatisticsCommandTest extends TestCase
         $previous_users = User::count();
         $previous_projects = Project::count();
         $previous_collections = Group::count();
-        $previous_personal_collections = Group::where('is_private', true)->count();
+        $previous_personal_collections = Group::type(Group::TYPE_PERSONAL)->count();
 
         $exitCode = Artisan::call('statistics', ['--summary' => true, '--overall' => true, '--influx' => true]);
 

--- a/tests/Unit/TusUploadStartedListenerTest.php
+++ b/tests/Unit/TusUploadStartedListenerTest.php
@@ -12,6 +12,7 @@ use OneOffTech\TusUpload\TusUpload;
 use KBox\Listeners\TusUploadStartedHandler;
 use OneOffTech\TusUpload\Events\TusUploadStarted;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use KBox\Group;
 
 class TusUploadStartedListenerTest extends TestCase
 {
@@ -69,7 +70,7 @@ class TusUploadStartedListenerTest extends TestCase
 
         $collection = $user->groups()->create([
             'name' => 'That exact collection',
-            'is_private' => true,
+            'type' => Group::TYPE_PERSONAL,
             'color' => '16a085',
         ]);
 

--- a/tests/Unit/UploadPageTest.php
+++ b/tests/Unit/UploadPageTest.php
@@ -6,6 +6,7 @@ use Tests\TestCase;
 use DmsRouting;
 use KBox\Capability;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use KBox\Group;
 
 class UploadPageTest extends TestCase
 {
@@ -89,7 +90,7 @@ class UploadPageTest extends TestCase
         
         $collection = $user->groups()->create([
             'name' => 'That exact collection',
-            'is_private' => true,
+            'type' => Group::TYPE_PERSONAL,
             'color' => '16a085',
         ]);
         


### PR DESCRIPTION
## What does this PR do?

- Use the collection type to filter for personal and project collections instead of the boolean is_private flag
- define new scopes: personalCollections and projectCollections
- Remove old public, orPublic, private, orPrivate scopes in favor of the new ones

### Related issues

Fixes ...

### Review checklist

* [ ] Are unit tests required?
* [ ] Are Documentation changes needed?

**Before merging**

* [ ] Is history cleaned up? (or can be squashed on merge?)